### PR TITLE
[cmds] Minor fixes to Paint

### DIFF
--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -138,8 +138,6 @@ void R_HighlightActiveButton(void)
 // ----------------------------------------------------
 void R_Paint(int x1, int y1, int x2, int y2) {
     int color = current_color;
-    // Draw initial point
-    R_DrawDisk(x1, y1, bushSize, color, CANVAS_WIDTH);
 
     // Bresenham's line algorithm for efficient line drawing
     int dx = abs(x2 - x1);
@@ -161,6 +159,7 @@ void R_Paint(int x1, int y1, int x2, int y2) {
             y1 += sy;
         }
     }
+    R_DrawDisk(x2, y2, bushSize, color, CANVAS_WIDTH);
 }
 
 // ----------------------------------------------------
@@ -236,8 +235,8 @@ void R_DrawRectangle(int x1, int y1, int x2, int y2)
     drawhline(xmin, xmax, ymax, color);
 
     // Left and right vertical lines
-    drawvline(xmin, ymin, ymax, color);
-    drawvline(xmax, ymin, ymax, color);
+    drawvline(xmin, ymin+1, ymax-1, color);
+    drawvline(xmax, ymin+1, ymax-1, color);
 }
 
 void R_DrawFilledRectangle(int x1, int y1, int x2, int y2)

--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -268,10 +268,11 @@ _vga_drawvline:
 
         ; prepare to draw vertical line
         mov     ax, y1[bp]      ; AX := y1
-        mov     cx, y2[bp]      ; BX := y2
+        mov     cx, y2[bp]      ; CX := y2
         sub     cx, ax          ; CX := dy
+        jc      L1112
 
-L311:   inc     cx              ; CX := number of pixels to draw
+        inc     cx              ; CX := number of pixels to draw
         mov     bx, x[bp]       ; BX := x
         push    cx              ; save register
 
@@ -311,7 +312,7 @@ L1111:  or      [bx], al        ; set pixel
         add     bx, dx          ; increment to next line
         loop    L1111
 
-        pop     ds
+L1112:  pop     ds
         pop     bp
         ret
 

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -269,10 +269,11 @@ vga_drawvline:
 
         // prepare to draw vertical line
         mov     y1(%bp), %ax    // AX := y1
-        mov     y2(%bp), %cx    // BX := y2
+        mov     y2(%bp), %cx    // CX := y2
         sub     %ax, %cx        // CX := dy
+        jc      L1112
 
-L311:   inc     %cx             // CX := number of pixels to draw
+        inc     %cx             // CX := number of pixels to draw
         mov     x(%bp), %bx     // BX := x
         push    %cx             // save register
 
@@ -312,7 +313,7 @@ L1111:  or      %al, (%bx)      // set pixel
         add     %dx, %bx        // increment to next line
         loop    L1111
 
-        pop     %ds
+L1112:  pop     %ds
         pop     %bp
         ret
 


### PR DESCRIPTION
While porting some of the Paint graphics code to [GFX](https://github.com/ghaerr/gfx), it was noticed that when drawing lines in Paint, the first point is always drawn twice and the last point never drawn. Also, the draw rectangle routine draws the corners twice. This PR fixes that, for @Vutshi's perfection!

A bug in the IA16 and C86 versions for drawvline is also fixed, when the end point is previous to the starting point.