### PR TITLE
[net, el3] Bugfixes, cleanups

### DIFF
--- a/elks/arch/i86/drivers/net/el3-asm.S
+++ b/elks/arch/i86/drivers/net/el3-asm.S
@@ -75,7 +75,7 @@ el3_sendpk:
 	inc	%cx
 	shr	%cx		// make word count
 	inc	%cx
-	and	$0xfe,%cx	// make dword aligned
+	and	$0xfffe,%cx	// make dword aligned
 	mov     current,%bx	// setup for far memory xfer
 	mov     TASK_USER_DS(%bx),%ds
 


### PR DESCRIPTION
Two important bugfixes brings the EL3/3C509 driver to production quality:

1) A bug that prevented outgoing packet sizes above 512 bytes
2) A race condition in select that under heavy load and with large packets would leave receive interrupts off, thus stopping all comms

The driver is now 'flood ping safe' up to and including 1400 byte packets, there are no known bugs and the effective speed is almost on par with the ne2k. There will be occasional lost packets on receive under heavy load or if the host is busy with floppy accesses or big syncs(), they recover nicely.

No tuning has been done, there may be potential for significant improvement by using the NIC's  'early interrupt' features in both send and receive. Also, there is no collection of statistics at this time. TBD.