### PR TITLE
[kernel] Use sem_t type for semaphores for clarity

### DIFF
--- a/elks/arch/i86/drivers/char/tcpdev.c
+++ b/elks/arch/i86/drivers/char/tcpdev.c
@@ -27,7 +27,7 @@
 unsigned char tdin_buf[TCPDEV_INBUFFERSIZE];	/* for reading tcpdev*/
 unsigned char tdout_buf[TCPDEV_OUTBUFFERSIZE];	/* for writing tcpdev*/
 
-short bufin_sem, bufout_sem;	/* Buffer semaphores */
+sem_t bufin_sem, bufout_sem;	/* Buffer semaphores */
 
 static unsigned int tdin_tail, tdout_tail;
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -183,7 +183,7 @@ struct inode {
     unsigned short		i_flags;
     unsigned char		i_lock;
     unsigned char		i_dirt;
-    short			i_sem;
+    sem_t			i_sem;
 #ifdef BLOAT_FS
     unsigned long int		i_blksize;
     unsigned long int		i_blocks;

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -28,7 +28,7 @@ struct socket {
 #if defined(CONFIG_INET)
     /* I added this here for smaller code and memory use - HarKal */
     int avail_data;
-    short sem;
+    sem_t sem;
 #endif
 #if defined(CONFIG_UNIX) || defined(CONFIG_NANO) || defined(CONFIG_INET)
     struct socket *conn;

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -152,12 +152,12 @@ void finish_wait(struct wait_queue *p);
 
 /*@-namechecks@*/
 
-extern void _wake_up(struct wait_queue *,unsigned short int);
+extern void _wake_up(struct wait_queue *,int);
 
 /*@+namechecks@*/
 
-extern void down(short *);
-extern void up(short *);
+extern void down(sem_t *);
+extern void up(sem_t *);
 
 extern void wake_up_process(struct task_struct *);
 

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -45,6 +45,8 @@ typedef __u16			umode_t;
 typedef __u8			cc_t;
 typedef __u16			sig_t;
 
+typedef __s16			sem_t;
+
 /*@ignore@*/
 
 /* The next three lines cause splint to complain needlessly */

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -135,7 +135,7 @@ void wake_up_process(register struct task_struct *p)
  * a process. The process itself must remove the queue once it has woken.
  */
 
-void _wake_up(register struct wait_queue *q, unsigned short int it)
+void _wake_up(register struct wait_queue *q, int it)
 {
     register struct task_struct *p;
 
@@ -154,13 +154,13 @@ void _wake_up(register struct wait_queue *q, unsigned short int it)
  *	Semaphores. These are not IRQ safe nor needed to be so for ELKS
  */
 
-void up(register short *s)
+void up(register sem_t *s)
 {
     if (++(*s) == 0)		/* Gone non-negative */
 	wake_up((void *) s);
 }
 
-void down(register short *s)
+void down(register sem_t *s)
 {
     /* Wait for the semaphore */
     while (*s < 0)

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -28,12 +28,12 @@
 #ifdef CONFIG_INET
 
 extern unsigned char tdin_buf[];
-extern short bufin_sem, bufout_sem;
+extern sem_t bufin_sem, bufout_sem;
 extern char tcpdev_inuse;
 extern int tcpdev_inetwrite(void *data, unsigned int len);
 extern char *get_tdout_buf(void);
 
-static short rwlock;	/* global inet_read/write semaphore*/
+static sem_t rwlock;	/* global inet_read/write semaphore*/
 
 int inet_process_tcpdev(register char *buf, int len)
 {

--- a/elks/net/nano/af_nano.h
+++ b/elks/net/nano/af_nano.h
@@ -31,7 +31,7 @@ struct nano_proto_data {
     struct nano_proto_data *npd_peerupd;
     struct wait_queue npd_wait;
     int npd_lock_flag;
-    short npd_sem;
+    sem_t npd_sem;
 };
 
 #endif

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -549,7 +549,7 @@ int sys_socket(int family, int type, int protocol)
     if (!(sock = sock_alloc()))
 	return -ENOSR;
 
-    sock->type = (short int) type;
+    sock->type = type;
     sock->ops = ops;
     if ((fd = sock->ops->create(sock, protocol)) < 0) {
 	sock_release(sock);

--- a/elks/net/unix/af_unix.h
+++ b/elks/net/unix/af_unix.h
@@ -29,7 +29,7 @@ struct unix_proto_data {
     struct unix_proto_data *peerupd;
     struct wait_queue wait;
     int lock_flag;
-    short sem;
+    sem_t sem;
 };
 
 #endif


### PR DESCRIPTION
Introduces typedef sem_t to avoid confusion and clarify semaphore data type.