### PR TITLE
[net] Runtime selection of network card I/O-port in /bootopts (netport=)

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -15,7 +15,7 @@
 
 // register array - offset from base I/O address
 
-io_ne2k_command    = 0x00  // command
+io_ne2k_command    = 0x00  // command register at base address
 io_ne2k_rx_first   = 0x01  // page 0
 io_ne2k_rx_last    = 0x02  // page 0
 io_ne2k_rx_get     = 0x03  // page 0
@@ -92,9 +92,7 @@ ne2k_addr_set:
 
 	mov     4(%bp),%si
 
-	mov	net_port,%dx
-	// Since $io_ne2k_command is ZERO, the 'add' is a 'noop'
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command-register
 	mov	$0x42,%al	// page 1
 	out	%al,%dx
 
@@ -112,8 +110,7 @@ ems_loop:
 	inc     %dx
 	loop    ems_loop
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov	$0x02,%al	// back to pg 0
 	out	%al,%dx
 
@@ -178,15 +175,14 @@ dma_write:
 
 	// start DMA write
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov	$0x12,%al	
 	out     %al,%dx
 
 	// I/O write loop
 
 	mov	net_port,%dx	// Do this before changing the data segment
-	push	%dx
+	push	%dx		// Command register
 	add	$io_ne2k_data_io,%dx
 	mov	current,%bx		// setup for far memory xfer
 	mov	TASK_USER_DS(%bx),%ds
@@ -241,8 +237,7 @@ dma_r:	// Use the send data command to read exactly one backet,
 	mov	$0x0f,%al	// prep for using the 'send packet' cmd
 	out	%al,%dx
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov	$0x18,%al	// send packet
 	out	%al,%dx
 	// now the dma does the rest, and an RDC interrupt is fielded when complete
@@ -301,8 +296,7 @@ buf_local:
 
 	// start DMA read
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov	$0x0a,%al	// RD0 & STA
 	out     %al,%dx
 
@@ -351,8 +345,7 @@ check_dma_r:
 
 ne2k_getpage:
 	mov	$0x42,%al		// page 1
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	out	%al,%dx
 
 	mov	net_port,%dx
@@ -361,8 +354,7 @@ ne2k_getpage:
 	mov     %al,%ah
 
 	mov	$0x02,%al		// page 0
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	out	%al,%dx
 
 	mov	net_port,%dx
@@ -386,8 +378,7 @@ ne2k_rx_stat:
 	// get RX put pointer
 #if 0
 	mov	$0x42,%al	// page 1
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	out	%al,%dx
 
 	mov	net_port,%dx
@@ -396,8 +387,7 @@ ne2k_rx_stat:
 	mov     %al,%ah
 
 	mov	$0x02,%al	// back to page 0
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	out	%al,%dx
 
 	// get RX get pointer
@@ -576,8 +566,7 @@ npg_more_data:
 
 ne2k_tx_stat:
 
-	mov	net_port,%dx
-	//or     $io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	in      %dx,%al
 	and     $0x04,%al
 	jz      nts_ready
@@ -639,8 +628,7 @@ ne2k_pack_put:
 	// start TX
 
 tx_rdy_wait:
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	in	%dx,%al
 	test	$0x4,%al	// Check that previous transmit competed.
 	jnz	tx_rdy_wait
@@ -652,8 +640,7 @@ tx_rdy_wait:
 	//mov	$2,%al		// Test, should not make any difference
 	//out	%al,%dx
 
-1:	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+1:	mov	net_port,%dx	// command register
 	in      %dx,%al
 	test    $4,%al		// Wait for completion
 	jnz	1b
@@ -706,8 +693,7 @@ nis_next:
 //--------------------------------------------------------------
 ne2k_base_init:
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 
 	mov	$0x21,%al	// page 0 + Abort DMA; STOP
 	out     %al,%dx
@@ -796,8 +782,7 @@ ne2k_init:
 	out     %al,%dx
 
 	mov	$0x42,%al	// page 1
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	out	%al,%dx
 
 	// set RX put pointer  = RX get
@@ -810,8 +795,7 @@ ne2k_init:
 	mov	%al,_ne2k_next_pk
 
 	mov	$0x02,%al	// page 0
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	out	%al,%dx
 
 	// now enable transmitter
@@ -832,8 +816,7 @@ ne2k_start:
 
 	// start the transceiver
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov	$0x02,%al
 	out	%al,%dx
 
@@ -856,8 +839,7 @@ ne2k_stop:
 
 	// Stop the DMA and the MAC
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov	$0x21,%al	// page 0 + stop
 	out     %al,%dx
 
@@ -919,8 +901,7 @@ ne2k_probe:
 	// If something is there, return 0.
 	// No attempt is made to get details about the i/f.
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov	$0x20,%al	// set page 0
 	out	%al,%dx
 	in	%dx,%al
@@ -971,8 +952,7 @@ nr_loop:
 
 	// Leave the NIC in a known (stopped) state
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 	mov     $0x21,%al
 	out     %al,%dx
 
