### PR TITLE
[kernel] Ensure interrupts disabled during kernel startup

### DIFF
--- a/elks/arch/i86/drivers/char/console-serial-8018x.c
+++ b/elks/arch/i86/drivers/char/console-serial-8018x.c
@@ -111,6 +111,7 @@ static void update_port(struct serial_info *port)
 {
     unsigned int cflags;
     unsigned int baudrate_compare;
+    flag_t flags;
 
     cflags = port->tty->termios.c_cflag & CBAUD;
     if (cflags & CBAUDEX) {
@@ -119,6 +120,7 @@ static void update_port(struct serial_info *port)
     /* get which baud rate compare value is requested */
     baudrate_compare = baudrate_compares[cflags];
 
+    save_flags(flags);
     clr_irq();
 
     /* Disable receiver */
@@ -137,7 +139,7 @@ static void update_port(struct serial_info *port)
     /* Enable receiver */
     outw(inw(port->io_ccon) | 0x0020, port->io_ccon);
 
-    set_irq();
+    restore_flags(flags);
 }
 
 /* Called from main.c! */

--- a/elks/arch/i86/drivers/char/kbd-scancode.c
+++ b/elks/arch/i86/drivers/char/kbd-scancode.c
@@ -143,13 +143,15 @@ static unsigned char *scan_tabs[] = {
 void kbd_init(void)
 {
     /* Set off the initial keyboard interrupt handler */
+    flag_t flags;
 
     if (request_irq(KBD_IRQ, keyboard_irq, INT_GENERIC))
 	panic("Unable to get keyboard");
 
+    save_flags(flags);
     clr_irq();
     kb_read();      /* discard any unread keyboard input*/
-    set_irq();
+    restore_flags(flags);
 
     set_leds();
 }
@@ -464,8 +466,11 @@ static void restart_timer(void)
    be enabled. */
 static void set_leds(void)
 {
+    flag_t flags;
+
     if (!(sys_caps & CAP_KBD_LEDS)) return;	/* PC/XT doesn't have LEDs */
 
+    save_flags(flags);
     clr_irq();
     if (kb_cmd_state == KS_FREE) {
 	/* if already in the middle of setting LEDs, then nothing to do;
@@ -473,5 +478,5 @@ static void set_leds(void)
 	kb_cmd_state = KS_SETTING_LED_1;
 	restart_timer();
     }
-    set_irq();
+    restore_flags(flags);
 }

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -159,6 +159,7 @@ static void update_port(register struct serial_info *port)
 {
     unsigned int cflags;        /* use smaller 16-bit width to save code*/
     unsigned divisor;
+    flag_t flags;
 
     /* set baud rate divisor, first lower, then higher byte */
     cflags = port->tty->termios.c_cflag & CBAUD;
@@ -172,6 +173,7 @@ static void update_port(register struct serial_info *port)
     if (divisor != port->divisor) {
         port->divisor = divisor;
 
+        save_flags(flags);
         clr_irq();
 
         /* Set the divisor latch bit */
@@ -184,7 +186,7 @@ static void update_port(register struct serial_info *port)
         /* Clear the divisor latch bit */
         OUTB(port->lcr, port->io + UART_LCR);
 
-        set_irq();
+        restore_flags(flags);
     }
 }
 

--- a/elks/arch/i86/drivers/char/serial-template.c
+++ b/elks/arch/i86/drivers/char/serial-template.c
@@ -112,6 +112,7 @@ static void update_port(struct serial_info *port)
 {
     unsigned int cflags;	/* use smaller 16-bit width to save code*/
     unsigned divisor;
+    flag_t flags;
 
     /* set baud rate divisor, first lower, then higher byte */
     cflags = port->tty->termios.c_cflag & CBAUD;
@@ -125,6 +126,7 @@ static void update_port(struct serial_info *port)
     if (divisor != port->divisor) {
 	port->divisor = divisor;
 
+	save_flags(flags);
 	clr_irq();
 
 	/* Set the divisor latch bit */
@@ -137,7 +139,7 @@ static void update_port(struct serial_info *port)
 	/* Clear the divisor latch bit */
 	outb(port->lcr, port->io + UART_LCR);
 
-	set_irq();
+	restore_flags(flags);
     }
 }
 

--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -277,6 +277,7 @@ dma_read:
 	inc     %cx     // make byte count even
 	and     $0xfffe,%cx
 
+	pushfw		// save interrupt state
 	cli		// Experimental - disable INTR
 	call    dma_init
 
@@ -323,7 +324,7 @@ check_dma_r:
 
 	mov     $0x40,%al       // clear ISR (RDC bit only)
 	out     %al,%dx
-	sti			//Experimental - Enable INTR
+	popfw			//Experimental - reenable interrupt state
 
 	pop	%bx
 	pop	%es


### PR DESCRIPTION
In general, the kernel expects interrupts to be disabled during kernel startup, all the way through block device initialization, until just before block I/O is required for reading partition tables. Tracing through startup showed various drivers didn't follow this convention and enabled interrupts without checking for prior interrupt state. This PR cleans that up.