### PR TITLE
[cmds] Get busyelks compiling again

### DIFF
--- a/elkscmd/busyelks/cmd/cut.c
+++ b/elkscmd/busyelks/cmd/cut.c
@@ -151,7 +151,7 @@ get_args(void)
 void
 cut(void)
 {
-  int i, j, length, maxcol;
+  int i, j, length, maxcol = 0;
   char *columns[MAX_FIELD];
 
   while (fgets(line, BUFSIZ, fd)) {

--- a/elkscmd/busyelks/cmd/diff.c
+++ b/elkscmd/busyelks/cmd/diff.c
@@ -322,14 +322,17 @@ static void
 build_option_string(void)
 {
   switch (mode) {
-	    case ed_mode:sprintf(options_string, "-e");
-	break;
-      case context:
-	if (context_lines == 3)
-		sprintf(options_string, "-c");
-	else
-		sprintf(options_string, "-C %d", context_lines);
-	break;
+  case ed_mode:
+        sprintf(options_string, "-e");
+        break;
+  case context:
+        if (context_lines == 3)
+                sprintf(options_string, "-c");
+        else
+                sprintf(options_string, "-C %d", context_lines);
+        break;
+  case undefined:
+        break;
   }
 
 }

--- a/elkscmd/busyelks/cmd/du.c
+++ b/elkscmd/busyelks/cmd/du.c
@@ -46,9 +46,6 @@
 
 #define BLOCK_SIZE	1024
 
-static char *optarg;
-static int optind;
-
 #define	LINELEN		256
 #define	NR_ALREADY	512
 

--- a/elkscmd/busyelks/cmd/ed.c
+++ b/elkscmd/busyelks/cmd/ed.c
@@ -7,6 +7,8 @@
  */
 
 #include "../sash.h"
+#include <unistd.h>
+#include <fcntl.h>
 
 #include "cmd.h"
 
@@ -59,7 +61,7 @@ int
 ed_main(int argc, char * argv[])
 {
 	if (!initedit())
-		return;
+		return 1;
 
 	if (argc > 1) {
 		filename = strdup(argv[1]);
@@ -127,7 +129,7 @@ docommands()
 
 		cp = buf;
 		while (isblank(*cp))
-			*cp++;
+			cp++;
 
 		have1 = 0;
 		have2 = 0;
@@ -750,6 +752,7 @@ initedit()
 
 	for (i = 0; i < 26; i++)
 		marks[i] = 0;
+	return TRUE;
 }
 
 
@@ -981,7 +984,7 @@ printlines(num1, num2, expandflag)
 		 * Show control characters and characters with the
 		 * high bit set specially.
 		 */
-		cp = lp->data;
+		cp = (unsigned char *)lp->data;
 		count = lp->len;
 		if ((count > 0) && (cp[count - 1] == '\n'))
 			count--;

--- a/elkscmd/busyelks/cmd/find.c
+++ b/elkscmd/busyelks/cmd/find.c
@@ -3,6 +3,7 @@
 /* Original author: Erik Baalbergen; POSIX compliant version: Bert Laverman */
 
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
@@ -12,6 +13,7 @@
 #include <grp.h>
 #include <dirent.h>
 #include <stdio.h>
+#include <limits.h>
 #include "../defs.h"
 
 #include "cmd.h"

--- a/elkscmd/busyelks/config.mk
+++ b/elkscmd/busyelks/config.mk
@@ -1,11 +1,11 @@
 CFLAGS	+= -DCMD_INFO_ARGS
 CFLAGS	+= -DCMD_INFO_DESCR
 
-ifeq "$(CONFIG_APP_DISK_UTILS)" "b"
+#ifeq "$(CONFIG_APP_DISK_UTILS)" "b"
 	CMD_fdisk	= yes
-endif
+#endif
 
-ifeq "$(CONFIG_APP_FILE_UTILS)" "b"
+#ifeq "$(CONFIG_APP_FILE_UTILS)" "b"
 	CMD_cat		= yes
 	CMD_chgrp	= yes
 	CMD_chmod	= yes
@@ -13,29 +13,29 @@ ifeq "$(CONFIG_APP_FILE_UTILS)" "b"
 	CMD_cmp		= yes
 	CMD_cp		= yes
 	CMD_dd		= yes
-endif
+#endif
 
-ifeq "$(CONFIG_APP_MINIX1)" "b"
+#ifeq "$(CONFIG_APP_MINIX1)" "b"
 	CMD_cksum	= yes
 	CMD_cut		= yes
 	CMD_du		= yes
-endif
+#endif
 
-ifeq "$(CONFIG_APP_MINIX3)" "b"
+#ifeq "$(CONFIG_APP_MINIX3)" "b"
 	CMD_cal		= yes
 	CMD_diff	= yes
 	CMD_find	= yes
-endif
+#endif
 
-ifeq "$(CONFIG_APP_MISC_UTILS)" "b"
+#ifeq "$(CONFIG_APP_MISC_UTILS)" "b"
 	CMD_ed		= yes
-endif
+#endif
 
-ifeq "$(CONFIG_APP_SH_UTILS)" "b"
+#ifeq "$(CONFIG_APP_SH_UTILS)" "b"
 	CMD_basename= yes
 	CMD_date	= yes
 	CMD_dirname	= yes
 	CMD_echo	= yes
 	CMD_false	= yes
 	CMD_true	= yes
-endif
+#endif

--- a/elkscmd/busyelks/lib/buildname.c
+++ b/elkscmd/busyelks/lib/buildname.c
@@ -13,6 +13,7 @@
 #include <dirent.h>
 #include <time.h>
 #include <utime.h>
+#include <limits.h>
 
 /*
  * Build a path name from the specified directory name and file name.


### PR DESCRIPTION
The BusyELKS "BusyBox"-like clone had bit-rotted for so long it wouldn't even compile. This is because its compilation was set by default to use the CONFIG_APP_xxx defines to set which modules to compile in. Since these are no longer set in any default configuration, it appears it may have been years since this program was compiled or used.

It appears almost all of the "commands" within BusyELKS actually come from sash, except that the sash source code has been bugfixed over the years whereas BusyELKS is completely unmaintained. There isn't much use in using BusyELKS on any system anymore, since sash can do everything it can, also works as a standalone shell, and is actually smaller, since loads of ASCII usage messages aren't included. Also, BusyELKS is hard to use without a filesystem that supports symbolic or hard-links, which means it isn't useful on FAT filesystems used on many CF cards.

Thus I propose that BusyELKS be removed after release v0.9.0. This will also allow considerable cleanup in the elkscmd/Make.install script, which @hexadec1mal did in #2426, but has been delayed.