### PR TITLE
[bios] Supporting FD1200 mount on PC-98

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -47,11 +47,7 @@ struct drive_infot fd_types[] = {   /* AT/PS2 BIOS reported floppy formats*/
 #ifdef CONFIG_ARCH_PC98
 unsigned char bios_drive_map[MAX_DRIVES] = {
     0xA0, 0xA1, 0xA2, 0xA3,             /* hda, hdb */
-#ifdef CONFIG_IMG_FD1232
     0x90, 0x91, 0x92, 0x93              /* fd0, fd1 */
-#else
-    0x30, 0x31, 0x32, 0x33              /* fd0, fd1 */
-#endif
 };
 #else
 unsigned char bios_drive_map[MAX_DRIVES] = {
@@ -93,11 +89,16 @@ int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
         BD_DX = (head << 8) | ((sector - 1) & 0xFF);
     }
     else {
-        if ((0xF0 & drive) == 0x90) {
+        if (((0xF0 & drive) == 0x90)||((0xF0 & drive) == 0xf0)) {
+            BD_AX = 0x5a00|drive;
+            call_bios(&bdt);
+            BD_AX = cmd | drive;
+            if((BD_CX & 0x300)==0x200) goto notMFM1024;
             BD_BX = (unsigned int) (num_sectors << 10);
             BD_CX = (3 << 8) | cylinder;
         }
         else {
+notMFM1024:
             BD_BX = (unsigned int) (num_sectors << 9);
             BD_CX = (2 << 8) | cylinder;
         }
@@ -286,17 +287,10 @@ int INITPROC bios_getfdinfo(struct drive_infot *drivep)
     int ndrives = FD_DRIVES;
 
 #ifdef CONFIG_ARCH_PC98
-#if defined(CONFIG_IMG_FD1232)
     drivep[0] = fd_types[FD1232];
     drivep[1] = fd_types[FD1232];
     drivep[2] = fd_types[FD1232];
     drivep[3] = fd_types[FD1232];
-#else
-    drivep[0] = fd_types[FD1440];
-    drivep[1] = fd_types[FD1440];
-    drivep[2] = fd_types[FD1440];
-    drivep[3] = fd_types[FD1440];
-#endif
 #endif
 
 #ifdef CONFIG_ARCH_IBMPC
@@ -317,16 +311,16 @@ int INITPROC bios_getfdinfo(struct drive_infot *drivep)
 #ifdef CONFIG_ARCH_PC98
     for (drive = 0; drive < 4; drive++) {
         if (peekb(0x55C,0) & (1 << drive)) {
-#ifdef CONFIG_IMG_FD1232
             bios_drive_map[DRIVE_FD0 + drive] = drive + 0x90;
             *drivep = fd_types[FD1232];
-#else
-            bios_drive_map[DRIVE_FD0 + drive] = drive + 0x30;
-            *drivep = fd_types[FD1440];
-#endif
+/* test yet. when bios_switch_device98 is called these value are broken to 0x90 or 0x30 or 0x10.
+        }else if (((peekb(0x55C,0) & 0xf) == 0) && (peekb(0x55D,0) & (0x10 << drive))) {
+            bios_drive_map[DRIVE_FD0 + drive] = drive + 0x70;
+            *drivep = fd_types[FD720];
+*/
+         }
             ndrives++;  /* floppy drive count*/
             drivep++;
-        }
     }
 #else
 
@@ -426,10 +420,16 @@ void BFPROC bios_switch_device98(int target, unsigned int device,
         (device | (bios_drive_map[target + DRIVE_FD0] & 0x0F));
     if (device == 0x30)
         *drivep = fd_types[FD1440];
-    else if (device == 0x10)
+    else if ((device == 0x10) || (device == 0x70))
         *drivep = fd_types[FD720];
-    else if (device == 0x90)
-        *drivep = fd_types[FD1232];
+    else if ((device == 0x90)||(device == 0xf0)){
+        BD_AX = 0x5a00|device|(bios_drive_map[target + DRIVE_FD0] & 0x0F);
+        call_bios(&bdt);
+        if((BD_CX & 0x300)==0x300)
+         *drivep = fd_types[FD1232];
+        else
+         *drivep = fd_types[FD1200];
+     }
 }
 #endif
 
@@ -449,6 +449,12 @@ dev_t INITPROC bios_conv_bios_drive(unsigned int biosdrive)
     } else {
         for (minor = 4; minor < 8; minor++) {
             if (biosdrive == bios_drive_map[minor]) break;
+		if((biosdrive &0xf0) == 0x30) {
+//		if(((biosdrive &0xf0) == 0x30)
+//		 ||((biosdrive &0xf0) == 0x70)){
+			minor = (biosdrive & 0x3) + 4;
+			break;
+		}
         }
         if (minor >= 8) minor = 4;
     }

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -142,7 +142,7 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
          * somewhere near)
          */
 #ifdef CONFIG_ARCH_PC98