@@ -1055,8 +1035,7 @@ ne2k_clr_oflow:
 	sub	$4,%sp		// get temp space on the stack
 	mov	%sp,%di
 
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// command register
 of_chk_tx:	// Ensure no transmit is in progress
 	in	%dx,%al
 	test	4,%al
@@ -1076,9 +1055,8 @@ of_reset:
 	add	$io_ne2k_tx_conf,%dx	// must set tx to loopback
 	mov	$2,%al
 	out	%al,%dx
-	mov	net_port,%dx	// restart NIC
-	//add	$io_ne2k_command,%dx
-	mov	$0x22,%al
+	mov	net_port,%dx	// Command register
+	mov	$0x22,%al	// Restart NIC
 	out	%al,%dx
 	
 	// NIC has stopped, now clear out the ring buffer
@@ -1112,8 +1090,7 @@ of_drop_loop1:
 	mov	%cl,%al		// save BOUNDARY for return
 	push	%ax
 	mov	$0x42,%al	// page 1
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// Command register
 	out	%al,%dx
 
 	mov	net_port,%dx
@@ -1121,8 +1098,7 @@ of_drop_loop1:
 	mov	%ah,%al		// set CURRENT to the beginning of the next pkt,
 	out	%al,%dx		// effectively clearing everything but the 
 				// first pkt in the buffer.
-	mov	net_port,%dx
-	//add	$io_ne2k_command,%dx
+	mov	net_port,%dx	// Command register
 	mov	$2,%al
 	out	%al,%dx		// page 0
 	pop	%ax

--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -5,6 +5,7 @@
 //	. pick up MAC address from prom
 //	. fixed read ring buffer wrap around errors
 //	. added ring buffer overflow handling
+// oct-2021: Pick up I/O port # from init/bootopts (HS)
 //-----------------------------------------------------------------------------
 
 #include "arch/ports.h"
@@ -12,47 +13,43 @@
 
 	.code16
 
-base               = NE2K_PORT     // I/O base address
+// register array - offset from base I/O address
 
-// register array
-io_ne2k_command    = base + 0x00  // command
-io_ne2k_rx_first   = base+0x01  // page 0
-io_ne2k_rx_last    = base+0x02  // page 0
-io_ne2k_rx_get     = base+0x03  // page 0
+io_ne2k_command    = 0x00  // command
+io_ne2k_rx_first   = 0x01  // page 0
+io_ne2k_rx_last    = 0x02  // page 0
+io_ne2k_rx_get     = 0x03  // page 0
 
-// This is not a true NE2K register
-//io_ne2k_rx_put1  = base+0x06  // page 0 - read
+io_ne2k_tx_start   = 0x04  // page 0 - write
+io_ne2k_tx_len1    = 0x05  // page 0 - write
+io_ne2k_tx_len2    = 0x06  // page 0 - write
 
-io_ne2k_tx_start   = base+0x04  // page 0 - write
-io_ne2k_tx_len1    = base+0x05  // page 0 - write
-io_ne2k_tx_len2    = base+0x06  // page 0 - write
+io_ne2k_int_stat   = 0x07  // page 0
 
-io_ne2k_int_stat   = base+0x07  // page 0
+io_ne2k_dma_addr1  = 0x08  // page 0
+io_ne2k_dma_addr2  = 0x09  // page 0
+io_ne2k_dma_len1   = 0x0A  // page 0 - write
+io_ne2k_dma_len2   = 0x0B  // page 0 - write
 
-io_ne2k_dma_addr1  = base+0x08  // page 0
-io_ne2k_dma_addr2  = base+0x09  // page 0
-io_ne2k_dma_len1   = base+0x0A  // page 0 - write
-io_ne2k_dma_len2   = base+0x0B  // page 0 - write
+io_ne2k_rx_stat    = 0x0C  // page 0 - read
+io_ne2k_tx_stat    = 0x04  // page 0 - read
 
-io_ne2k_rx_stat    = base+0x0C  // page 0 - read
-io_ne2k_tx_stat    = base+0x04  // page 0 - read
+io_ne2k_rx_conf    = 0x0C  // page 0 - write
+io_ne2k_tx_conf    = 0x0D  // page 0 - write
+io_ne2k_data_conf  = 0x0E  // page 0 - write
+io_ne2k_int_mask   = 0x0F  // page 0 - write
 
-io_ne2k_rx_conf    = base+0x0C  // page 0 - write
-io_ne2k_tx_conf    = base+0x0D  // page 0 - write
-io_ne2k_data_conf  = base+0x0E  // page 0 - write
-io_ne2k_int_mask   = base+0x0F  // page 0 - write
+io_ne2k_frame_errs = 0x0D	// page 0 read - Frame Alignment Error counter
+io_ne2k_crc_errs   = 0x0E	// page 0 read - CRC error counter
+io_ne2k_lost_pkts  = 0x0F	// page 0 read - Lost packet counter
 
