### PR TITLE
[kernel] Add simple_strtol, replaces atoi, atol, hex2i

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -366,16 +366,17 @@ void ne2k_drv_init(void)
 		ne2k_get_hw_addr(prom);
 
 		/* If there is no prom (i.e. emulator), use default */
-		if ((prom[0]&0xff == 0xff) && (prom[1]&0xff == 0xff)) {
+		if (((prom[0]&0xff) == 0xff) && ((prom[1]&0xff) == 0xff)) {
 			err = -1;
 		} else {
 			while (i < 6) hw_addr[i] = prom[i]&0xff,i++;
 			err = 0;
 		}
 
+		printk ("eth: NE2K at 0x%x, irq %d, ", net_port, net_irq);
 		if (!err) {	/* address found, interface is present */
 
-			printk ("eth: NE2K at 0x%x, irq %d, MAC %02x", net_port, net_irq, hw_addr[0]);
+			printk ("MAC %02x", hw_addr[0]);
 			i = 1;
 			while (i < 6) printk(":%02x", hw_addr[i++]);
 			printk("\n");
@@ -386,7 +387,7 @@ void ne2k_drv_init(void)
 			debug_setcallback(ne2k_display_status);
 #endif
 		} else
-			printk("eth: NE2K interface not responding.\n");
+			printk("not responding.\n");
 
 		break;
 

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -346,7 +346,7 @@ void ne2k_drv_init(void)
 	while (1) {
 		err = ne2k_probe();
 		if (err) {
-			printk ("eth: NE2K not found @ IRQ %d, IO 0x%x\n", net_irq, net_port);
+			printk ("eth: NE2K not found at 0x%x, irq %d\n", net_port, net_irq);
 			break;
 		}
 		err = request_irq (net_irq, ne2k_int, INT_GENERIC);

--- a/elks/include/linuxmt/string.h
+++ b/elks/include/linuxmt/string.h
@@ -36,6 +36,7 @@ extern char *strstr(char *,char *);
  */
 
 extern void *memscan(void *,int,size_t);
+extern long simple_strtol(char *,int);
 extern int atoi(char *);
 
 /*@+namechecks@*/

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -51,8 +51,6 @@ static char * INITPROC root_dev_name(int dev);
 static int INITPROC parse_options(void);
 static void INITPROC finalize_options(void);
 static char * INITPROC option(char *s);
-static long INITPROC atol(char *number);
-static int INITPROC hex2i(char *s);
 #endif
 
 static void init_task(void);
@@ -283,7 +281,7 @@ static int INITPROC parse_options(void)
 				*p++ = 0;
 #ifdef CONFIG_CHAR_DEV_RS
 				/* set serial console baud rate*/
-				rs_setbaud(dev, atol(p));
+				rs_setbaud(dev, simple_strtol(p, 10));
 #endif
 			}
 
@@ -316,7 +314,7 @@ static int INITPROC parse_options(void)
 			continue;
 		}
 		if (!strncmp(line,"netport=",8)) {
-			net_port = hex2i(line+8);
+			net_port = simple_strtol(line+8, 0);
 			continue;
 		}
 		
@@ -399,17 +397,6 @@ static char * INITPROC option(char *s)
 	return s;
 }
 
-#ifdef CONFIG_CHAR_DEV_RS
-static long INITPROC atol(char *number)
-{
-    long n = 0;
-
-    while (*number >= '0' && *number <= '9')
-	n = (n * 10) + *number++ - '0';
-    return n;
-}
-#endif
-
 char *strchr(char *s, int c)
 {
 	for(; *s != (char)c; ++s) {
@@ -418,28 +405,4 @@ char *strchr(char *s, int c)
 	}
 	return s;
 }
