### PR TITLE
[kernel] Issue BIOSHD disk reset when ATA CF driver present on boot

### DIFF
--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -20,6 +20,7 @@
 #include <linuxmt/init.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/ioctl.h>
+#include <linuxmt/biosparm.h>
 #include <linuxmt/debug.h>
 
 #include <arch/system.h>
@@ -382,8 +383,10 @@ void INITPROC blk_dev_init(void)
 #endif
 
 #ifdef CONFIG_BLK_DEV_BHD
-    if (biosdisk)
+    if (biosdisk) {
+        bios_disk_reset(0x80);      /* required for copy.sh/v86 with ATA CF driver */
         init_partitions(biosdisk);
+    }
 #endif
 
 #ifdef CONFIG_BLK_DEV_ATA_CF

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -21,6 +21,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/ioctl.h>
 #include <linuxmt/biosparm.h>
+#include <linuxmt/genhd.h>
 #include <linuxmt/debug.h>
 
 #include <arch/system.h>
@@ -384,7 +385,7 @@ void INITPROC blk_dev_init(void)
 
 #ifdef CONFIG_BLK_DEV_BHD
     if (biosdisk) {
-        bios_disk_reset(0x80);      /* required for copy.sh/v86 with ATA CF driver */
+        bios_disk_reset(bios_drive_map[0]); /* required for copy.sh/v86 with ATA CF */
         init_partitions(biosdisk);
     }
 #endif


### PR DESCRIPTION
Finally fixes extended boot delay issue discussed in https://github.com/ghaerr/elks/pull/2408#issuecomment-3422276867.

When the ATA CF driver is initialized, the BIOSHD driver was hanging on the next I/O request, which happened to be in the MBR partition handling code. Apparently both drivers talking to the same ATA hardware caused the BIOS code to wait 30 seconds before returning an I/O error, then retrying. Issuing a BIOS disk reset beforehand eliminates this problem.