-io_ne2k_frame_errs = base+0x0D	// page 0 read - Frame Alignment Error counter
-io_ne2k_crc_errs   = base+0x0E	// page 0 read - CRC error counter
-io_ne2k_lost_pkts  = base+0x0F	// page 0 read - Lost packet counter
+io_ne2k_unicast    = 0x01  // page 1 - 6 bytes
+io_ne2k_rx_put     = 0x07  // page 1
+io_ne2k_multicast  = 0x08  // page 1 - 8 bytes
 
-io_ne2k_unicast    = base+0x01  // page 1 - 6 bytes
-io_ne2k_rx_put     = base+0x07  // page 1
-io_ne2k_multicast  = base+0x08  // page 1 - 8 bytes
+io_ne2k_data_io    = 0x10  // 2 bytes
 
-io_ne2k_data_io    = base+0x10  // 2 bytes
-
-io_ne2k_reset      = base+0x1F	// Really a port, not a register, force HW reset of the chip
+io_ne2k_reset      = 0x1F	// Really a port, not a register, force HW reset of the chip
 
 
 // Ring segmentation
@@ -64,6 +61,7 @@ rx_last            = 0x80
 //-----------------------------------------------------------------------------
 	.data
 	.extern current
+	.extern	net_port	// io-port base
 
 _ne2k_next_pk:
 	.word 0	// being used as byte ...
@@ -94,13 +92,16 @@ ne2k_addr_set:
 
 	mov     4(%bp),%si
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	// Since $io_ne2k_command is ZERO, the 'add' is a 'noop'
+	//add	$io_ne2k_command,%dx
 	mov	$0x42,%al	// page 1
 	out	%al,%dx
 
 	// load MAC address
 
-	mov     $io_ne2k_unicast,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_unicast,%dx
 	mov     $6,%cx
 	cld
 
@@ -111,7 +112,8 @@ ems_loop:
 	inc     %dx
 	loop    ems_loop
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$0x02,%al	// back to pg 0
 	out	%al,%dx
 
@@ -130,7 +132,8 @@ dma_init:
 
 	// set DMA start address
 
-	mov     $io_ne2k_dma_addr1,%dx
+	mov     net_port,%dx
+	add	$io_ne2k_dma_addr1,%dx
 	mov     %bl,%al
 	out     %al,%dx
 
@@ -175,15 +178,18 @@ dma_write:
 
 	// start DMA write
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$0x12,%al	
 	out     %al,%dx
 
 	// I/O write loop
 
+	mov	net_port,%dx	// Do this before changing the data segment
+	push	%dx
+	add	$io_ne2k_data_io,%dx
 	mov	current,%bx		// setup for far memory xfer
 	mov	TASK_USER_DS(%bx),%ds
-	mov     $io_ne2k_data_io,%dx
 	cld
 
 emw_loop:
@@ -194,7 +200,8 @@ emw_loop:
 
 	// wait for DMA completed
 
-	mov     $io_ne2k_int_stat,%dx
+	pop	%dx	// instead of: mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 check_dma_w:
 	in      %dx,%al
 	test    $0x40,%al       // dma done?
@@ -229,11 +236,13 @@ dma_r:	// Use the send data command to read exactly one backet,
 	mov     %ds,%ax
 	mov     %ax,%es	// only required if we're setting up the dma locally
 
-	mov	$io_ne2k_tx_len2,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_tx_len2,%dx
 	mov	$0x0f,%al	// prep for using the 'send packet' cmd
 	out	%al,%dx
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$0x18,%al	// send packet
 	out	%al,%dx
 	// now the dma does the rest, and an RDC interrupt is fielded when complete
@@ -242,7 +251,8 @@ dma_r:	// Use the send data command to read exactly one backet,
 	test	$0x40,%al
 	jz	rlp
 rlp1:	
-	mov	$io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 	mov     $0x40,%al       // reset (only this bit in) ISR
 	out     %al,%dx         // Clear RDC
 
@@ -271,7 +281,7 @@ dma_read:
 	push	%bx
 	push	%ax
 
-	cli		//Experimental
+	cli		// Experimental - disable INTR
 	inc     %cx     // make byte count even
 	and     $0xfffe,%cx
 	call    dma_init
@@ -284,19 +294,22 @@ dma_read:
 	jz	buf_local
 	mov	current,%bx	// Normal: read directly into the (far) buffer
 	mov	TASK_USER_DS(%bx),%es
+
 buf_local:
 	pop	%bx
 	push	%bx
 
 	// start DMA read
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$0x0a,%al	// RD0 & STA
 	out     %al,%dx
 
 	// I/O read loop
 
-	mov     $io_ne2k_data_io,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_data_io,%dx
 	cld
 emr_loop:
 	in      %dx,%ax
@@ -305,17 +318,16 @@ emr_loop:
 
 	// wait for DMA to complete
 
-	mov     $io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 check_dma_r:
 	in      %dx,%al
 	test    $0x40,%al       // dma done?
 	jz      check_dma_r     // loop if not
 
-	//mov	$0xabcd,%ax	// TEST
-	//mov	%ax,10(%di)
 	mov     $0x40,%al       // reset ISR (RDC bit only)
 	out     %al,%dx
-	sti		//Experimental
+	sti		//Experimental - Enable INTR
 
 	pop	%bx
 	pop	%es