-        static unsigned char sector_probe[3] = { 8, 9, 18 };
+        static unsigned char sector_probe[4] = { 8, 9, 15, 18 };
         static unsigned char track_probe[2] = { 77, 80 };
 #else
         static unsigned char sector_probe[5] = { 8, 9, 15, 18, 36 };
@@ -233,7 +233,7 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
             if (count && read_sector(target, track_probe[count] - 1, 1)) {
                 bios_switch_device98(target, 0x10, drivep);  /* 720 KB */
                 if (read_sector(target, track_probe[count] - 1, 1))
-                    bios_switch_device98(target, 0x90, drivep);  /* 1.232 MB */
+                    bios_switch_device98(target, 0x90, drivep);  /* 1.200 MB or 1.232 MB */
                 else
                     pc98_720KB = 1;
             }
@@ -262,10 +262,10 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
         count = 0;
 #ifdef CONFIG_ARCH_PC98
         do {
-            if (count == 2)
+            if (count == 3)
                 bios_switch_device98(target, 0x30, drivep);  /* 1.44 MB */
             /* skip reading first entry */
-            if ((count == 2) && read_sector(target, 0, sector_probe[count])) {
+            if ((count == 3) && read_sector(target, 0, sector_probe[count])) {
                 if (pc98_720KB) {
                     bios_switch_device98(target, 0x10, drivep);  /* 720 KB */
                     /* Read BPB to find 8 sectors, 640KB format. Currently, it is not supported */
@@ -274,7 +274,7 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
                         bios_switch_device98(target, 0x90, drivep);
                 }
                 else
-                    bios_switch_device98(target, 0x90, drivep);  /* 1.232 MB */
+                    bios_switch_device98(target, 0x90, drivep);  /* 1.200 MB or 1.232 MB */
             }
         } while (++count < sizeof(sector_probe)/sizeof(sector_probe[0]));
 #else

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -56,7 +56,11 @@
 
 #define PER_DRIVE_INFO  1       /* =1 for per-line display of drive info at init */
 #define DEBUG_PROBE     0       /* =1 to display more floppy probing information */
+#ifdef CONFIG_ARCH_PC98
+#define FORCE_PROBE     1       /* =1 to force floppy probing */
+#else
 #define FORCE_PROBE     0       /* =1 to force floppy probing */
+#endif
 #define TRACK_SPLIT_BLK 0       /* =1 to read extra sector on track split block */
 #define SPLIT_BLK       0       /* =1 to read extra sector on single split block */
 #define FULL_TRACK      0       /* =1 to read full tracks when track caching */


### PR DESCRIPTION
Hello @ghaerr and @drachen6jp 

This PR is based on the bios.c code of @drachen6jp that I have cherry-picked to mount FD1200 on PC-98.

I have reverted ifdefs and some modifications that are not related to FD1200, 512Byte/sector, device address 90 feature,
since we are in the release phase of elks 0.9 and
I think it is better to postpone heavy modifications until the release.
(I might have reasons for the ifdefs. One of those are to indicate the kernel(boot) is compiled for 1232K or 1440K on the boot messages.)

I have added FORCE_PROBE = 1 in the bioshd.c and some minor changes,
since I have found bios_switch_device98 with the probe always needed when FD1232 <-> FD1200.

I have confirmed on the NP2.
<img width="644" height="478" alt="image" src="https://github.com/user-attachments/assets/1ec6f581-2f17-4fb5-82ff-36700917193a" />

To boot from FD1200, further changes to boot_sect and Setup are needed.
I will try to separate the FD1200 feature of those from other enhancement @drachen6jp made.

Thank you! 