### PR TITLE
[cmds] Update mkfat table to use cluster size 2 for 32MB hard drive

### DIFF
--- a/elkscmd/disk_utils/mkfat.c
+++ b/elkscmd/disk_utils/mkfat.c
@@ -55,7 +55,7 @@ struct sec_per_clus_table
 struct sec_per_clus_table _cluster_size_table16[] =
 {
     { 4084L,   1},   // 2MB - 512b
-    { 65525L,  2},   // 64MB - 1K (was 32680/16MB)
+    { 65524L,  2},   // 64MB - 1K (was 32680/16MB)
     { 262144L, 4},   // 128MB - 2K
     { 524288L, 8},   // 256MB - 4K
     { 1048576L, 16}, // 512MB - 8K

--- a/elkscmd/disk_utils/mkfat.c
+++ b/elkscmd/disk_utils/mkfat.c
@@ -55,7 +55,7 @@ struct sec_per_clus_table
 struct sec_per_clus_table _cluster_size_table16[] =
 {
     { 4084L,   1},   // 2MB - 512b
-    { 32680L,  2},   // 16MB - 1K
+    { 65525L,  2},   // 64MB - 1K (was 32680/16MB)
     { 262144L, 4},   // 128MB - 2K
     { 524288L, 8},   // 256MB - 4K
     { 1048576L, 16}, // 512MB - 8K


### PR DESCRIPTION
ELKS `mkfat` was creating 64MB FAT images using a cluster size of 4, rather than 2, which the host `mformat` command uses. 

This change allows `mkfat` to be used within ELKS with very similar results to the host`mformat` (the exception being that mkfat creates a FAT table 1 sector larger, for reasons unknown).

To create a 32MB hard drive image with the same size as created by the ELKS build, use `mkfat /dev/hda1 31752`.