### PR TITLE
[cmds] Allow cp -v to work without -R

### DIFF
--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -369,8 +369,6 @@ char *destdir(char *file)
 
 int do_cp(char *srcfile, char *dstfile)
 {
-	if (opt_verbose) printf("Copying %s to %s\n", srcfile, dstfile);
-
 	return copyfile(srcfile, dstfile, 1);
 }
 
@@ -537,6 +535,8 @@ int copyfile(char *srcname, char *destname, int setmodes)
 	struct	stat	statbuf1;
 	struct	stat	statbuf2;
 	struct	utimbuf	times;
+
+	if (opt_verbose) printf("Copying %s to %s\n", srcname, destname);
 
 	if (stat(srcname, &statbuf1) < 0) {
 		perror(srcname);


### PR DESCRIPTION
Allows using `cp -v /bin/* /mnt/tmp` etc to better see the results of copy operations when not using -R. Previously, -v only displayed verbose results when -R was also specified.
