### PR TITLE
[kernel, build] Dynamically configure kernel when /bin/init not present

### DIFF
--- a/elks/arch/i86/defconfig
+++ b/elks/arch/i86/defconfig
@@ -200,7 +200,7 @@ CONFIG_APPS_1440K=y
 
 # System startup
 CONFIG_SYS_DEFSHELL_SASH=n
-CONFIG_SYS_NO_BININIT=n
+# CONFIG_SYS_NO_BININIT is not set
 
 #
 # Target image

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -43,7 +43,7 @@ int sys_utime(char *filename, register struct utimbuf *times)
  * We do this by temporarily setting fsuid/fsgid to the wanted values
  */
 
-int sys_access(char *filename, mode_t mode)
+int sys_access(const char *filename, mode_t mode)
 {
     struct inode *inode;
     uid_t old_euid;

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -361,6 +361,7 @@ extern int notify_change(struct inode *,struct iattr *);
 
 extern int sys_open(const char *,int,mode_t);
 extern int sys_close(unsigned int);     /* yes, it's really unsigned */
+extern int sys_access(const char *, mode_t);
 
 extern void _close_allfiles(void);
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -261,10 +261,8 @@ static void INITPROC do_init_task(void)
 
     mount_root();
 
-    execinit = (strcmp(init_command, bininit) == 0) && (sys_access("/bin/init", 1) == 0);
-    printk("execinit %d\n", execinit);
-
     /* when no /bin/init, force initial process group on console to make signals work*/
+    execinit = (strcmp(init_command, bininit) == 0) && (sys_access(bininit, 1) == 0);
     if (!execinit)
         current->session = current->pgrp = 1;
 

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -17,7 +17,7 @@ static void reparent_children(void)
         if (p->p_parent == current) {
             /* remove orphaned zombies, no need to reparent them to init*/
             if (p->state == TASK_ZOMBIE) {
-                printk("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
+                debug_wait("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
                 p->state = TASK_UNUSED;     /* unassign task entry*/
                 next_task_slot = p;
                 task_slots_unused++;
@@ -25,7 +25,7 @@ static void reparent_children(void)
 
             /* reparent orphans to init*/
             if (p->state != TASK_UNUSED) {
-                printk("Reparenting orphan pid %d ppid %d to init\n",
+                debug_wait("Reparenting orphan pid %d ppid %d to init\n",
                     p->pid, p->p_parent->pid);
                 p->p_parent = &task[1];
                 p->ppid = task[1].pid;

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -17,7 +17,7 @@ static void reparent_children(void)
         if (p->p_parent == current) {
             /* remove orphaned zombies, no need to reparent them to init*/
             if (p->state == TASK_ZOMBIE) {
-                debug_wait("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
+                printk("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
                 p->state = TASK_UNUSED;     /* unassign task entry*/
                 next_task_slot = p;
                 task_slots_unused++;
@@ -25,7 +25,7 @@ static void reparent_children(void)
 
             /* reparent orphans to init*/
             if (p->state != TASK_UNUSED) {
-                debug_wait("Reparenting orphan pid %d ppid %d to init\n",
+                printk("Reparenting orphan pid %d ppid %d to init\n",
                     p->pid, p->p_parent->pid);
                 p->p_parent = &task[1];
                 p->ppid = task[1].pid;

--- a/elks/tools/.gitignore
+++ b/elks/tools/.gitignore
@@ -23,3 +23,4 @@ bin/mformat
 bin/minfo
 bin/mmd
 bin/mshowfat
+bin/hd

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -19,6 +19,7 @@
 #   Tag         Description                                 Directory
 #   --------    -----------------------------------------   -----------
 #   :boot       Required for ELKS to boot
+#   :init       Used by /bin/init, installed when CONFIG_SYS_NO_BININIT not set
 #   :128k       Minimal set of apps to fit on 128k rom image
 #   :192k       Additional apps to fit on 192k rom image
 #   :360k       Minimal set of apps to fit on 360k disks
@@ -48,6 +49,7 @@
 #   :busyelks   Busyelks                                    busyelks
 #   :be-*       File created as symlink if busyelks option 'B' set
 #   ::path/file path/file to install file as on $(DESTDIR)
+#   :::file     install as symlink
 #
 # ------------- ----------------------------------------------------------
 sys_utils/init          :init   :sysutil

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -50,10 +50,10 @@
 #   ::path/file path/file to install file as on $(DESTDIR)
 #
 # ------------- ----------------------------------------------------------
-sys_utils/init          :boot   :sysutil    :128k
-#sys_utils/min_init ::bin/init :boot :sysutil :128k
-sys_utils/getty         :boot   :sysutil    :128k
-sys_utils/login         :boot   :sysutil    :128k
+sys_utils/init          :init   :sysutil
+#sys_utils/min_init ::bin/init :init :sysutil
+sys_utils/getty         :init   :sysutil
+sys_utils/login         :init   :sysutil
 sash/sash   ::bin/sh            :defsash    # install as /bin/sh
 ash/ash     ::bin/sh    :boot   :ash :nocomp # install as /bin/sh (must follow :defsash)
 sash/sash                       :sash                   :1200k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -175,6 +175,9 @@ endif
 ifdef CONFIG_SYS_DEFSHELL_SASH
 	TAGS += :defsash|
 endif
+ifndef CONFIG_SYS_NO_BININIT
+	TAGS += :init|
+endif
 
 TAGS += :end
 

--- a/elkscmd/config.in
+++ b/elkscmd/config.in
@@ -68,6 +68,6 @@ mainmenu_option next_comment
 	comment "System startup"
 
 	bool 'Use sash as default shell'		CONFIG_SYS_DEFSHELL_SASH n
-	bool 'Dont run /bin/init on startup' 	CONFIG_SYS_NO_BININIT n
+	bool 'Run /bin/sh as init'				CONFIG_SYS_NO_BININIT n
 
 endmenu

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -564,6 +564,10 @@ runcmd(char *cmd, int argc, char **argv)
 
 	endpwent();
 	endgrent();
+
+	while (waitpid(-1, &status, 0) != -1)   /* reap any spurious children */
+		continue;
+
 	/*
 	 * If a full shell is required, run 'sh -c cmd' unless we are the only shell.
 	 */

--- a/elkscmd/tui/.gitignore
+++ b/elkscmd/tui/.gitignore
@@ -7,4 +7,4 @@ sl
 ttyclock
 ttyinfo
 ttypong
-ttytetris
+tetris

--- a/image/Make.image
+++ b/image/Make.image
@@ -81,7 +81,9 @@ endif
 minixfs: template
 	rm -f $(TARGET_FILE)
 	mfs $(VERBOSE) $(TARGET_FILE) mkfs $(MINIX_MKFSOPTS)
+ifndef CONFIG_SYS_NO_BININIT
 	mfs -v $(TARGET_FILE) addfs Image.all $(DESTDIR)
+endif
 #	rm -f Filelist
 #	for f in $$(cd $(DESTDIR); find * -name '*'); do \
 #		echo $$f >> FileList; \

--- a/image/Makefile
+++ b/image/Makefile
@@ -41,6 +41,7 @@ copyrom:
 compress:
 	cd $(TOPDIR)/target/bin; elks-compress *
 
+.NOTPARALLEL: images images-minix images-fat images-hd
 images: images-minix images-hd images-fat
 
 images-minix: fd360-minix fd720-minix fd1200-minix fd1440-minix fd2880-minix


### PR DESCRIPTION
The kernel startup for task 1 was enhanced to allow for dynamically handling the case when the first task is not /bin/init. 
Previously, this required special kernel compilation using CONFIG_SYS_NO_BININIT. Now, the kernel handles this dynamically, which can occur when /bootopts uses init= or /bin/init is missing from the boot image. In addition, the meaning of CONFIG_SYS_NO_BININIT is changed when set in a config file to not copy /bin/init, /bin/getty and /bin/login, resulting in smaller systems, mostly useful for ROM systems.

Discussed in more detail in #2426. This PR also includes several enhancements originally written or conceived by @hexadec1mal in #2426. In particular, @hexadec1mal's ideas or code is used:
- Using CONFIG_SYS_NO_BININIT for controlling image contents
- Adding `:init` tag in Applications installation file
- Better language in menuconfig when CONFIG_SYS_NO_BININIT used
- Fixes in .gitignore and parallel makes

Thank you @hexadec1mal!

The previous mechanism for disabling auto-reaping of child processes on parent exit when /bin/init is not running was broken. `sash` now calls `waitpid` to remove zombie processes, which caused an out-of-tasks condition when /bin/sash was run as the init task.

Tested on PC builds and `emu86` ROM images. Should work on all other images since CONFIG_SYS_NO_BININIT is not set by default for any supported port.
