### PR TITLE
Change USER_FLAGS so it is compatible with NEC V25 microcontroller

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -89,7 +89,7 @@ void kfork_proc(void (*addr)())
  *  especially as our syscall entry doesnt use the user stack.
  */
 
-#define USER_FLAGS 0x3200               /* IPL 3, interrupt enabled */
+#define USER_FLAGS 0xf200               /* IPL 3, interrupt enabled */
 
 void put_ustack(register struct task_struct *t,int off,int val)
 {


### PR DESCRIPTION
USER_FLAGS is used in process.c/arch_setup_user_stack() to prepare the processor status word (PSW) for a context switch. Currently bits 15-14 are set to '0' which conflicts with the NEC V25 CPU (switches to undefined register bank on next contrext switch). As these bits are not used for other CPUs it can be set to '1'.

Refernce: https://github.com/ghaerr/elks/issues/2424