### PR TITLE
[cmds] Slim down 'env' command and add back to distribution

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -146,7 +146,7 @@ minix1/wc                       :minix1                 :1200k
 minix1/cut                      :be-minix1               :1200c     :1440k
 #minix1/cksum                   :be-minix1              :1200k
 minix1/du                       :be-minix1              :1200k
-#minix2/env                     :minix2                 :1200k
+minix2/env                      :minix2                             :1440k
 minix2/lp                       :minix2                 :1200k
 minix2/lpd                      :minix2                 :1200k
 #minix2/pwdauth                 :minix2

--- a/elkscmd/minix2/Makefile
+++ b/elkscmd/minix2/Makefile
@@ -12,8 +12,8 @@ LOCALFLAGS=-D_POSIX_SOURCE
 # compiling but unused: pwdauth
 PRGS=env lp lpd remsync synctree tget
 
-env: env.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o env env.o $(TINYPRINTF) $(LDLIBS)
+env: env.o
+	$(LD) $(LDFLAGS) -o env env.o $(LDLIBS)
 
 pwdauth: pwdauth.o
 	$(LD) $(LDFLAGS) -o pwdauth pwdauth.o $(LDLIBS)


### PR DESCRIPTION
Adds `env` back into distribution. Removed stdio dependency, saves 1440 bytes.