@@ -331,7 +343,7 @@ check_dma_r:
 //-----------------------------------------------------------------------
 // NOTE: BOUNDARY is always one behind where the next read will start, the real 
 // 	read point is in the variable _NE2K_NEXT_PK. This trick is necessary
-//	because the internal logic in the NIC will trogger an overrun interrupt
+//	because the internal logic in the NIC will trigger an overrun interrupt
 //	if the BOUNDARY pointer matches or exceeds the CURRENT pointer.
 // Used internally, exposed externally for debugging purposes.
 //
@@ -339,18 +351,22 @@ check_dma_r:
 
 ne2k_getpage:
 	mov	$0x42,%al		// page 1
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	out	%al,%dx
 
-	mov     $io_ne2k_rx_put,%dx     // CURRENT
+	mov	net_port,%dx
+	add	$io_ne2k_rx_put,%dx	// CURRENT
 	in      %dx,%al
 	mov     %al,%ah
 
 	mov	$0x02,%al		// page 0
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	out	%al,%dx
 
-	mov     $io_ne2k_rx_get,%dx     // BOUNDARY
+	mov	net_port,%dx
+	add	$io_ne2k_rx_get,%dx     // BOUNDARY
 	in      %dx,%al
 
 	ret
@@ -370,15 +386,18 @@ ne2k_rx_stat:
 	// get RX put pointer
 #if 0
 	mov	$0x42,%al	// page 1
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	out	%al,%dx
 
-	mov     $io_ne2k_rx_put,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_put,%dx
 	in      %dx,%al
 	mov     %al,%ah
 
 	mov	$0x02,%al	// back to page 0
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	out	%al,%dx
 
 	// get RX get pointer
@@ -473,11 +492,6 @@ npg_cont0:
 	push	%cx		// save length
 	push	%ax
 	add	$4,%bx
-	//mov	%bx,%ax
-	//mov	current,%bx	// Read directly into the (far) buffer
-	//mov	TASK_USER_DS(%bx),%es
-	//mov	%ax,%bx
-	
 
 	mov	$1,%al		// use far transfer
 	call    dma_read
@@ -496,7 +510,8 @@ npg_cont:
 
 npg_next:
 
-	mov     $io_ne2k_rx_get,%dx	// update RX_get (BOUNDARY)
+	mov	net_port,%dx
+	add	$io_ne2k_rx_get,%dx	// update RX_get (BOUNDARY)
 	out     %al,%dx
 
 #if 0	/* error processing - not used */
@@ -514,7 +529,8 @@ npg_exit:
 #if 0	/* Handle ring buffer overflow - not used */
         /* OFLOW handled by its interrupt handler */
 
-	mov     $io_ne2k_int_stat,%dx  
+	mov	net_port,%dx  
+	add	$io_ne2k_int_stat,%dx  
 	in	%dx,%al			// get the status bits
 	test	$0x10,%al
 	jz	npg_no_oflw
@@ -526,7 +542,7 @@ npg_no_oflw:
 #endif
 	// The is effectively the replacement for the rx_stat routine,
 	// clear the has_data flag if ring buffer is empty.
-	cli
+	cli	// Interrupts off (experimental)
 	//mov	_ne2k_has_data,%ax
 	//dec	%ax	// TESTING
 	//cmp	$0,%ax
@@ -539,7 +555,7 @@ npg_zero:
 	movw	$0,_ne2k_has_data
 npg_more_data:
 
-	sti
+	sti		// Enable interrupts
 	pop	%ax	// return byte count (from %cx)
 	//pop	%es
 	pop     %di
@@ -560,7 +576,8 @@ npg_more_data:
 
 ne2k_tx_stat:
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//or     $io_ne2k_command,%dx
 	in      %dx,%al
 	and     $0x04,%al
 	jz      nts_ready
@@ -606,7 +623,8 @@ ne2k_pack_put:
 
 	// set TX pointer and length
 
-	mov     $io_ne2k_tx_start,%dx	// FIXME: This may not be required, done
+	mov	net_port,%dx
+	add	$io_ne2k_tx_start,%dx	// FIXME: This may not be required, done
 					// at initialization time, never changes.
 	mov     $tx_first,%al
 	out     %al,%dx
@@ -621,18 +639,21 @@ ne2k_pack_put:
 	// start TX
 
 tx_rdy_wait:
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	in	%dx,%al
 	test	$0x4,%al	// Check that previous transmit competed.
 	jnz	tx_rdy_wait
 	mov	$6,%al		// Set TX bit, starts transfer...
 	out	%al,%dx
 
-	//mov	$io_ne2k_int_stat,%dx	// reset tx intr bit
+	//mov	net_port,%dx
+	//add	$io_ne2k_int_stat,%dx	// reset tx intr bit
 	//mov	$2,%al		// Test, should not make any difference
 	//out	%al,%dx
 
-1:	mov     $io_ne2k_command,%dx
+1:	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	in      %dx,%al
 	test    $4,%al		// Wait for completion
 	jnz	1b
@@ -661,7 +682,8 @@ ne2k_int_stat:
 
 	// get interrupt status
 
