### PR TITLE
[boot] Add FD1200 boot for PC-98

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -434,7 +434,7 @@ dr_try:
 #if defined(CONFIG_IMG_FD1232)
 	mov $0x03,%ch    // 1024 Bytes per sector
 	inc %dl          // sector number for PC_98
-#elif defined(CONFIG_IMG_FD1440)
+#elif defined(CONFIG_IMG_FD1440) || defined(CONFIG_IMG_FD1200)
 	mov $0x02,%ch    // 512 Bytes per sector
 	inc %dl          // sector number for PC_98
 #endif


### PR DESCRIPTION
Hello @ghaerr and @drachen6jp 

Just with a single line modification, I could boot it from FD1200.

<img width="644" height="478" alt="image" src="https://github.com/user-attachments/assets/baa7b616-a6c8-4554-9f6c-5ebb8344431e" />

It is nice if we can have fd1200 image for PC-98 when ELKS 0.9 release,
since  fd1200 and hdd can have common boot code, so that it can install to the hdd just using sys without makeboot fat.bin.
(I have confirmed it)

EDIT: old PC-98 cannot use fd1440.

Thank you.
