### PR TITLE
[ktcp] Fix RST sequence number sent on refused packet

### DIFF
--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -3,7 +3,7 @@
 
 /* compile time options*/
 #define CSLIP			1	/* compile in CSLIP support*/
-#define SEND_RST_ON_REFUSED_PKT	0	/* send RST on unknown TCP packets*/
+#define SEND_RST_ON_REFUSED_PKT	1	/* send RST on unknown TCP packets*/
 
 /* turn these on for ELKS debugging*/
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -3,7 +3,6 @@
 
 /* compile time options*/
 #define CSLIP			1	/* compile in CSLIP support*/
-#define SEND_RST_ON_REFUSED_PKT	1	/* send RST on unknown TCP packets*/
 
 /* turn these on for ELKS debugging*/
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -433,6 +433,8 @@ void tcp_process(struct iphdr_s *iph)
 	    cbnode->tcpcb.localport = ntohs(tcph->dport);
 	    cbnode->tcpcb.remaddr = iph->saddr;
 	    cbnode->tcpcb.remport = ntohs(tcph->sport);
+	    cbnode->tcpcb.send_nxt = ntohl(tcph->seqnum);
+	    cbnode->tcpcb.rcv_nxt = ntohl(tcph->acknum);
 	    cbnode->tcpcb.state = TS_CLOSED;
 	    tcp_reset_connection(&cbnode->tcpcb); /* send RST and deallocate*/
 	}

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -426,17 +426,26 @@ void tcp_process(struct iphdr_s *iph)
 		ntohs(tcph->sport), ntohs(tcph->dport));
 
 #if SEND_RST_ON_REFUSED_PKT
+	if (tcph->flags & TF_RST)
+		return;
+
 	/* Dummy up a new control block and send RST to shutdown sender */
 	cbnode = tcpcb_new();
 	if (cbnode) {
+	    __u32 seqno = ntohl(tcph->seqnum);
+	    cbnode->tcpcb.state = TS_CLOSED;
 	    cbnode->tcpcb.localaddr = iph->daddr;
 	    cbnode->tcpcb.localport = ntohs(tcph->dport);
 	    cbnode->tcpcb.remaddr = iph->saddr;
 	    cbnode->tcpcb.remport = ntohs(tcph->sport);
-	    cbnode->tcpcb.send_nxt = ntohl(tcph->seqnum);
-	    cbnode->tcpcb.rcv_nxt = ntohl(tcph->acknum);
-	    cbnode->tcpcb.state = TS_CLOSED;
-	    tcp_reset_connection(&cbnode->tcpcb); /* send RST and deallocate*/
+	    if (tcph->flags & TF_ACK) {
+		cbnode->tcpcb.flags = TF_RST;
+		cbnode->tcpcb.send_nxt = ntohl(tcph->acknum);
+	    } else
+		cbnode->tcpcb.flags = TF_RST|TF_ACK;
+	    cbnode->tcpcb.rcv_nxt = (tcph->flags & TF_SYN)? seqno+1: seqno;
+	    tcp_output(&cbnode->tcpcb);		/* send RST*/
+	    tcpcb_remove_cb(&cbnode->tcpcb);	/* deallocate*/
 	}
 #endif
 	netstats.tcpdropcnt++;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -425,7 +425,6 @@ void tcp_process(struct iphdr_s *iph)
 	printf("tcp: refusing packet %s:%u->%d\n", in_ntoa(iph->saddr),
 		ntohs(tcph->sport), ntohs(tcph->dport));
 
-#if SEND_RST_ON_REFUSED_PKT
 	if (tcph->flags & TF_RST)
 		return;
 
@@ -447,7 +446,7 @@ void tcp_process(struct iphdr_s *iph)
 	    tcp_output(&cbnode->tcpcb);		/* send RST*/
 	    tcpcb_remove_cb(&cbnode->tcpcb);	/* deallocate*/
 	}
-#endif
+
 	netstats.tcpdropcnt++;
 	return;
     }


### PR DESCRIPTION
Attempts to send correct TCP sequence number on RST response to refused packet.

@Mellvik, as a result of the sequence number discussion you brought up in https://github.com/jbruchon/elks/pull/979#issuecomment-950391936, I read up on the required sequence number for RST packets [here](https://superuser.com/questions/1056492/rst-sequence-number-and-window-size), where Linux requires a specific sequence number on RST packets in order to stop blind RST attacks. This fix attempts to make the ktcp config.h SEND_RST_ON_REFUSED_PKT work.

We will need to test this in `urlget`, AFTER the already committed source tree has been proven to work. That is, the master branch code should send an RST on close for errors, so the server's connection will have been closed by the time this fix sends an additional RST. The proper way we need to test this patch, after you OK the master branch fixes, is to temporarily turn off the new "send RST on close" in urlget. This can be done by commenting out the following line in elkscmd/in/urlget/net.c (which effectively takes us back to being bombarded with extra packets after ^C):
```
int net_connect(host, port)
char *host;
int port;
{
    int netfd;
    struct sockaddr_in in_adr;
    struct linger l;
    int ret;

    netfd = socket(AF_INET, SOCK_STREAM, 0);

    in_adr.sin_family = AF_INET;
    in_adr.sin_port = PORT_ANY;
    in_adr.sin_addr.s_addr = INADDR_ANY;

    ret = bind(netfd, (struct sockaddr *)&in_adr, sizeof(struct sockaddr_in));
    if (ret < 0){
        perror("Bind failed");
        exit(1);
    }

    l.l_onoff = 1;  /* turn on linger option: will send RST on close*/
    l.l_linger = 0; /* must be 0 to turn on option*/
   // ret = setsockopt(netfd, SOL_SOCKET, SO_LINGER, &l, sizeof(l)); // <-- comment out these three lines
   // if (ret < 0)
        //perror("setsockopt RST");

    in_adr.sin_family = AF_INET;

```
After this temp change, typing ^C on a urlget transfer should result in lots of refused packets. With this PR applied, the resulting RST sent should stop the server TCP from sending those packets. If they don't stop, then this fix needs more inspection/work.

We're almost there :)

Thank you!

