### PR TITLE
[cmds] Enhance fsck-dos to work with large 32M hard drives

### DIFF
--- a/elkscmd/fsck_dos/Makefile
+++ b/elkscmd/fsck_dos/Makefile
@@ -4,7 +4,7 @@ include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 
-LOCALCFLAGS = -Dlint -DELKS=1
+LOCALCFLAGS = -Dlint -DELKS=1 -D__huge=
 # remove next line when FAT32 supported
 LOCALCFLAGS += -Wno-shift-count-overflow
 
@@ -35,5 +35,9 @@ fat.o: fat.c
 fsck-dos: main.o boot.o check.o dir.o fat.o
 	$(LD) $(LDFLAGS) -maout-heap=0xffff -o $@ $^ $(LDLIBS)
 
+fsck-dos.os2:
+	ewcc -Dlint=1 -DELKS=1 boot.c check.c dir.c fat.c main.c mem.c
+	ewlink -o fsck-dos.os2 boot.obj check.obj dir.obj fat.obj main.obj mem.obj
+
 clean:
-	$(RM) *.o $(PRGS)
+	$(RM) *.o $(PRGS) *.obj *.os2

--- a/elkscmd/fsck_dos/ext.h
+++ b/elkscmd/fsck_dos/ext.h
@@ -64,6 +64,16 @@ extern int skipclean;	/* skip clean file systems if preening */
 
 extern struct dosDirEntry *rootDir;
 
+#if defined(__COMPACT__) || defined(__LARGE__)
+void *hmalloc(unsigned long size);
+void *hcalloc(unsigned long size);
+#define MAXCLUSTERS     31752
+#else
+#define hmalloc(n)      malloc(n)
+#define hcalloc(n)      calloc(n,1)
+#define MAXCLUSTERS     3969
+#endif
+
 /*
  * function declarations
  */
@@ -114,22 +124,22 @@ int readfat(int, struct bootblock *, int, struct fatEntry **);
  * Check two FAT copies for consistency and merge changes into the
  * first if neccessary.
  */
-int comparefat(struct bootblock *, struct fatEntry *, struct fatEntry *, int);
+int comparefat(struct bootblock *, struct fatEntry __huge *, struct fatEntry __huge *, int);
 
 /*
  * Check a FAT
  */
-int checkfat(struct bootblock *, struct fatEntry *);
+int checkfat(struct bootblock *, struct fatEntry __huge *);
 
 /*
  * Write back FAT entries
  */
-int writefat(int, struct bootblock *, struct fatEntry *, int);
+int writefat(int, struct bootblock *, struct fatEntry __huge *, int);
 
 /*
  * Read a directory
  */
-int resetDosDirSection(struct bootblock *, struct fatEntry *);
+int resetDosDirSection(struct bootblock *, struct fatEntry __huge *);
 void finishDosDirSection(void);
 int handleDirTree(int, struct bootblock *, struct fatEntry *);
 
@@ -139,11 +149,11 @@ int handleDirTree(int, struct bootblock *, struct fatEntry *);
 /*
  * Check for lost cluster chains
  */
-int checklost(int, struct bootblock *, struct fatEntry *);
+int checklost(int, struct bootblock *, struct fatEntry __huge *);
 /*
  * Try to reconnect a lost cluster chain
  */
-int reconnect(int, struct bootblock *, struct fatEntry *, cl_t);
+int reconnect(int, struct bootblock *, struct fatEntry __huge *, cl_t);
 void finishlf(void);
 
 /*
@@ -157,6 +167,6 @@ char *rsrvdcltype(cl_t);
 /*
  * Clear a cluster chain in a FAT
  */
-void clearchain(struct bootblock *, struct fatEntry *, cl_t);
+void clearchain(struct bootblock *, struct fatEntry __huge *, cl_t);
 
 #endif

--- a/elkscmd/fsck_dos/fat.c
+++ b/elkscmd/fsck_dos/fat.c
@@ -344,7 +344,6 @@ readfat(int fs, struct bootblock *boot, int no, struct fatEntry **fp)
 			break;
 		}
 	}
-    //{ char c; read(0, &c, 1); }
 
 	free(buffer);
 	*fp = fat;

