### PR TITLE
[libc] Don't require precision timer init when FTRACE disabled

### DIFF
--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -57,23 +57,25 @@ static unsigned short __far *pjiffies;  /* only access low order jiffies word */
 
 #define errmsg(str)     write(STDERR_FILENO, str, sizeof(str) - 1)
 
-void init_ptime(void)
+int init_ptime(void)
 {
     int fd, offset, kds;
 
     __LINK_SYMBOL(ptostr);
     fd = open("/dev/kmem", O_RDONLY);
     if (fd < 0) {
-        errmsg("No kmem\n");
-        return;
+        errmsg("No /dev/kmem\n");
+        return 0;
     }
     if (ioctl(fd, MEM_GETDS, &kds) < 0 ||
         ioctl(fd, MEM_GETJIFFADDR, &offset) < 0) {
-        errmsg("No mem ioctl\n");
-    } else {
-        pjiffies = _MK_FP(kds, offset);
+        errmsg("No kmem ioctl\n");
+        close(fd);
+        return 0;
     }
+    pjiffies = _MK_FP(kds, offset);
     close(fd);
+    return 1;
 }
 #endif
 

--- a/elks/include/linuxmt/prectimer.h
+++ b/elks/include/linuxmt/prectimer.h
@@ -7,7 +7,7 @@
 
 /* returns pticks in 0.838us resolution, 0.838 microseconds to 42.85 seconds  */
 unsigned long get_ptime(void);
-void init_ptime(void);
+int init_ptime(void);
 
 /* internal test routines */
 void test_ptime_idle_loop(void);

--- a/libc/debug/instrument.c
+++ b/libc/debug/instrument.c
@@ -43,9 +43,10 @@ static noinstrument void ftrace_checkargs(void)
             close(fd);
         }
         sym_read_exe_symbols(__program_filename);
+        if (!init_ptime())          /* init precision time routine */
+            _exit(1);
+        get_ptime();
     }
-    init_ptime();                   /* init precision time routine */
-    get_ptime();
 }
 
 /* every function this function calls must also be noinstrument!! */

--- a/libc/debug/prectimer.c
+++ b/libc/debug/prectimer.c
@@ -57,23 +57,25 @@ static unsigned short __far *pjiffies;  /* only access low order jiffies word */
 
 #define errmsg(str)     write(STDERR_FILENO, str, sizeof(str) - 1)
 
-void init_ptime(void)
+int init_ptime(void)
 {
     int fd, offset, kds;
 
     __LINK_SYMBOL(ptostr);
     fd = open("/dev/kmem", O_RDONLY);
     if (fd < 0) {
-        errmsg("No kmem\n");
-        return;
+        errmsg("No /dev/kmem\n");
+        return 0;
     }
     if (ioctl(fd, MEM_GETDS, &kds) < 0 ||
         ioctl(fd, MEM_GETJIFFADDR, &offset) < 0) {
-        errmsg("No mem ioctl\n");
-    } else {
-        pjiffies = _MK_FP(kds, offset);
+        errmsg("No kmem ioctl\n");
+        close(fd);
+        return 0;
     }
+    pjiffies = _MK_FP(kds, offset);
     close(fd);
+    return 1;
 }
 #endif
 


### PR DESCRIPTION
Discussed in https://gitlab.com/tkchia/build-ia16/-/issues/36.

This should allow @tkchia's [Build IA16](https://gitlab.com/tkchia/build-ia16) build to succeed creating its version of the ELKS C library, which uses `elksemu` to test programs compiled with `-finstrument-functions-simple`. `elksemu`doesn't emulate /dev/kmem ioctl calls, which are used by the precision timer library for accurate FTRACE timer display. 

This change doesn't require /dev/kmem unless FTRACE is enabled via an environment variable or a --ftrace command line option.
