### PR TITLE
[kernel] Limit accessible SD card size to 2GB in SSD driver

### DIFF
--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -70,6 +70,10 @@ static int ssd_open(struct inode *inode, struct file *filp)
 #endif
     ++access_count;
     inode->i_size = ssd_num_sects << 9;
+    /* limit inode size to 2GB for num_sects >= 4MB (2^22) */
+    if (ssd_num_sects >= 0x00400000L)   /* 2^22*/
+        inode->i_size = 0x7ffffffL;     /* 2^31 - 1*/
+
     return 0;
 }
 


### PR DESCRIPTION
Identified on NEC V25 port in #2445.