### PR TITLE
[kernel] Issue BIOS disk reset only when ATA CF driver configured

### DIFF
--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -385,7 +385,9 @@ void INITPROC blk_dev_init(void)
 
 #ifdef CONFIG_BLK_DEV_BHD
     if (biosdisk) {
+#ifdef CONFIG_BLK_DEV_ATA_CF
         bios_disk_reset(bios_drive_map[0]); /* required for copy.sh/v86 with ATA CF */
+#endif
         init_partitions(biosdisk);
     }
 #endif


### PR DESCRIPTION
Discussed in https://github.com/ghaerr/elks/issues/2398#issuecomment-3506754501 as likely problem for new BIOS retry errors on PC-98 system.

Should fix original PR #2411 by only resetting BIOS using bios_drive_map[] when **both** ATA CF driver and BIOS HD driver present. While still not optimal, this should fix PC98 issue with BIOS retries since ATA CF driver is not present on PC98.

It appears the original fix #2411 may not work on all systems, more testing on real hardware system may be required.