### PR TITLE
[cmds] Remove build directory from Makefile

### DIFF
--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -45,7 +45,6 @@ IA16DIRS =       \
 	# EOL
 
 OWCDIRS =       \
-    basic       \
     fsck_dos    \
     gui         \
     # EOL


### PR DESCRIPTION
elkscmd/Makefile no longer references the build directory, since Makefile.owc does not exist in elkscmd/build. This fixes errors that were preventing the build.