-	mov     $io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 	in      %dx,%al
 	test    $0x13,%al	// ring buffer overflow, tx, rx
 	jz      nis_next
@@ -684,21 +706,24 @@ nis_next:
 //--------------------------------------------------------------
 ne2k_base_init:
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 
 	mov	$0x21,%al	// page 0 + Abort DMA; STOP
 	out     %al,%dx
 
 	// data I/O in words for PC/AT and higher
 
-	mov     $io_ne2k_data_conf,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_data_conf,%dx
 	mov     $0x49,%al	// set word access
 	out     %al,%dx
 
 	// clear DMA length 
 
 	xor     %al,%al
-	mov     $io_ne2k_dma_len1,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_dma_len1,%dx
 	out     %al,%dx
 	inc     %dx  		// = io_ne2k_dma_len2
 	out     %al,%dx
@@ -716,14 +741,16 @@ ne2k_init:
 	// Accept only packets without errors.
 	// Unicast & broadcast, no promiscuous, no multicast
 
-	mov     $io_ne2k_rx_conf,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_conf,%dx
 	mov     $0x04,%al
 	out     %al,%dx
 
 	// half-duplex and internal loopback
 	// to insulate the MAC while stopped.
 
-	mov     $io_ne2k_tx_conf,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_tx_conf,%dx
 	mov     $2,%al  // 2 for loopback
 	out     %al,%dx
 
@@ -731,55 +758,65 @@ ne2k_init:
 	// all 16KB on-chip memory
 	// except one TX frame at beginning (6 x 256B)
 
-	mov     $io_ne2k_rx_first,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_first,%dx
 	mov     $rx_first,%al
 	out     %al,%dx
 
 	// set RX_get pointer [BOUNDARY]
 
-	mov     $io_ne2k_rx_get,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_get,%dx
 	out     %al,%dx
 
-	mov     $io_ne2k_rx_last,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_last,%dx
 	mov     $rx_last,%al
 	out     %al,%dx
 
-	mov     $io_ne2k_tx_start,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_tx_start,%dx
 	mov     $tx_first,%al
 	out     %al,%dx
 
 	// clear all interrupt flags
 
-	mov     $io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 	mov     $0x7F,%al
 	out     %al,%dx
 
 	// set interrupt mask
 	// TX & RX & OFLW, no error interrupts
 
-	mov     $io_ne2k_int_mask,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_mask,%dx
 	mov     $0x13,%al	// 0x53 = RDC, Overflow, RX, TX 
 				// 0x13 = Overflow, RX, TX
 	out     %al,%dx
 
 	mov	$0x42,%al	// page 1
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	out	%al,%dx
 
 	// set RX put pointer  = RX get
 
-	mov     $io_ne2k_rx_put,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_put,%dx
 	mov     $rx_first,%al
 	inc     %al		// CURRENT = always one ahead
 	out     %al,%dx
 	mov	%al,_ne2k_next_pk
 
 	mov	$0x02,%al	// page 0
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	out	%al,%dx
 
 	// now enable transmitter
-	mov     $io_ne2k_tx_conf,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_tx_conf,%dx
 	mov     $0,%al		// 2 for loopback
 	out     %al,%dx
 
@@ -795,13 +832,15 @@ ne2k_start:
 
 	// start the transceiver
 
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$0x02,%al
 	out	%al,%dx
 
 	// move out of internal loopback
 
-	mov	$io_ne2k_tx_conf,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_tx_conf,%dx
 	xor	%al,%al
 	out	%al,%dx
 
@@ -817,7 +856,8 @@ ne2k_stop:
 
 	// Stop the DMA and the MAC
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$0x21,%al	// page 0 + stop
 	out     %al,%dx
 
@@ -825,14 +865,16 @@ ne2k_stop:
 	// to insulate the MAC while stopped
 	// and ensure TX finally ends
 
-	mov     $io_ne2k_tx_conf,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_tx_conf,%dx
 	mov     $2,%al
 	out     %al,%dx
 
 	// clear DMA length
 
 	xor     %al,%al
-	mov     $io_ne2k_dma_len1,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_dma_len1,%dx
 	out     %al,%dx
 	inc     %dx  // = io_ne2k_dma_len2
 	out     %al,%dx
@@ -853,7 +895,8 @@ ne2k_term:
 
 	// mask all interrrupts
 
-	mov     $io_ne2k_int_mask,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_mask,%dx
 	xor     %al,%al
 	out     %al,%dx
 
@@ -876,7 +919,8 @@ ne2k_probe:
 	// If something is there, return 0.
 	// No attempt is made to get details about the i/f.
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$0x20,%al	// set page 0
 	out	%al,%dx
 	in	%dx,%al
@@ -907,11 +951,13 @@ ne2k_reset:
 	// reset device
 	// with pulse on reset port
 
-	mov     $io_ne2k_reset,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_reset,%dx
 	in      %dx,%al
 	out     %al,%dx
 
-	mov     $io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 
 nr_loop:
 	// wait for reset
@@ -925,7 +971,8 @@ nr_loop:
 
 	// Leave the NIC in a known (stopped) state
 
