### PR TITLE
[kernel] Fix kernel memset for nonzero fill

### DIFF
--- a/elks/arch/i86/lib/string.S
+++ b/elks/arch/i86/lib/string.S
@@ -105,7 +105,8 @@ memset:
 	mov	ARG1(%bx),%ax	// byte to write
 	mov	ARG2(%bx),%cx	// loop count
 	cld
-	shr     $1,%cx         	// copy words
+	shr     $1,%cx         	// store words
+	mov     %al,%ah
 	rep			// while (cx) cx--, [es:di++] = al
 	stosw
 	rcl	$1,%cx		// then possibly final byte


### PR DESCRIPTION
Long story short, while testing some code for an upcoming feature, automatic kernel stack overflow checking (in v0.8.0), it was found that kernel `memset` doesn't work for fill values != 0 (!!). This was broken by an "optimization" I threw in PR #1554, where `memset` runs faster using ASM `stow` to store words rather than bytes. 

The faulty optimization wasn't picked up by the C library test routines because this is the kernel `memset`, not the C library version, which isn't optimized for word copies (yet). We don't currently have any test suites for kernel library routines.

Amazingly enough, although there are many calls to `memset` to zero-fill, there are only two calls otherwise, both in the FAT filesystem, used when pre-filling 8.3 filenames with spaces. No one had apparently ran into that problem yet.

