### PR TITLE
[kernel] Add getsockopt system call and SO_LINGER for RST on close

### DIFF
--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -248,6 +248,7 @@ struct syscall_info elks_table[] = {
     { "listen",		packinfo(2, P_SSHORT, P_SSHORT,  P_NONE   ) },
     { "accept",		packinfo(3, P_SSHORT, P_DATA,    P_PSSHORT) },
     { "connect",	packinfo(3, P_SSHORT, P_PDATA,   P_SSHORT ) },
+    { "setsockopt",	packinfo(5, P_SSHORT, P_SSHORT,  P_SSHORT, P_PDATA,   P_SSHORT ) },
 };
 
 #endif

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -99,6 +99,7 @@ bind		+200	3	= CONFIG_SOCKET
 listen		+201	2	= CONFIG_SOCKET
 accept		+202	3	= CONFIG_SOCKET
 connect		+203	3	= CONFIG_SOCKET
+setsockopt	+204	5	= CONFIG_SOCKET
 #
 # Name			No	Args	Flag&comment
 #

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -71,6 +71,7 @@ struct proto_ops {
 #define SO_ACCEPTCON	(1 << 1)
 #define SO_WAITDATA	(1 << 2)
 #define SO_NOSPACE	(1 << 3)
+#define SO_RST_ON_CLOSE	(1 << 4)
 
 struct net_proto {
     char *name;			/* Protocol name */

--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -12,6 +12,17 @@ struct sockaddr {
     char sa_data [MAX_SOCK_ADDR];
 };
 
+/* for setsockopt(2) */
+#define SOL_SOCKET	1
+
+/* careful: option name scheme interferes with internal SO_ options in net.h*/
+#define SO_LINGER	13		/* only implemented for l_linger = 0*/
+
+struct linger {
+        int             l_onoff;        /* Linger active                */
+        int             l_linger;       /* How long to linger for       */
+};
+
 struct msghdr {
     void *		msg_name;
     int 		msg_namelen;

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -29,6 +29,7 @@
 struct tdb_release {
     unsigned char cmd;
     struct socket *sock;
+	int reset;
 };
 
 struct tdb_accept {

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -95,11 +95,12 @@ static int inet_release(struct socket *sock, struct socket *peer)
     int ret;
 
     debug_net("INET(%d) release sock %x\n", current->pid, sock);
-	if (!tcpdev_inuse)
-		return -EINVAL;
+    if (!tcpdev_inuse)
+	return -EINVAL;
     cmd = (struct tdb_release *)get_tdout_buf();
     cmd->cmd = TDC_RELEASE;
     cmd->sock = sock;
+    cmd->reset = sock->flags & SO_RST_ON_CLOSE;
     ret = tcpdev_inetwrite(cmd, sizeof(struct tdb_release));
     return (ret >= 0 ? 0 : ret);
 }

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -588,7 +588,6 @@ int sys_setsockopt(int fd, int level, int option_name, void *option_value,
     if (l.l_onoff != 0 && l.l_linger == 0)
 	sock->flags |= SO_RST_ON_CLOSE;
     else sock->flags &= ~SO_RST_ON_CLOSE;
-    printk("setsockopt reset %x\n", sock->flags);
 
     return 0;
 }

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -567,4 +567,29 @@ int sys_socket(int family, int type, int protocol)
     return fd;
 }
 
+int sys_setsockopt(int fd, int level, int option_name, void *option_value,
+	unsigned int option_len)
+{
+    register struct socket *sock;
+    int err;
+    struct linger l;
+
+    if (!(sock = sockfd_lookup(fd, NULL)))
+	return -ENOTSOCK;
+
+    if (option_name != SO_LINGER || option_len != sizeof(struct linger))
+	return -EINVAL;
+
+    err = check_addr_to_kernel(option_value, sizeof(struct linger));
+    if (err < 0)
+	return err;
+    memcpy_fromfs(&l, option_value, sizeof(struct linger));
+
+    if (l.l_onoff != 0 && l.l_linger == 0)
+	sock->flags |= SO_RST_ON_CLOSE;
+    else sock->flags &= ~SO_RST_ON_CLOSE;
+    printk("setsockopt reset %x\n", sock->flags);
+
+    return 0;
+}
 #endif /* CONFIG_SOCKET */

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -156,9 +156,8 @@ int main(int argc, char *argv[])
 	struct linger l;
 
 	l.l_onoff = 1;
-	l.l_linger = 0;
-	ret = setsockopt(tcp_fd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
-	printf("setsockopt returns %d\n", ret);
+	l.l_linger = 0;		/* send RST on close */
+	setsockopt(tcp_fd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
 }
 #endif
 	ret = bind(tcp_fd, (struct sockaddr *)&locadr, sizeof(struct sockaddr_in));

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -151,6 +151,16 @@ int main(int argc, char *argv[])
 	locadr.sin_port = PORT_ANY;
 	locadr.sin_addr.s_addr = INADDR_ANY;
 
+#if 0	/* test code to force RST on telnet exit*/
+{
+	struct linger l;
+
+	l.l_onoff = 1;
+	l.l_linger = 0;
+	ret = setsockopt(tcp_fd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
+	printf("setsockopt returns %d\n", ret);
+}
+#endif
 	ret = bind(tcp_fd, (struct sockaddr *)&locadr, sizeof(struct sockaddr_in));
 	if (ret < 0){
 		perror("Bind failed");

--- a/elkscmd/inet/urlget/net.c
+++ b/elkscmd/inet/urlget/net.c
@@ -43,7 +43,7 @@ int port;
 	l.l_linger = 0;	/* must be 0 to turn on option*/
 	ret = setsockopt(netfd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
 	if (ret < 0)
-		perror("Setsockopt send RST on close failed");
+		perror("setsockopt RST");
 
 	in_adr.sin_family = AF_INET;
 	in_adr.sin_port = htons(port);
@@ -58,22 +58,21 @@ int port;
 	return(netfd);
 }
 
-void net_close_error(fd)
+/* if errflag set, send TCP RST on close, else send FIN */
+void net_close(fd, errflag)
 int fd;
-{
-	close(fd);	/* keep linger option active: will send RST on close*/
-}
-
-void net_close_noerror(fd)
-int fd;
+int errflag;
 {
 	int ret;
 	struct linger l;
 
-	l.l_onoff = 0;	/* turn off linger option: will send FIN on close*/
-	l.l_linger = 0;
-	ret = setsockopt(fd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
-	if (ret < 0)
-		perror("Setsockopt send FIN on close failed");
+	/* Send RST on close was previously turned on by net_connect*/
+	if (!errflag) {
+		l.l_onoff = 0;	/* turn off linger option: will send FIN on close*/
+		l.l_linger = 0;
+		ret = setsockopt(fd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
+		if (ret < 0)
+			perror("setsockopt FIN");
+	}
 	close(fd);
 }

--- a/elkscmd/inet/urlget/urlget.c
+++ b/elkscmd/inet/urlget/urlget.c
@@ -485,9 +485,12 @@ int ftpio(char *host, int port, char *user, char *pass, char *path, int type, in
 error:
    (void) ftpcmd(fpw, fpr, "QUIT", "");
 
-   fclose(fpr);
-   fclose(fpw);
+   /* flush buffered output, then close descriptor first so that FIN/RST works*/
+   fflush(fpw);
    net_close(fd, s);	/* s == 0? FIN: RST */
+
+   fclose(fpr);		/* associated fd already closed above*/
+   fclose(fpw);
 
    return(s == 0 ? 0 : -1);
 }

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -3,7 +3,6 @@
 
 /* compile time options*/
 #define CSLIP			1	/* compile in CSLIP support*/
-#define SEND_RST_ON_CLOSE	0	/* send RST instead of FIN on close*/
 #define SEND_RST_ON_REFUSED_PKT	0	/* send RST on unknown TCP packets*/
 
 /* turn these on for ELKS debugging*/

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -387,7 +387,7 @@ static void tcpdev_release(void)
 	    case TS_CLOSE_WAIT:
 		cb->state = TS_LAST_ACK;
 common_close:
-		if (SEND_RST_ON_CLOSE || db->reset) { /* SO_LINGER w/zero timer */
+		if (db->reset) {		/* SO_LINGER w/zero timer */
 		   tcp_reset_connection(cb);	/* send RST and deallocate */
 		} else {
 		    cbs_in_user_timeout++;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -364,7 +364,7 @@ static void tcpdev_release(void)
     void * sock = db->sock;
 
     n = tcpcb_find_by_sock(sock);
-    debug_close("tcpdev release: close socket %x from application, found %x\n", sock, n);
+    debug_close("tcpdev release: close socket %x, tcb %x\n", sock, n);
     if (n) {
 	cb = &n->tcpcb;
 	switch(cb->state){
@@ -387,7 +387,7 @@ static void tcpdev_release(void)
 	    case TS_CLOSE_WAIT:
 		cb->state = TS_LAST_ACK;
 common_close:
-		if (SEND_RST_ON_CLOSE) {	/* future SO_LINGER w/zero timer */
+		if (SEND_RST_ON_CLOSE || db->reset) { /* SO_LINGER w/zero timer */
 		   tcp_reset_connection(cb);	/* send RST and deallocate */
 		} else {
 		    cbs_in_user_timeout++;

--- a/libc/include/sys/socket.h
+++ b/libc/include/sys/socket.h
@@ -11,5 +11,6 @@ int bind (int socket, const struct sockaddr * address, socklen_t address_len);
 int connect (int socket, const struct sockaddr * address, socklen_t address_len);
 int listen (int socket, int backlog);
 int socket (int domain, int type, int protocol);
+int setsockopt(int socket, int level, int option_name, const void *option_value, socklen_t option_len);
 
 #endif


### PR DESCRIPTION
Implements ability to send TCP RST instead of TCP FIN on socket close, particularly on forced application exit, as discussed in #976 and #980.

The SO_LINGER option only implements l_linger == 0 when l_on_off == 1, in which case a RST is sent instead of FIN on socket close. The option can be used on any socket, and changed anytime before `close` or application exit.

Adds capability to `urlget`, but untested. Needs testing with `urlget -d`. The changes add two library calls (in net.c), `net_close_error`, which when called will send RST on close (which is also the default when a ^C signal kills the process), as well as `net_close_noerror`, which will allow for a normal close and associated TCP FIN cleanup when no file transfer errors have occurred. The `net_connect` call will default to sending RST on close, to handle the case of ^C interrupts while transfer is in progress.

Adds tested capability to `telnet`, tested but OFF by default, as unneeded.

@Mellvik, if this works, then the purge option can be deleted, as the TCP stack will send RST on close to shutdown the remote TCP packet sending. We may want to also turn on SEND_RST_ON_REFUSED_PKT as well, depending on what the packet trace shows. This may not be required, depending on the remote TCP stack. We will have to see. In either case, no data will be passed upwards to the application, and we should comment out the purge code and call close first with RST, to test that the low-level TCP handles the excess data instead (by dropping it). This will allow the user to operate without concern after ^C and no delays.