-	mov     $io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov     $0x21,%al
 	out     %al,%dx
 
@@ -958,13 +1005,16 @@ w_reset:
 	call	ne2k_base_init	// basic initialization
 
 	xor	%al,%al
-	mov	$io_ne2k_int_mask,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_mask,%dx
 	out	%al,%dx         // mask completion irq
-	mov	$io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 	mov	$0x7f,%al
 	out	%al,%dx		// clear interrupt status reg, required
 
-	mov	$io_ne2k_rx_conf,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_conf,%dx
 	mov	$0x20,%al
 	out	%al,%dx		// set to monitor mode
 	inc	%dx		// $io_ne2k_tx_conf
@@ -977,7 +1027,8 @@ w_reset:
 	xor	%al,%al		// AL = 0 : local xfer
 	call	dma_read
 
-	mov	$io_ne2k_tx_conf,%dx	// set tx back to normal
+	mov	net_port,%dx	// set tx back to normal
+	add	$io_ne2k_tx_conf,%dx	// set tx back to normal
 	xor	%al,%al
 	out	%al,%dx
 
@@ -1004,7 +1055,8 @@ ne2k_clr_oflow:
 	sub	$4,%sp		// get temp space on the stack
 	mov	%sp,%di
 
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 of_chk_tx:	// Ensure no transmit is in progress
 	in	%dx,%al
 	test	4,%al
@@ -1012,17 +1064,20 @@ of_chk_tx:	// Ensure no transmit is in progress
 
 	call	ne2k_base_init	// stop & soft reset
 
-	mov	$io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 
 of_reset:
 	in	%dx,%al		// wait for reset to complete
 	test	$0x80,%al
 	jz	of_reset
 
-	mov	$io_ne2k_tx_conf,%dx	// must set tx to loopback
+	mov	net_port,%dx
+	add	$io_ne2k_tx_conf,%dx	// must set tx to loopback
 	mov	$2,%al
 	out	%al,%dx
-	mov	$io_ne2k_command,%dx	// restart NIC
+	mov	net_port,%dx	// restart NIC
+	//add	$io_ne2k_command,%dx
 	mov	$0x22,%al
 	out	%al,%dx
 	
@@ -1057,14 +1112,17 @@ of_drop_loop1:
 	mov	%cl,%al		// save BOUNDARY for return
 	push	%ax
 	mov	$0x42,%al	// page 1
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	out	%al,%dx
 
-	mov     $io_ne2k_rx_put,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_rx_put,%dx
 	mov	%ah,%al		// set CURRENT to the beginning of the next pkt,
 	out	%al,%dx		// effectively clearing everything but the 
 				// first pkt in the buffer.
-	mov	$io_ne2k_command,%dx
+	mov	net_port,%dx
+	//add	$io_ne2k_command,%dx
 	mov	$2,%al
 	out	%al,%dx		// page 0
 	pop	%ax
@@ -1082,11 +1140,13 @@ of_wraparound:
 
 of_drop_ok:
 	push	%ax	// save for return
-	mov	$io_ne2k_tx_conf,%dx	// set tx back to normal
+	mov	net_port,%dx	// set tx back to normal
+	add	$io_ne2k_tx_conf,%dx
 
 	xor	%al,%al
 	out	%al,%dx
-	mov	$io_ne2k_int_stat,%dx	// clear all interrupt bits
+	mov	net_port,%dx	// clear all interrupt bits
+	add	$io_ne2k_int_stat,%dx
 	in	%dx,%al
 	out	%al,%dx
 
@@ -1112,7 +1172,8 @@ ne2k_rdc:
 #if 0
 	// don't do this unless we have real dma,
 	// it will screw up the transfers between NIC and system.
-	mov     $io_ne2k_int_stat,%dx   // reset the interrupt bit
+	mov	net_port,%dx
+	add     $io_ne2k_int_stat,%dx   // reset the interrupt bit
 	mov     $0x40,%al
 	out     %al,%dx
 
@@ -1141,15 +1202,16 @@ ne2k_get_errstat:
 	mov	4(%bp),%di	
 
 	// assume pg 0
-	mov	$io_ne2k_frame_errs,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_frame_errs,%dx
 	in	%dx,%al
 	stosb
 
-	mov	$io_ne2k_crc_errs,%dx
+	inc	%dx	//	$io_ne2k_crc_errs
 	in	%dx,%al
 	stosb
 
-	mov	$io_ne2k_lost_pkts,%dx
+	inc	%dx	//	$io_ne2k_lost_pkts
 	in	%dx,%al
 	stosb
 	
@@ -1167,11 +1229,13 @@ ne2k_get_errstat:
 	.global ne2k_get_tx_stat
 
 ne2k_get_tx_stat:
-	mov	$io_ne2k_int_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
 	mov	$0x08,%al	// Clear TXE bit in ISR
 	out	%al,%dx
 
-	mov	$io_ne2k_tx_stat,%dx
+	mov	net_port,%dx
+	add	$io_ne2k_tx_stat,%dx
 	in	%dx,%al
 	xor	%ah,%ah
 	ret

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -20,7 +20,8 @@
 
 #include "ne2k.h"
 
