### PR TITLE
[kernel][cmds] Properly cleanup TCP connection on close/exit

### DIFF
--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -21,7 +21,7 @@ typedef enum {
 struct socket {
     short type;
     unsigned char state;
-    long flags;
+    unsigned char flags;
     struct proto_ops *ops;
     void *data;
 
@@ -30,7 +30,6 @@ struct socket {
     int avail_data;
     short sem;
 #endif
-
 #if defined(CONFIG_UNIX) || defined(CONFIG_NANO) || defined(CONFIG_INET)
     struct socket *conn;
     struct socket *iconn;
@@ -68,10 +67,10 @@ struct proto_ops {
     int (*fcntl) ();
 };
 
-#define SO_CLOSING	(1 << 12)
-#define SO_ACCEPTCON	(1 << 13)
-#define SO_WAITDATA	(1 << 14)
-#define SO_NOSPACE	(1 << 15)
+#define SO_CLOSING	(1 << 0)
+#define SO_ACCEPTCON	(1 << 1)
+#define SO_WAITDATA	(1 << 2)
+#define SO_NOSPACE	(1 << 3)
 
 struct net_proto {
     char *name;			/* Protocol name */

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -390,7 +390,7 @@ static int inet_send(struct socket *sock, void *buff, int len, int nonblock,
     if (flags != 0)
 	return -EINVAL;
 
-    return inet_write(sock, (char *) buff, len, nonblock);
+    return inet_write(sock, buff, len, nonblock);
 }
 
 static int inet_recv(struct socket *sock, void *buff, int len, int nonblock,
@@ -399,7 +399,7 @@ static int inet_recv(struct socket *sock, void *buff, int len, int nonblock,
     if (flags != 0)
         return -EINVAL;
 
-    return inet_read(sock, (char *) buff, len, nonblock);
+    return inet_read(sock, buff, len, nonblock);
 }
 
 int not_implemented(void)

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -27,10 +27,11 @@
 
 #ifdef CONFIG_INET
 
-extern char tdin_buf[];
+extern unsigned char tdin_buf[];
 extern short bufin_sem, bufout_sem;
-extern int tcpdev_inetwrite();
-extern char *get_tdout_buf();
+extern char tcpdev_inuse;
+extern int tcpdev_inetwrite(void *data, unsigned int len);
+extern char *get_tdout_buf(void);
 
 static short rwlock;	/* global inet_read/write semaphore*/
 
@@ -39,14 +40,14 @@ int inet_process_tcpdev(register char *buf, int len)
     register struct socket *sock;
 
     sock = ((struct tdb_return_data *)buf)->sock;
-    debug_net("inet_process_tcpdev(%d) sock %x, type %d, wait %x\n",
+    debug_net("INET(%d) process_tcpdev sock %x type %d wait %x\n",
 	current->pid, sock, ((struct tdb_return_data *)buf)->type, sock->wait);
 
     switch (((struct tdb_return_data *)buf)->type) {
     case TDT_CHG_STATE:
         sock->state = (unsigned char) ((struct tdb_return_data *)buf)->ret_value;
         tcpdev_clear_data_avail();
-	debug_net("CHG_STATE(%d) sock %x %d\n", current->pid, sock, sock->state);
+	debug_net("INET(%d) chg_state sock %x %d\n", current->pid, sock, sock->state);
 	if (sock->state == SS_DISCONNECTING) {
 	    sock->flags |= SO_CLOSING;
 	    wake_up(sock->wait);
@@ -56,7 +57,7 @@ int inet_process_tcpdev(register char *buf, int len)
     case TDT_AVAIL_DATA:
         down(&sock->sem);
         sock->avail_data = ((struct tdb_return_data *)buf)->ret_value;
-	debug_net("avail_data sock %x %u, bufin %d\n", sock, sock->avail_data, bufin_sem);
+	debug_net("INET(%d) avail_data sock %x %u bufin %d\n", current->pid, sock, sock->avail_data, bufin_sem);
         up(&sock->sem);
         tcpdev_clear_data_avail();
         wake_up(sock->wait);
@@ -64,7 +65,7 @@ int inet_process_tcpdev(register char *buf, int len)
 
     case TDT_RETURN:
     case TDT_ACCEPT:
-	debug_net("retval %d, bufin %d\n", ((struct tdb_return_data *)buf)->ret_value, bufin_sem);
+	debug_net("INET(%d) retval %d bufin %d\n", current->pid, ((struct tdb_return_data *)buf)->ret_value, bufin_sem);
         wake_up(sock->wait);
 	break;
     }
@@ -72,11 +73,9 @@ int inet_process_tcpdev(register char *buf, int len)
     return 1;
 }
 
-extern char tcpdev_inuse;
-
 static int inet_create(struct socket *sock, int protocol)
 {
-    debug_net("NET inet_create(sock: 0x%x) tcpdev %d\n", sock, tcpdev_inuse);
+    debug_net("INET(%d) create sock %x\n", current->pid, sock);
 
     if (protocol != 0 || !tcpdev_inuse)
         return -EINVAL;
@@ -95,7 +94,7 @@ static int inet_release(struct socket *sock, struct socket *peer)
     register struct tdb_release *cmd;
     int ret;
 
-    debug_net("NET inet_release(sock: 0x%x) tcpdev %d\n", sock, tcpdev_inuse);
+    debug_net("INET(%d) release sock %x\n", current->pid, sock);
 	if (!tcpdev_inuse)
 		return -EINVAL;
     cmd = (struct tdb_release *)get_tdout_buf();
@@ -111,7 +110,7 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
     register struct tdb_bind *cmd;
     int ret;
 
-    debug("inet_bind(sock: 0x%x)\n", sock);
+    debug_net("INET(%d) bind sock %x\n", current->pid, sock);
     if (!sockaddr_len || sockaddr_len > sizeof(struct sockaddr_in))
         return -EINVAL;
 
@@ -143,7 +142,7 @@ static int inet_connect(register struct socket *sock,
     register struct tdb_connect *cmd;
     int ret;
 
-    debug_net("inet_connect(sock: 0x%x)\n", sock);
+    debug_net("INET(%d) connect sock %x\n", current->pid, sock);
 
     if (!sockaddr_len || sockaddr_len > sizeof(struct sockaddr_in))
         return -EINVAL;
@@ -216,7 +215,7 @@ static int inet_accept(register struct socket *sock,
     register struct tdb_accept *cmd;
     int ret;
 
-    debug_net("inet_accept(sock: 0x%x newsock: 0x%x)\n", sock, newsock);
+    debug_net("INET(%d) accept sock %x -> newsock %x\n", current->pid, sock, newsock);
     cmd = (struct tdb_accept *)get_tdout_buf();
     cmd->cmd = TDC_ACCEPT;
     cmd->sock = sock;
@@ -231,7 +230,7 @@ static int inet_accept(register struct socket *sock,
         interruptible_sleep_on(sock->wait);
         //sock->flags &= ~SO_WAITDATA;
         if (current->signal) {
-printk("inet_accept: RESTARTSYS\n");
+printk("INET(%d) accept RESTARTSYS\n", current->pid);
             return -ERESTARTSYS;
 	}
     }
@@ -253,7 +252,7 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
     register struct tdb_read *cmd;
     int ret;
 
-    debug_net("inet_READ(%d)(socket: 0x%x size:%d nonblock: %d bufin %d)\n",
+    debug_net("INET(%d) read sock %x size %d nonblock %d bufin %d\n",
 	   current->pid, sock, size, nonblock, bufin_sem);
 
     if (size > TCPDEV_MAXREAD)
@@ -264,7 +263,7 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
 	/* return EOF on socket remote closed*/
 	if (sock->flags & SO_CLOSING)
 	    return 0;
-	debug_net("inet_read(%d): waiting on sock->avail_data sock %x\n", current->pid, sock);
+	debug_net("INET(%d) read waiting on sock->avail_data sock %x\n", current->pid, sock);
 	interruptible_sleep_on(sock->wait);
 	if (current->signal)
 	    return -EINTR;
@@ -278,25 +277,25 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
     cmd->nonblock = nonblock;
     tcpdev_inetwrite(cmd, sizeof(struct tdb_read));
 
-    debug_net("inet_read(%d) waiting on wait %x, bufin %d\n",
+    debug_net("INET(%d) read waiting on wait %x, bufin %d\n",
 	current->pid, sock->wait, bufin_sem);
     /* Sleep until tcpdev has news and we have a lock on the buffer */
     while (bufin_sem == 0) {
-	debug_net("read WAIT(%d) sock %x bufin_sem\n", current->pid, sock);
+	debug_net("INET(%d) read WAIT sock %x bufin_sem\n", current->pid, sock);
         interruptible_sleep_on(sock->wait);
     }
-    debug_net("got read WAIT(%d) bufin_sem %d\n", current->pid, bufin_sem);
+    debug_net("INET(%d) read wait done bufin_sem %d\n", current->pid, bufin_sem);
 
     down(&sock->sem);
 
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
 
     if (ret > 0) {
-	debug_net("INET_READ(%d) %u, %u\n", current->pid, ret, sock->avail_data);
+	debug_net("INET(%d) READ %u avail %u\n", current->pid, ret, sock->avail_data);
         memcpy_tofs(ubuf, &((struct tdb_return_data *)tdin_buf)->data,
 		(size_t) ((struct tdb_return_data *)tdin_buf)->size);
         sock->avail_data = 0;
-    } else debug_net("INET_READ %d, %u\n", ret, sock->avail_data);
+    } else debug_net("INET(%d) READ %d avail %u\n", ret, sock->avail_data);
 
     up(&sock->sem);
 
@@ -311,8 +310,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
     register struct tdb_write *cmd;
     int ret, usize, count;
 
-    debug("inet_write(socket: 0x%x size:%d nonblock: %d)\n", sock, size,
-	   nonblock);
+    debug("INET(%d) write sock %x size %d nonblock %d\n", current->pid, sock, size, nonblock);
     if (size <= 0)
         return 0;
 
@@ -332,21 +330,21 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
         cmd->size = count > TDB_WRITE_MAX ? TDB_WRITE_MAX : count;
 
-	debug_net("INET_WRITE(%d) %u\n", current->pid, cmd->size);
+	debug_net("INET(%d) WRITE %u\n", current->pid, cmd->size);
         memcpy_fromfs(cmd->data, ubuf, (size_t) cmd->size);
 	usize = cmd->size;
         tcpdev_inetwrite(cmd, sizeof(struct tdb_write));
 
 	/* Sleep until tcpdev has news and we have a lock on the buffer */
         while (bufin_sem == 0) {
-	    debug_net("write WAIT(%d) sock %x bufin_sem\n", current->pid, sock);
+	    debug_net("INET(%d) write WAIT sock %x bufin_sem\n", current->pid, sock);
             interruptible_sleep_on(sock->wait);
 	}
-	debug_net("got write WAIT(%d) bufin_sem %d\n", current->pid, bufin_sem);
+	debug_net("INET(%d) write WAIT done bufin_sem %d\n", current->pid, bufin_sem);
 
 	ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
 
-	debug_net("INET_WRITE retval %d\n", ret);
+	debug_net("INET(%d) write retval %d\n", current->pid, ret);
 	tcpdev_clear_data_avail();
 	up(&rwlock);
 
@@ -371,7 +369,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
 static int inet_select(register struct socket *sock, int sel_type)
 {
-    debug_net("inet_select(%d) sock %04x wait %04x type %d, %u\n",
+    debug_net("INET(%d) select sock %04x wait %04x type %d avail %u\n",
 	current->pid, sock, sock->wait, sel_type, sock->avail_data);
 
     if (sel_type == SEL_IN) {

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <arpa/inet.h>
 #include <ktcp/tcp.h>
 #include <ktcp/netconf.h>
@@ -45,6 +46,17 @@ int s;
 int ret,size;
 struct sockaddr_in localadr,remaddr;
 char buf[100];
+
+timeq_t timer_get_time(void)
+{
+    struct timezone	tz;
+    struct timeval 	tv;
+
+    gettimeofday(&tv, &tz);
+
+	/* return 1/16 second ticks, 1,000,000/16 = 62500*/
+    return (tv.tv_sec << 4) | ((unsigned long)tv.tv_usec / 62500U);
+}
 
 int main(void)
 {
@@ -116,6 +128,14 @@ int main(void)
 		addrbytes = (__u8 *)&cbstats->remaddr;
 		sprintf(addr,"%d.%d.%d.%d",addrbytes[0],addrbytes[1],addrbytes[2],addrbytes[3]);
 		printf("%3d %12s %4dms", i+1, tcp_states[cbstats->state], cbstats->rtt);
-		printf(" %5u %15s  %5u\n", cbstats->localport, addr, cbstats->remport);
+		printf(" %5u %15s  %5u", cbstats->localport, addr, cbstats->remport);
+		if (cbstats->state > TS_ESTABLISHED) {
+			/* time is in 1/16 second clicks*/
+			int secs = (unsigned)(cbstats->time_wait_exp - (long)timer_get_time());
+			unsigned int tenthsecs = ((secs + 8) & 15) >> 1;
+			secs >>= 4;
+			printf(" (%d.%d secs)", secs, tenthsecs);
+		}
+		printf("\n");
     }
 }

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -2,7 +2,9 @@
 #define CONFIG_H
 
 /* compile time options*/
-#define CSLIP		1	/* compile in CSLIP support*/
+#define CSLIP			1	/* compile in CSLIP support*/
+#define SEND_RST_ON_CLOSE	0	/* send RST instead of FIN on close*/
+#define SEND_RST_ON_REFUSED_PKT	0	/* send RST on unknown TCP packets*/
 
 /* turn these on for ELKS debugging*/
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -8,6 +8,7 @@
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/
 #define DEBUG_STARTDEF	0	/* default startup debug display*/
 #define DEBUG_TCP	1
+#define DEBUG_CLOSE	1
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
 #define DEBUG_ETH	0
@@ -30,6 +31,12 @@ void dprintf(const char *, ...);
 #define debug_tcp	DPRINTF
 #else
 #define debug_tcp(...)
+#endif
+
+#if DEBUG_CLOSE
+#define debug_close	DPRINTF
+#else
+#define debug_close(...)
 #endif
 
 #if DEBUG_IP

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -54,6 +54,7 @@ void netconf_send(struct tcpcb_s *cb)
 	    cbstats.remaddr = ncb->remaddr;
 	    cbstats.remport = ncb->remport;
 	    cbstats.localport = ncb->localport;
+		cbstats.time_wait_exp = ncb->time_wait_exp;
 	} else
 	    cbstats.valid = 0;
 	tcpcb_buf_write(cb, (unsigned char *)&cbstats, sizeof(cbstats));

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -10,6 +10,7 @@ struct general_stats_s {
 
 struct cb_stats_s {
 	__u32	remaddr;
+	__u32	time_wait_exp;
 	__u16	rtt;		/* Round trip time in ms */
 	__u16	remport;
 	__u16	localport;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -432,9 +432,9 @@ void tcp_process(struct iphdr_s *iph)
 	/* Dummy up a new control block and send RST to shutdown sender */
 	cbnode = tcpcb_new();
 	if (cbnode) {
-	    cbnode->tcpcb.localaddr = ntohl(iph->daddr);
+	    cbnode->tcpcb.localaddr = iph->daddr;
 	    cbnode->tcpcb.localport = ntohs(tcph->dport);
-	    cbnode->tcpcb.remaddr = ntohl(iph->saddr);
+	    cbnode->tcpcb.remaddr = iph->saddr;
 	    cbnode->tcpcb.remport = ntohs(tcph->sport);
 	    cbnode->tcpcb.state = TS_CLOSED;
 	    tcp_reset_connection(&cbnode->tcpcb); /* send RST and deallocate*/

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -199,5 +199,6 @@ void tcp_process(struct iphdr_s *iph);
 void tcp_connect(struct tcpcb_s *cb);
 void tcp_send_fin(struct tcpcb_s *cb);
 void tcp_send_reset(struct tcpcb_s *cb);
+void tcp_reset_connection(struct tcpcb_s *cb);
 
 #endif

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -204,13 +204,38 @@ void tcpcb_rmv_all_unaccepted(struct tcpcb_s *cb)
     }
 }
 
+#if DEBUG_CLOSE
+char *tcp_states[11] = {
+	"CLOSED",
+	"LISTEN",
+	"SYN_SENT",
+	"SYN_RECEIVED",
+	"ESTABLISHED",
+	"FIN_WAIT_1",
+	"FIN_WAIT_2",
+	"CLOSE_WAIT",
+	"CLOSING",
+	"LAST_ACK",
+	"TIME_WAIT"
+};
+
+#endif
+
 void tcpcb_expire_timeouts(void)
 {
     struct tcpcb_list_s *n = tcpcbs, *next;
 
     while (n) {
 	next = n->next;
-debug_tcp("expire state %d\n", n->tcpcb.state);
+#if DEBUG_CLOSE
+	if (n->tcpcb.state > TS_ESTABLISHED) {
+	    int secs = (unsigned)(n->tcpcb.time_wait_exp - Now);
+	    unsigned int tenthsecs = ((secs + 8) & 15) >> 1;
+	    secs >>= 4;
+	    debug_close("ktcp: check expire %s (%d.%d)\n",
+		tcp_states[n->tcpcb.state], secs, tenthsecs);
+	}
+#endif
 	switch (n->tcpcb.state) {
 	    case TS_TIME_WAIT:
 		if (TIME_GT(Now, n->tcpcb.time_wait_exp)) {
@@ -218,8 +243,8 @@ debug_tcp("expire state %d\n", n->tcpcb.state);
 		    tcpcb_remove(n);
 		}
 		break;
-	    case TS_CLOSE_WAIT:		//FIXME added
-		debug_tcp("expire close\n");
+	    //case TS_CLOSE_WAIT:		//FIXME added
+		//debug_close("ktcp: expire close_wait\n");
 	    case TS_FIN_WAIT_1:
 	    case TS_FIN_WAIT_2:
 	    case TS_LAST_ACK:

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -243,8 +243,6 @@ void tcpcb_expire_timeouts(void)
 		    tcpcb_remove(n);
 		}
 		break;
-	    //case TS_CLOSE_WAIT:		//FIXME added
-		//debug_close("ktcp: expire close_wait\n");
 	    case TS_FIN_WAIT_1:
 	    case TS_FIN_WAIT_2:
 	    case TS_LAST_ACK:

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -80,7 +80,7 @@ static void tcpdev_bind(void)
     } else {
 	if (tcpcb_check_port(port) != NULL) {	/* Port already bound */
 	    tcpcb_remove(n);
-	    retval_to_sock(db->sock,-EINVAL);
+	    retval_to_sock(db->sock, -EADDRINUSE);
 	    return;
 	}
     }
@@ -387,8 +387,7 @@ static void tcpdev_release(void)
 	    case TS_CLOSE_WAIT:
 		cb->state = TS_LAST_ACK;
 common_close:
-#define SEND_RST_ON_CLOSE	0	/* future SO_LINGER w/zero timer */
-		if (SEND_RST_ON_CLOSE) {
+		if (SEND_RST_ON_CLOSE) {	/* future SO_LINGER w/zero timer */
 		   tcp_reset_connection(cb);	/* send RST and deallocate */
 		} else {
 		    cbs_in_user_timeout++;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -364,7 +364,7 @@ static void tcpdev_release(void)
     void * sock = db->sock;
 
     n = tcpcb_find_by_sock(sock);
-    debug_tcp("tcpdev: got close from ELKS process, %x\n", n);
+    debug_close("tcpdev release: close socket %x from application, found %x\n", sock, n);
     if (n) {
 	cb = &n->tcpcb;
 	switch(cb->state){


### PR DESCRIPTION
Proposed fix for #976, allows proper FIN and CLOSE wait timeouts on socket close and/or application exit.

Enhances `netstat` to show timer values for better understanding of TCP wait states and possible fine tuning.
Improved debug display for both kernel and `ktcp`.

Also adds (commented out) sending RST on receipt of refused packets.

Internal structure changes, `make clean` after pull before compiling.

@Mellvik: although this looks like lots of changes, almost all is reformatting of kernel debug messages to display process IDs rather than internal buffer addresses for ease of tracing. Also added DEBUG_CLOSE (default on) option to `ktcp` to trace close activity on ^P (DEBUG_TCP also on).

I also added lines 431-442 in elkscmd/ktcp/tcp.c (default commented out) to send an RST just after printing "Refusing packet". Unfortunately, I am not able to test this, so I'd like you to test `urlget` as previously discussed both with and without the RST sending turned on. Since there is no TCP control block when we need to send the RST, it has to be built from scratch, and there's no way of seeing it unless you've got an external packet tracer. I could have possibly got the network/host byte order incorrect or an internal control block field improper which might prevent the single RST from going on the wire.

If the RST works and is left in, we should perform further normal testing of say, streaming `ls -l` telnet while ^D typed, or other fast application exits while data may be still outgoing after the application has exited. We can always leave the RST code out for the time being.