### PR TITLE
[kernel] Fix broken NE2K driver broken from #2355

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -272,12 +272,12 @@ dma_read:
 	push    %di
 	push    %es
 	push	%bx
+	pushfw		// save interrupt state
 	push	%ax
 
 	inc     %cx     // make byte count even
 	and     $0xfffe,%cx
 
-	pushfw		// save interrupt state
 	cli		// Experimental - disable INTR
 	call    dma_init
 


### PR DESCRIPTION
Fixes the ELKS NE2K driver which was broken since #2355. Discussed in #2441, and is definitely the problem there, on both real hardware and QEMU.

PR #2355 ensured that interrupts remain off throughout kernel startup. A change was added to ne2k-asm.S to save the current interrupt state on the stack, rather than forcing cli/sti, which is improper. The problem is that I did not notice a subsequent POP AX within the ASM driver code, which then trashed the registers, thus causing the dma_read routine to always fail:
```
        pushfw          // save interrupt state <--- new proper position
        push    %ax

        inc     %cx     // make byte count even
        and     $0xfffe,%cx
//      pushfw          // save interrupt state <--- used to be here
        cli             // Experimental - disable INTR
        call    dma_init

        mov     %ds,%bx
        mov     %bx,%es
        pop     %ax  // I didn't notice this!!
```