-int net_irq = NE2K_IRQ;		/* default IRQ, changed by netirq= in /bootopts */
+int net_irq = NE2K_IRQ;	/* default IRQ, changed by netirq= in /bootopts */
+int net_port = NE2K_PORT; /* default IO PORT, changed by netport= in /bootopts */
 
 // Static data
 struct wait_queue rxwait;
@@ -28,11 +29,11 @@ struct wait_queue txwait;
 
 static byte_t ne2k_inuse = 0;
 
-//static byte_t def_mac_addr [6] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  /* QEMU default */
-static byte_t mac_addr [6]; /* Current MAC address, from HW or default */
+static byte_t mac_addr[6]  = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  /* QEMU default */
+			     /* Overwritten by actual HW MAC address if found */
 
 extern word_t _ne2k_has_data;
-extern word_t _ne2k_skip_cnt;	/* In case the NIC ring buffer overflows, skip this # of packets,
+extern word_t _ne2k_skip_cnt;	/* If the NIC ring buffer overflows, skip this # of packets,
 				 * zero means 'all'. */
 
 /*
@@ -159,8 +160,9 @@ static void ne2k_int(int irq, struct pt_regs * regs)
 
 	stat = ne2k_int_stat();
 #if 0
-        page = ne2k_getpage();
-        printk("|%04x|", page);
+	printk("/%d/", stat);
+	page = ne2k_getpage();
+	printk("|%04x|", page);
 #endif
 
         if (stat & NE2K_STAT_OF) {
@@ -188,7 +190,7 @@ static void ne2k_int(int irq, struct pt_regs * regs)
 	if (stat & NE2K_STAT_RDC) {
 		printk("eth: Warning - RDC intr. (0x%x)\n", stat);
 		/* The RDC interrupt should be disabled in the low level driver.
-		 * When real DMA transfer from NIC til system RAM is enabled, this is where
+		 * When real DMA transfer from NIC to system RAM is enabled, this is where
 		 * we handle transfer completion.
 		 * NOTICE: If we get here, a remote DMA transfer was aborted. This should
 		 * not happen.
@@ -274,7 +276,6 @@ static int ne2k_open(struct inode * inode, struct file * file)
 
 		ne2k_reset();
 		ne2k_init();
-		ne2k_addr_set(mac_addr);
 		ne2k_start();
 
 		ne2k_inuse = 1;
@@ -341,12 +342,11 @@ void ne2k_drv_init(void)
 				 * PROM size is 32 bytes.
 				 */
 	byte_t hw_addr[6];
-	byte_t *addr;
 
 	while (1) {
 		err = ne2k_probe();
 		if (err) {
-			printk ("eth: NE2K not detected\n");
+			printk ("eth: NE2K not found @ IRQ %d, IO 0x%x\n", net_irq, net_port);
 			break;
 		}
 		err = request_irq (net_irq, ne2k_int, INT_GENERIC);
@@ -365,31 +365,28 @@ void ne2k_drv_init(void)
 
 		ne2k_get_hw_addr(prom);
 
-		while (i < 6) hw_addr[i] = prom[i]&0xff,i++;
-		//i=0;while (i < 16) printk("%02X ", prom[i++]);
-
 		/* If there is no prom (i.e. emulator), use default */
-       if ((hw_addr[0] == 0xff) && (hw_addr[1] == 0xff)) {
-               //addr = def_mac_addr;
-           err = -1;
-       } else {
-                addr = hw_addr;
-           err = 0;
-       }
+		if ((prom[0]&0xff == 0xff) && (prom[1]&0xff == 0xff)) {
+			err = -1;
+		} else {
+			while (i < 6) hw_addr[i] = prom[i]&0xff,i++;
+			err = 0;
+		}
 
-       if (!err) {
-           printk ("eth: NE2K at 0x%x, irq %d, MAC %02x", NE2K_PORT, net_irq, addr[0]);
-           i = 1;
-           while (i < 6) printk(":%02x", addr[i++]);
-           printk("\n");
+		if (!err) {	/* address found, interface is present */
 
-           memcpy(mac_addr, addr, 6);
-           ne2k_addr_set(addr);   /* Set NIC mac addr now so IOCTL works */
+			printk ("eth: NE2K at 0x%x, irq %d, MAC %02x", net_port, net_irq, hw_addr[0]);
+			i = 1;
+			while (i < 6) printk(":%02x", hw_addr[i++]);
+			printk("\n");
+
+			memcpy(mac_addr, hw_addr, 6);
+			ne2k_addr_set(hw_addr);   /* Set NIC mac addr now so IOCTL works */
 #if DEBUG_ETH
-		debug_setcallback(ne2k_display_status);
+			debug_setcallback(ne2k_display_status);
 #endif
-       } else
-           printk("eth: Cannot access NE2K interface.\n");
+		} else
+			printk("eth: NE2K interface not responding.\n");
 
 		break;
 
@@ -398,7 +395,8 @@ void ne2k_drv_init(void)
 	_ne2k_skip_cnt = 0;	/* # of packets to discard if the NIC buffer overflows. 
                  		 * Zero is the default, discard entire buffer less one pkt.
 				 * May be changed via ioctl.
-				 * A big # will elar the entire bnuffer.
+				 * A big # will clear the entire buffer.
 				 * On a floppy based system, anything else is useless.
 				 */
+	return;
 }