--- a/elkscmd/fsck_dos/mem.c
+++ b/elkscmd/fsck_dos/mem.c
@@ -1,0 +1,94 @@
+/* malloc/free wholesale replacement for 8086 toolchain */
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#define MALLOC_ARENA_SIZE   8192  /* size of initial arena fmemalloc (max 65520)*/
+#define MALLOC_ARENA_THRESH 1500U   /* max size to allocate from arena-managed heap */
+
+unsigned int malloc_arena_size = MALLOC_ARENA_SIZE;
+unsigned int malloc_arena_thresh = MALLOC_ARENA_THRESH;
+
+#define FP_SEG(fp)          ((unsigned)((unsigned long)(void __far *)(fp) >> 16))
+#define FP_OFF(fp)          ((unsigned)(unsigned long)(void __far *)(fp))
+
+static void __far *heap;
+
+void *hmalloc(unsigned long size)
+{
+    char *p;
+
+    if (heap == NULL) {
+        heap = fmemalloc(malloc_arena_size);
+        if (!heap) {
+            __dprintf("FATAL: Can't fmemalloc %u\n", malloc_arena_size);
+            system("meminfo > /dev/console");
+            exit(1);
+        }
+        _fmalloc_add_heap(heap, malloc_arena_size);
+    }
+
+    if (size <= malloc_arena_thresh)
+        p = _fmalloc(size);
+    else p = fmemalloc(size);
+    return p;
+}
+
+void *malloc(size_t size)
+{
+    return hmalloc(size);
+}
+
+void *hcalloc(unsigned long size)
+{
+    char *mem = hmalloc(size);
+    char __huge *clr = mem;
+
+    if (!mem) return NULL;
+    do {
+        unsigned long n = size;
+        if (n > 16384) n = 16384;
+        fmemset(clr, '\0', n);
+        size -= n;
+        clr += n;
+    } while (size);
+    return mem;
+}
+
+void free(void *ptr)
+{
+    if (ptr == NULL)
+        return;
+    if (FP_OFF(ptr) == 0)       /* non-arena pointer */
+        fmemfree(ptr);
+    else
+        _ffree(ptr);
+}
+
+#if UNUSED
+void *realloc(void *ptr, size_t size)
+{
+    void *new;
+    size_t osize = size;
+
+    if (ptr == 0)
+        return hmalloc(size);
+
+#if LATER
+    /* we can't yet get size from fmemalloc'd block */
+    osize = _fmalloc_usable_size(ptr);
+    __dprintf("old %u new %u\n", osize, size);
+    if (size < osize || osize == 0)
+        osize = size;           /* copy less bytes in memcpy below */
+#endif
+
+    new = hmalloc(size);
+    if (new == 0) {
+        __dprintf("realloc: Out of memory\n");
+        return 0;
+    }
+    memcpy(new, ptr, osize);    /* FIXME copies too much but can't get real osize */
+    free(ptr);
+    return new;
+}
+#endif


### PR DESCRIPTION
This now allows for 32MB and smaller hard drive DOS FAT images to be consistency checked. 

When compiled with OWCC, `fsck-dos.os2` uses huge pointers to work with the much larger FAT table found in ELKS 32MB FAT hard disk images.  To check a 32MB hard drive, there must be > 256KB of contiguous main memory available, which may not be the case with multiple logins or shells running.

Hopefully this tool might help @tyama501 with the possible HD FAT corruption seen in #2398.

The source code for `fsck-dos` was somewhat easily enhanced to use \_\_huge far pointers, which causes OWCC to generate additional code for indexing huge far pointers into > 64KB contiguous RAM allocated through `fmemalloc`. The standard malloc/free were then replaced with an enhanced version developed for the 8086-toolchain, where two far memory arenas are maintained, one for small allocations using \_fmalloc, and the other using fmemalloc.

For the time being, this requires OWCC being installed on the host. To build the enhanced version, type:
```
# cd elkscmd/fsck_dos
# make fsck-dos.os2
# cp fsck-dos.os2 ../rootfs_template/root
# cd
# ./fsck-dos.os2 /dev/hda1
```
<img width="832" height="540" alt="Screenshot 2025-10-11 at 9 22 26 PM" src="https://github.com/user-attachments/assets/4721965e-1ffc-45f3-bf8e-26f9a00bbfba" />

For those without OWCC, here's a pre-compiled binary: 
[fsck-dos.os2.zip](https://github.com/user-attachments/files/22868779/fsck-dos.os2.zip)



