### PR TITLE
[cmds] Build fsck-dos.os2 and paint.os2 when WATCOM environment installed

### DIFF
--- a/elkscmd/fsck_dos/.gitignore
+++ b/elkscmd/fsck_dos/.gitignore
@@ -1,1 +1,2 @@
 fsck-dos
+fsck-dos.os2

--- a/elkscmd/fsck_dos/Makefile
+++ b/elkscmd/fsck_dos/Makefile
@@ -11,6 +11,9 @@ LOCALCFLAGS += -Wno-shift-count-overflow
 ###############################################################################
 
 PRGS = fsck-dos
+ifdef WATCOM
+PRGS += fsck-dos.os2
+endif
 
 all: $(PRGS)
 
@@ -37,7 +40,8 @@ fsck-dos: main.o boot.o check.o dir.o fat.o
 
 fsck-dos.os2:
 	ewcc -Dlint=1 -DELKS=1 boot.c check.c dir.c fat.c main.c mem.c
-	ewlink -o fsck-dos.os2 boot.obj check.obj dir.obj fat.obj main.obj mem.obj
+	ewlink -o $@ boot.obj check.obj dir.obj fat.obj main.obj mem.obj
+	cp $@ $(TOPDIR)/elkscmd/rootfs_template/bin
 
 clean:
 	$(RM) *.o $(PRGS) *.obj *.os2

--- a/elkscmd/fsck_dos/Makefile
+++ b/elkscmd/fsck_dos/Makefile
@@ -45,3 +45,4 @@ fsck-dos.os2:
 
 clean:
 	$(RM) *.o $(PRGS) *.obj *.os2
+	$(RM) $(TOPDIR)/elkscmd/rootfs_template/bin/fsck-dos.os2

--- a/elkscmd/gui/.gitignore
+++ b/elkscmd/gui/.gitignore
@@ -1,6 +1,6 @@
 paint
-opaint
-cpaint
+paint.os2
+paint.c86
 *.oaj
 *.obj
 *.ocj

--- a/elkscmd/gui/Makefile
+++ b/elkscmd/gui/Makefile
@@ -23,9 +23,5 @@ c86:
 
 clean:
 	make -f Makefile.gcc clean
-ifdef WATCOM
 	make -f Makefile.owc clean
-endif
-ifdef C86
 	make -f Makefile.c86 clean
-endif

--- a/elkscmd/gui/Makefile.c86
+++ b/elkscmd/gui/Makefile.c86
@@ -49,7 +49,7 @@ DEFINES +=
 LOCALFLAGS =
 
 BINDIR = .
-PROG = $(BINDIR)/cpaint
+PROG = $(BINDIR)/paint.c86
 SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c \
     drawscanline.c
 OBJS += vga-c86.o8j
@@ -58,7 +58,7 @@ all: $(PROG)
 
 $(PROG): $(OBJS)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
-	cp $(PROG) $(TOPDIR)/elkscmd/rootfs_template/bin
+	cp $@ $(TOPDIR)/elkscmd/rootfs_template/bin
 
 clean:
 	rm -f $(PROG) *.o8j *.as *.i *.lst

--- a/elkscmd/gui/Makefile.c86
+++ b/elkscmd/gui/Makefile.c86
@@ -5,9 +5,9 @@ ifndef TOPDIR
 $(error ELKS TOPDIR is not defined)
 endif
 
-ifndef C86
-$(error C86 is not defined)
-endif
+#ifndef C86
+#$(error C86 is not defined)
+#endif
 
 CPP=cpp86
 CC=c86
@@ -61,4 +61,5 @@ $(PROG): $(OBJS)
 	cp $@ $(TOPDIR)/elkscmd/rootfs_template/bin
 
 clean:
-	rm -f $(PROG) *.o8j *.as *.i *.lst
+	$(RM) $(PROG) *.o8j *.as *.i *.lst
+	$(RM) $(TOPDIR)/elkscmd/rootfs_template/bin/$(PROG)

--- a/elkscmd/gui/Makefile.gcc
+++ b/elkscmd/gui/Makefile.gcc
@@ -49,4 +49,4 @@ vga-ia16.oaj: vga-ia16.o
 	mv vga-ia16.o vga-ia16.oaj
 
 clean:
-	rm -f $(PROG) *.oaj
+	$(RM) $(PROG) *.oaj

--- a/elkscmd/gui/Makefile.owc
+++ b/elkscmd/gui/Makefile.owc
@@ -38,7 +38,7 @@ OBJS = $(SRCS:.c=.obj)
 
 BINDIR = .
 LOCALFLAGS =
-PROG = $(BINDIR)/opaint
+PROG = $(BINDIR)/paint.os2
 SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c
 SRCS += drawscanline.c
 
@@ -46,7 +46,7 @@ all: $(PROG)
 
 $(PROG): $(OBJS)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
-	cp $(PROG) $(TOPDIR)/elkscmd/rootfs_template/bin
+	cp $@ $(TOPDIR)/elkscmd/rootfs_template/bin
 
 clean:
 	rm -f $(PROG) *.obj

--- a/elkscmd/gui/Makefile.owc
+++ b/elkscmd/gui/Makefile.owc
@@ -5,9 +5,9 @@ ifndef TOPDIR
 $(error ELKS TOPDIR is not defined)
 endif
 
-ifndef WATCOM
-$(error OpenWatcom WATCOM is not defined)
-endif
+#ifndef WATCOM
+#$(error OpenWatcom WATCOM is not defined)
+#endif
 
 CC = owcc
 LD = owcc
@@ -49,4 +49,5 @@ $(PROG): $(OBJS)
 	cp $@ $(TOPDIR)/elkscmd/rootfs_template/bin
 
 clean:
-	rm -f $(PROG) *.obj
+	$(RM) $(PROG) *.obj
+	$(RM) $(TOPDIR)/elkscmd/rootfs_template/bin/$(PROG)


### PR DESCRIPTION
This is the first step in automatically building some OpenWatcom applications already in the ELKS applications tree.

When OpenWatcom C has been configured for ELKS by executing the `libc/wcenv.sh` script, the WATCOM= environment variable is set and the OWC tools are added to PATH.

When WATCOM is defined, an enhanced FAT filesystem checker is built using OWC huge model `fsck-dos.os2`, which allows for checking FAT16 HD images without running out of memory, and an experimental `paint.os2` OWC version of Paint is built, for testing graphics using OWC. In addition, when C86 is defined from executing `c86env.sh` in 8086-toolchain, the C86 version of Paint `paint.c86` is built, testing the C86 compiler and development library by building a larger application. 

All these programs are copied directly to /bin in the target image (elkscmd/rootfs_template/bin). The next step will be integrating external Nano-X into the build process.