### PR TITLE
[reset] Adding reboot function by shutdown -r to PC-98

### DIFF
--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -44,7 +44,7 @@ OBJS += divzero.o
 endif
 
 ifeq ($(CONFIG_ARCH_PC98), y)
-OBJS += irq-8259.o reset-stubs.o timer-8254.o
+OBJS += irq-8259.o reset-pc98.o timer-8254.o
 endif
 
 ifeq ($(CONFIG_ARCH_8018X), y)

--- a/elks/arch/i86/kernel/reset-pc98.c
+++ b/elks/arch/i86/kernel/reset-pc98.c
@@ -1,0 +1,35 @@
+#include <arch/system.h>
+
+/*
+ * This function gets called by the keyboard interrupt handler.
+ * As it's called within an interrupt, it may NOT sync.
+ */
+void ctrl_alt_del(void)
+{
+}
+
+void hard_reset_now(void)
+{
+    asm("mov $0x37,%dx\n\t"
+        "mov $0xb,%al\n\t"
+        "out %al,%dx\n\t"
+        "mov $0xf,%al\n\t"
+        "out %al,%dx\n\t"
+        "mov $0xf0,%dx\n\t"
+        "in  %dx,%al\n\t"
+        "and $2,%al\n\t"
+        "cmp $2,%al\n\t"
+        "je V30\n\t"
+        "mov $0,%al\n\t"
+        "out %al,%dx\n\t"
+        "ljmp $0xFFFF,$0\n\t"
+"V30:\n\t"
+        "mov $7,%al\n\t"
+        "out %al,%dx\n\t"
+        "ljmp $0xFFFF,$0\n\t"
+    );
+}
+
+void apm_shutdown_now(void)
+{
+}

--- a/elks/arch/i86/kernel/reset-stubs.c
+++ b/elks/arch/i86/kernel/reset-stubs.c
@@ -10,6 +10,27 @@ void ctrl_alt_del(void)
 
 void hard_reset_now(void)
 {
+#if defined CONFIG_ARCH_PC98
+    asm("mov $0x37,%dx\n\t"
+        "mov $0xb,%al\n\t"
+        "out %al,%dx\n\t"
+        "mov $0xf,%al\n\t"
+        "out %al,%dx\n\t"
+        "mov $0xf0,%dx\n\t"
+        "in  %dx,%al\n\t"
+        "and $2,%al\n\t"
+        "cmp $2,%al\n\t"
+        "je V30\n\t"
+        "mov $0,%al\n\t"
+        "out %al,%dx\n\t"
+        "ljmp $0xFFFF,$0\n\t"
+"V30:\n\t"
+        "mov $7,%al\n\t"
+        "out %al,%dx\n\t"
+        "ljmp $0xFFFF,$0\n\t"
+    );
+
+#endif
 }
 
 void apm_shutdown_now(void)

--- a/elks/arch/i86/kernel/reset-stubs.c
+++ b/elks/arch/i86/kernel/reset-stubs.c
@@ -10,27 +10,6 @@ void ctrl_alt_del(void)
 
 void hard_reset_now(void)
 {
-#if defined CONFIG_ARCH_PC98
-    asm("mov $0x37,%dx\n\t"
-        "mov $0xb,%al\n\t"
-        "out %al,%dx\n\t"
-        "mov $0xf,%al\n\t"
-        "out %al,%dx\n\t"
-        "mov $0xf0,%dx\n\t"
-        "in  %dx,%al\n\t"
-        "and $2,%al\n\t"
-        "cmp $2,%al\n\t"
-        "je V30\n\t"
-        "mov $0,%al\n\t"
-        "out %al,%dx\n\t"
-        "ljmp $0xFFFF,$0\n\t"
-"V30:\n\t"
-        "mov $7,%al\n\t"
-        "out %al,%dx\n\t"
-        "ljmp $0xFFFF,$0\n\t"
-    );
-
-#endif
 }
 
 void apm_shutdown_now(void)


### PR DESCRIPTION
Hello @ghaerr and @drachen6jp 

This is the PR to add the shutdown -r reboot function for PC-98 by @drachen6jp .

I have cherry-picked his commit, then I have added reset-pc98.c and moved the function from the reset-stub.c.

I have confirmed it work with NP2 emulator.

Thank you!