-
-/* Simple hex (ascii) to int conversion, accept '0x' in front,
-   no argument checking except address range  */
-
-static int INITPROC hex2i(char *s)
-{
-	char * p = s;
-	unsigned int r = 0;
-
-	if (*p && (s[1]&0xdf) == 'X' ) p += 2;	/* Not null string, has 0x prefix */
-	while (*p) {
-		/* NOTE: No sanity check, no length check! */
-		if (*p > '9')
-			r = (r<<4)+((*p&0xdf)-'@' + 9);
-		else
-			r = (r<<4)+(*p-'0');
-#if 0
-		printk("%c 0x%x ", *p, r);
-#endif
-		p++;
-	}
-	return r;
-}
-
 #endif /* CONFIG_BOOTOPTS*/

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -314,7 +314,7 @@ static int INITPROC parse_options(void)
 			continue;
 		}
 		if (!strncmp(line,"netport=",8)) {
-			net_port = simple_strtol(line+8, 0);
+			net_port = (int)simple_strtol(line+8, 0);
 			continue;
 		}
 		

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -314,7 +314,7 @@ static int INITPROC parse_options(void)
 			continue;
 		}
 		if (!strncmp(line,"netport=",8)) {
-			net_port = (int)simple_strtol(line+8, 0);
+			net_port = (int)simple_strtol(line+8, 16);
 			continue;
 		}
 		

--- a/elks/lib/string.c
+++ b/elks/lib/string.c
@@ -49,7 +49,7 @@ long simple_strtol(char *s, int base)
 		if (isdigit(c))
 			c -= '0';
 		else if (isalpha(c))
-			c = (c & 0xdf) - '@' + 9;
+			c = (c & 0xdf) - 'A' + 10;
 		else break;
 		if (c >= base)
 			break;

--- a/elks/lib/string.c
+++ b/elks/lib/string.c
@@ -2,6 +2,8 @@
  *  linux/lib/string.c
  *
  *  Copyright (C) 1991, 1992  Linus Torvalds
+ *
+ *  12 Oct 21 ghaerr Add simple_strtol, remove old atoi
  */
 
 /*
@@ -13,6 +15,54 @@
 
 #include <linuxmt/types.h>
 #include <linuxmt/string.h>
+
+#define isdigit(c)	((c) >= '0' && (c) <= '9')
+#define isalpha(c)	(((c) >= 'a' && (c) <= 'z') || ((c) >= 'A' && (c) <= 'Z'))
+
+long simple_strtol(char *s, int base)
+{
+	register int c;
+	int neg;
+	long result = 0;
+
+	/* Skip spaces and pick up leading +/- sign, if any */
+	do {
+		c = *s++;
+	} while (c != '\0' && c <= ' ');
+	if (((neg = c) == '-') || c == '+')
+		c = *s++;
+
+	/*
+	 * If base is 0, allow 0x for hex and 0 for octal;
+	 * if base is already 16, allow 0x.
+	 */
+	if ((base == 0 || base == 16) &&
+		c == '0' && (*s == 'x' || *s == 'X')) {
+			c = s[1];
+			s += 2;
+			base = 16;
+		}
+	if (base == 0)
+		base = c == '0' ? 8 : 10;
+
+	do {
+		if (isdigit(c))
+			c -= '0';
+		else if (isalpha(c))
+			c = (c & 0xdf) - '@' + 9;
+		else break;
+		if (c >= base)
+			break;
+		result = result * base + c;
+	} while ((c = *s++) != '\0');
+
+	return (neg == '-') ? -result: result;
+}
+
+int atoi(char *number)
+{
+	return (int)simple_strtol(number, 10);
+}
 
 #ifndef __HAVE_ARCH_STRCPY
 
@@ -27,6 +77,8 @@ char *strcpy(char *dest, char *src)
 }
 
 #endif
+
+#if 0
 
 #ifndef __HAVE_ARCH_ATOI
 
@@ -50,8 +102,6 @@ int atoi(register char *number)
 }
 
 #endif
-
-#if 0
 
 #ifndef __HAVE_ARCH_STRNCPY
 


### PR DESCRIPTION
Adds ability to decode ascii strings as decimal, octal and hex values. Programmatic second parameter to `simple_strtol` specifies base, use 0 to allow any base, depending on prefix (0x or 0X for hex, 0 for octal, otherwise decimal).

Replaces `int atoi()`, `long atol()`, and `int hex2i()`.

Total overall 'cost': only 112 byte kernel size increase, because three prior routines were able to be completely removed.

Currently, only /bootops `netport=` parameter allows specification in other than decimal.

@Mellvik: I also added a couple of parens to stop compiler warnings in ne2k.c and also always output the network port and IRQ number, even when the NIC isn't responding. This allows easier catching of improper settings.