--- a/elks/arch/i86/drivers/net/ne2k.h
+++ b/elks/arch/i86/drivers/net/ne2k.h
@@ -11,16 +11,8 @@
 #define NE2K_STAT_RDC   0x0040  // Remote DMA complete
 #define NE2K_STAT_TXE	0x0080	// TX error
 
-
-// From low level NE2K PHY
-
-extern word_t ne2k_phy_get (word_t, word_t *);
-extern word_t ne2k_phy_set (word_t, word_t);
-
-
 // From low level NE2K MAC
 
-extern word_t ne2k_link_stat ();
 extern word_t ne2k_int_stat ();
 
 extern word_t ne2k_probe ();
@@ -43,11 +35,12 @@ extern word_t ne2k_pack_put (char *, word_t);
 extern word_t ne2k_test ();
 
 extern word_t ne2k_getpage(void);
+extern word_t ne2k_clr_oflow(void);
+extern word_t ne2k_get_tx_stat(void);
+
 extern void ne2k_get_addr(byte_t *);
 extern void ne2k_get_hw_addr(word_t *);
-extern word_t ne2k_clr_oflow(void);
 extern void ne2k_rdc(void);
 extern void ne2k_get_errstat(byte_t *);
-extern word_t ne2k_get_tx_stat(void);
 
 #endif /* !NE2K_H */

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -60,8 +60,8 @@
 #define COM4_PORT	0x2e8
 #define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
 
-/* ne2k, ne2k.c */
-//#define NE2K_IRQ	9
+/* ne2k, ne2k.c, may be overridden in /bootopts
+ * using netirq= and netport= 		*/
 #define NE2K_IRQ	12
 #define NE2K_PORT	0x300
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -52,7 +52,7 @@ static int INITPROC parse_options(void);
 static void INITPROC finalize_options(void);
 static char * INITPROC option(char *s);
 static long INITPROC atol(char *number);
-static int hex2i(char *s);
+static int INITPROC hex2i(char *s);
 #endif
 
 static void init_task(void);
@@ -422,27 +422,23 @@ char *strchr(char *s, int c)
 /* Simple hex (ascii) to int conversion, accept '0x' in front,
    no argument checking except address range  */
 
-static int hex2i(char *s)
+static int INITPROC hex2i(char *s)
 {
 	char * p = s;
 	unsigned int r = 0;
 
-	if ((s[1]&0xdf) == 'X' ) p += 2;
+	if (*p && (s[1]&0xdf) == 'X' ) p += 2;	/* Not null string, has 0x prefix */
 	while (*p) {
 		/* NOTE: No sanity check, no length check! */
 		if (*p > '9')
 			r = (r<<4)+((*p&0xdf)-'@' + 9);
 		else
 			r = (r<<4)+(*p-'0');
-#ifdef DEBUG
+#if 0
 		printk("%c 0x%x ", *p, r);
 #endif
 		p++;
 	}
-	/* ISA Ethernet cards typically use IOports from 0x240-0x360 */
-	/* To include most ISA interfaces, change to 0x0f0 - 0x640 */
-	if (r < 0x240 || r > 0x37F) 
-		return 0;
 	return r;
 }
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -27,7 +27,7 @@ int root_mountflags = MS_RDONLY;
 #else
 int root_mountflags = 0;
 #endif
-extern int net_irq, net_port;
+int net_irq, net_port;
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char *init_command = bininit;

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -2,7 +2,6 @@
 #console=ttyS0 debug net=eth 3 # condensed
 #init=/bin/init 3 n	# multiuser serial no sysinit
 #init=/bin/sh		# singleuser shell
-#console=ttyS0,19200 # serial console
-#root=hda1			# hd partition 1
-#ro					# read-only root
-#netirq=9			# set NIC IRQ
+#console=ttyS0,19200	# serial console
+#root=hda1 ro	# hd partition 1, read-only root
+#netirq=9 netport=0x300	# set NIC parms


### PR DESCRIPTION
Runtime selection of network card I/O port is now supported. 

The /bootopt syntax is similar to @ghaerr's `netirq=`option: `netport=`. Tested on qemu and physical hardware.

Summary:
- Minimal changes to `init/main.c`, mainly a simple ascii-to-hex conversion routine.
- Many cleanups in `ne2k-asm.S`, removing leftovers from previous debugging sessions.
- The default MAC address is back in `ne2k.c`.
- The `netport=` command in `/bootopts` will accept '0x' prefix and no prefix, both will be considered hex.
- The new /bootopts file includes a sample config line with both `netirq=` and `netport=`, but is pushing its size limit, weighing in at 255 bytes!
- The ne2k driver will correctly report a missing NIC if the I/O port is wrong, but will not detect and erroneous IRQ.