### PR TITLE
Make USER_FLAGS a config parameter

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -88,9 +88,6 @@ void kfork_proc(void (*addr)())
  *  Build a user return stack for exec*(). This is quite easy,
  *  especially as our syscall entry doesnt use the user stack.
  */
-
-#define USER_FLAGS 0x3200               /* IPL 3, interrupt enabled */
-
 void put_ustack(register struct task_struct *t,int off,int val)
 {
     pokew(t->t_regs.sp+off, t->t_regs.ss, (word_t) val);

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -12,6 +12,8 @@
 
 #define CONFIG_FS_DEV           1               /* support FAT /dev folder */
 
+#define USER_FLAGS 0x3200                       /* IPL 3, interrupt enabled,  used in process.c */
+
 /*
  * SETUP_ defines are initialzied by setup.S and queried only during kernel init.
  * The REL_INITSEG segment is released at end of kernel init. If used later any


### PR DESCRIPTION
USER_FLAGS is used in process.c/arch_setup_user_stack() to prepare the processor status word (PSW) for a context switch. Currently bits 15-14 are set to 0 which conflicts with the NEC V25 CPU. To make this configurable USER_FLAGS is moved to config.h

see https://github.com/ghaerr/elks/issues/2424