### PR TITLE
[cmds] Enhance ibmpc BASIC to use EGA or VGA graphics mode

### DIFF
--- a/elkscmd/basic/host-ibmpc.c
+++ b/elkscmd/basic/host-ibmpc.c
@@ -72,10 +72,8 @@ void host_mode(int mode) {
 
 void host_cls() {
 
-    if (gmode) {
-        fmemsetw(0, 0xB800, 0, 4000);
-        fmemsetw(0, 0xBA00, 0, 4000);
-    }
+    if (gmode)
+        fmemsetw(0, 0xA000, 0, 19200);  /* 640*480/8 bytes VGA ram */
     else
         fprintf(outfile, "\033[H\033[2J");
 }
@@ -88,12 +86,17 @@ void host_color(int fgc, int bgc) {
     }
 }
 
+static void draw_point(int x, int y)
+{
+    int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, x, y);
+}
+
 void host_plot(int x, int y) {
 
     if (gmode) {
         y = MAX_Y - y;
 
-        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, x, y);
+        draw_point(x, y);
 
         gxyc.x = x;
         gxyc.y = y;
@@ -171,19 +174,19 @@ void host_draw(int x, int y) {
                     if (ny < y) {
                         for (ni = 0; ni < (nydiff >> 7); ni++) {
                             ny++;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nydiff &= 0x007F;
                     }
                     else if (ny > y) {
                         for (ni = 0; ni < (nydiff >> 7); ni++) {
                             ny--;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nydiff &= 0x007F;
                     }
                     else
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                 }
             }
             else if (nx > x) {
@@ -193,32 +196,32 @@ void host_draw(int x, int y) {
                     if (ny < y) {
                         for (ni = 0; ni < (nydiff >> 7); ni++) {
                             ny++;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nydiff &= 0x007F;
                     }
                     else if (ny > y) {
                         for (ni = 0; ni < (nydiff >> 7); ni++) {
                             ny--;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nydiff &= 0x007F;
                     }
                     else
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                 }
             }
             else if (nx == x) {
                 if (ny < y) {
                     while (ny < y) {
                         ny++;
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                     }
                 }
                 else if (ny > y) {
                     while (ny > y) {
                         ny--;
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                     }
                 }
             }
@@ -231,19 +234,19 @@ void host_draw(int x, int y) {
                     if (nx < x) {
                         for (ni = 0; ni < (nxdiff >> 7); ni++) {
                             nx++;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nxdiff &= 0x007F;
                     }
                     else if (nx > x) {
                         for (ni = 0; ni < (nxdiff >> 7); ni++) {
                             nx--;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nxdiff &= 0x007F;
                     }
                     else
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                 }
             }
             else if (ny > y) {
@@ -253,37 +256,37 @@ void host_draw(int x, int y) {
                     if (nx < x) {
                         for (ni = 0; ni < (nxdiff >> 7); ni++) {
                             nx++;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nxdiff &= 0x007F;
                     }
                     else if (nx > x) {
                         for (ni = 0; ni < (nxdiff >> 7); ni++) {
                             nx--;
-                            int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                            draw_point(nx, ny);
                         }
                         nxdiff &= 0x007F;
                     }
                     else
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                 }
             }
             else if (ny == y) {
                 if (nx < x) {
                     while (nx < x) {
                         nx++;
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                     }
                 }
                 else if (nx > x) {
                     while (nx > x) {
                         nx--;
-                        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, nx, ny);
+                        draw_point(nx, ny);
                     }
                 }
             }
         }
-        int_10((0x0C00 | (0xFF & gxyc.fgc)), 0, x, y);
+        draw_point(nx, ny);
 
         gxyc.x = x;
         gxyc.y = y;

--- a/elkscmd/basic/host-ibmpc.c
+++ b/elkscmd/basic/host-ibmpc.c
@@ -1,5 +1,5 @@
 /*
- * Architecture Specific routines for CGA
+ * Architecture Specific routines for IBM PC BASIC with EGA/VGA graphics support
  * Sep 2024 Takahiro Yamada
  */
 #include <stdio.h>
@@ -8,7 +8,7 @@
 #include "host.h"
 #include "basic.h"
 
-/* supported graphics modes in host_mode() */
+/* supported graphics modes */
 #define VGA_640x350x16      0x10        /* 640x350 16 color/4bpp */
 #define VGA_640x480x16      0x12        /* 640x480 16 color/4bpp */
 #define TEXT_MODE           0x03        /* 80x25 text mode */
@@ -31,26 +31,32 @@ static struct gc gc = {0, 0, 7, 0, 1};
 void fmemsetw(void * off, unsigned int seg, unsigned int val, size_t count);
 void int_10(unsigned int ax, unsigned int bx, unsigned int cx, unsigned int dx);
 
-void host_digitalWrite(int pin,int state) {
+void host_digitalWrite(int pin,int state)
+{
 }
 
-int host_digitalRead(int pin) {
+int host_digitalRead(int pin)
+{
     return 0;
 }
 
-int host_analogRead(int pin) {
+int host_analogRead(int pin)
+{
     return 0;
 }
 
-void host_pinMode(int pin,int mode) {
+void host_pinMode(int pin,int mode)
+{
 }
 
-static void mode_reset() {
+static void mode_reset(void)
+{
     if (gmode)
         int_10(TEXT_MODE, 0, 0, 0);
 }
 
-void host_mode(int mode) {
+void host_mode(int mode)
+{
     gmode = mode;
 
     if (gmode && !exit_on) {
@@ -71,14 +77,16 @@ void host_mode(int mode) {
         int_10(TEXT_MODE, 0, 0, 0);
 }
 
-void host_cls() {
+void host_cls(void)
+{
     if (gmode)
         fmemsetw(0, 0xA000, 0, 19200);  /* 640*480/8 bytes VGA ram */
     else
         fprintf(outfile, "\033[H\033[2J");
 }
 
-void host_color(int fg, int bg) {
+void host_color(int fg, int bg)
+{
     if (gmode) {
         gc.fg = fg;
         gc.bg = bg;
@@ -115,7 +123,8 @@ static void draw_line(int x1, int y1, int x2, int y2)
     draw_point(x2, y2);
 }
 
-void host_plot(int x, int y) {
+void host_plot(int x, int y)
+{
     if (gmode) {
         y = MAX_Y - y;
 
@@ -126,7 +135,8 @@ void host_plot(int x, int y) {
     }
 }
 
-void host_draw(int x, int y) {
+void host_draw(int x, int y)
+{
     if (gmode) {
         y = MAX_Y - y;
         draw_line(gc.x, gc.y, x, y);
@@ -136,7 +146,8 @@ void host_draw(int x, int y) {
 }
 
 //using midpoint circle algorithm
-void host_circle(int xc, int yc, int r) {
+void host_circle(int xc, int yc, int r)
+{
     int x = 0;
     int y = r;
     int d = 1 - r;
@@ -161,18 +172,22 @@ void host_circle(int xc, int yc, int r) {
     }
 }
 
-void host_outb(int port, int value) {
+void host_outb(int port, int value)
+{
     outb(value, port);
 }
 
-void host_outw(int port, int value) {
+void host_outw(int port, int value)
+{
     outw(value, port);
 }
 
-int host_inpb(int port) {
+int host_inpb(int port)
+{
     return inb(port);
 }
 
-int host_inpw(int port) {
+int host_inpw(int port)
+{
     return inw(port);
 }


### PR DESCRIPTION
Enhances IBM PC version of ELKS `basic` to use 16-color EGA 640x350 graphics (when EGAMODE environment variable set), otherwise use VGA 640x480. This allows programs such as elkscmd/basic/test98.bas (originally written for PC-98) to also run on IBM PC BASIC.

The 16 colors are still not compatible between IBM PC and PC98, see screenshots below.

Also replaces host_plot() function with the much smaller draw_line() routine from ELKS Paint, which reduces the size of `basic` by 1K bytes on disk.

IBM PC `basic test98.bas`:
<img width="752" height="620" alt="IBMPC basic" src="https://github.com/user-attachments/assets/5e26a07d-7258-46cd-916f-7eec78d78a84" />

PC-98 `basic test98.bas`:
<img width="752" height="540" alt="PC98 basic" src="https://github.com/user-attachments/assets/67cb9262-1beb-4c0e-b6b0-68aa34fa63c4" />

Note that the PC-98 allows ASCII text to display in graphics mode (see "BASIC" and "260-STOP" in above screenshot), while the IBM PC EGA/VGA does not. There isn't much that can be done about this. Typing ^D to exit basic, or "mode 0" to exit graphics mode, will revert to EGA/VGA text mode.