### PR TITLE
docker: install patch, required for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /elks
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
   flex bison texinfo libncurses5-dev \
-  bash make g++ git libelf-dev \
+  bash make g++ git libelf-dev patch \
   xxd ca-certificates wget mtools \
  && rm -r /var/lib/apt/lists /var/cache/apt/archives \
  && addgroup \


### PR DESCRIPTION
Otherwise I was getting the following error:

```
cd lib/elftoolchain-0.7.1 && patch -p1 <'/elks/elks/tools/elf2elks/lib/elftoolchain.patch' /bin/sh: 1: patch: not found
make[3]: *** [Makefile:63: lib/elftoolchain-0.7.1/libelf/libelf.a] Error 127 make[3]: Leaving directory '/elks/elks/tools/elf2elks' make[2]: *** [Makefile:35: all] Error 2
make[2]: Leaving directory '/elks/elks/tools'
make[1]: *** [Makefile:126: tools] Error 2
make[1]: Leaving directory '/elks/elks'
make: *** [Makefile:13: all] Error 2
```