### PR TITLE
[kernel] Correct potential timing errors by using atomic jiffies access

### DIFF
--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -54,6 +54,7 @@
 #include <linuxmt/debug.h>
 #include <linuxmt/prectimer.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 
 /* hardware controller access modes, override using xtide= in /bootopts */
 #define MODE_ATA        0       /* standard - ATA at ports 0x1F0/0x3F6 */
@@ -133,9 +134,9 @@ static void ATPROC OUTB(unsigned int byte, int reg)
 /* delay 10ms */
 static void ATPROC delay_10ms(void)
 {
-    unsigned long timeout = jiffies + 1 + 1;    /* guarantee at least 10ms interval */
+    jiff_t timeout = jiffies() + 1 + 1; /* guarantee at least 10ms interval */
 
-    while (!time_after(jiffies, timeout))
+    while (!time_after(jiffies(), timeout))
         continue;
 }
 
@@ -144,7 +145,7 @@ static void ATPROC delay_10ms(void)
  */
 static int ATPROC ata_wait(unsigned int ticks)
 {
-    unsigned long timeout = jiffies + ticks + 1;
+    jiff_t timeout = jiffies() + ticks + 1;
     unsigned char status;
 
     do
@@ -156,7 +157,7 @@ static int ATPROC ata_wait(unsigned int ticks)
         if ((status & ATA_STATUS_BSY) == 0)
             return 0;
 
-    } while (!time_after(jiffies, timeout));
+    } while (!time_after(jiffies(), timeout));
 
     return -ENXIO;
 }

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -348,7 +348,7 @@ static void DFPROC floppy_select(unsigned int nr)
 
     /* Some FDCs require a delay when changing the current drive */
     del_timer(&select);
-    select.tl_expires = jiffies + 2;
+    select.tl_expires = jiffies() + 2;
     add_timer(&select);
 }
 
@@ -407,7 +407,7 @@ static void DFPROC floppy_on(int nr)
     if (!(mask & current_DOR)) {        /* motor not running yet */
         del_timer(&motor_on_timer[nr]);
         /* TEAC 1.44M says 'waiting time' 505ms, may be too little for 5.25in drives. */
-        motor_on_timer[nr].tl_expires = jiffies +
+        motor_on_timer[nr].tl_expires = jiffies() +
             ((running_qemu && !MOTORDELAY)? 0: TIMEOUT_MOTOR_ON);
         add_timer(&motor_on_timer[nr]);
 
@@ -428,7 +428,7 @@ static void DFPROC floppy_on(int nr)
 static void floppy_off(int nr)
 {
     del_timer(&motor_off_timer[nr]);
-    motor_off_timer[nr].tl_expires = jiffies + TIMEOUT_MOTOR_OFF;
+    motor_off_timer[nr].tl_expires = jiffies() + TIMEOUT_MOTOR_OFF;
     add_timer(&motor_off_timer[nr]);
     DEBUG("flpOFF-\n");
 }
@@ -771,7 +771,7 @@ static void DFPROC setup_rw_floppy(void)
             ms += 10 + numsectors;    /* 1440k @300rpm = 100ms + ~10ms/sector + 4ms/tr */
         else
             ms += 8 + (numsectors<<1); /* 360k @360rpm = 83ms + ~20ms/sector + 3ms/tr */
-        unsigned long timeout = jiffies + ms*HZ/100;
+        jiff_t timeout = jiffies + ms*HZ/100;
         while (!time_after(jiffies, timeout)) continue;
     }
 #endif
@@ -1250,7 +1250,7 @@ static void DFPROC redo_fd_request(void)
 
     /* restart timer for hung operations, 6 secs probably too long ... */
     del_timer(&fd_timeout);
-    fd_timeout.tl_expires = jiffies + TIMEOUT_CMD_COMPL;
+    fd_timeout.tl_expires = jiffies() + TIMEOUT_CMD_COMPL;
     add_timer(&fd_timeout);
 
     if (seek_track != current_track)

--- a/elks/arch/i86/drivers/block/idequery.c
+++ b/elks/arch/i86/drivers/block/idequery.c
@@ -69,7 +69,7 @@ int INITPROC get_ide_data(int drive, struct drive_infot *drivep) {
 	if (!ide_buffer) return -1;
 
 	while (1) {
-	    unsigned long timeout = jiffies + WAIT_READY;
+	    jiff_t timeout = jiffies + WAIT_READY;
 	    out_hd(drive, IDE_DRIVE_ID);
 	    while ((STATUS(port) & 0x80) == 0x80) {     /* wait 300ms until not busy */
 		if (time_after(jiffies, timeout))

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -16,8 +16,8 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/types.h>
 #include <linuxmt/debug.h>
-
 #include <arch/io.h>
+#include <arch/irq.h>
 
 struct lp_info {
     unsigned short io;
@@ -83,7 +83,7 @@ lp_char_polled(unsigned char c, struct lp_info *lpp)
 static size_t
 lp_write(struct inode *inode, struct file *file, char *buf, size_t count)
 {
-    jiff_t timeout = jiffies + LP_TIME_WAIT;
+    jiff_t timeout = jiffies() + LP_TIME_WAIT;
     unsigned short target;
     struct lp_info *lpp;
     size_t retval;
@@ -112,7 +112,7 @@ lp_write(struct inode *inode, struct file *file, char *buf, size_t count)
             } else if (!(status & LP_PERRORP)) {
                 printk("lp%d printer error\n", target);
                 retval = -EFAULT;
-            } else if (timeout >= jiffies) {
+            } else if (timeout >= jiffies()) {
                 debug_lp("lp%d: timeout %d<%d\n", target, chrsp, count);
                 retval = 0;
             } else {

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -96,7 +96,7 @@ static int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg
 
     switch (cmd) {
     case MEM_GETTASK:
-        retword = (unsigned short)task;
+        retword = (unsigned)task;
         break;
     case MEM_GETMAXTASKS:
         retword = max_tasks;
@@ -115,17 +115,17 @@ static int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg
         memcpy_tofs(arg, &mu, sizeof(struct mem_usage));
         return 0;
     case MEM_GETHEAP:
-        retword = (unsigned short) &_heap_all;
+        retword = (unsigned)&_heap_all;
         break;
     case MEM_GETJIFFADDR:
-        retword = (unsigned short) &jiffies;
+        retword = (unsigned)&jiffies;
         break;
     case MEM_GETSEGALL:
-        retword = (unsigned short) &_seg_all;
+        retword = (unsigned)&_seg_all;
         break;
     case MEM_GETUPTIME:
 #ifdef CONFIG_CPU_USAGE
-        retword = (unsigned short) &uptime;
+        retword = (unsigned)&uptime;
         break;
 #endif
         /* fall thru */

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -321,7 +321,7 @@ size_t tty_read(struct inode *inode, struct file *file, char *data, size_t len)
     int ch, k;
 
     while (i < len) {
-        timeout = jiffies + vtime * (HZ / 10);
+        timeout = jiffies() + vtime * (HZ / 10);
 again:
         if (tty->ops->read) {
             tty->ops->read(tty);
@@ -338,7 +338,7 @@ again:
                 if (current->signal)
                     return -EINTR;
                 if (!icanon && vtime) {
-                    if (jiffies < timeout) {
+                    if (jiffies() < timeout) {
                         schedule();
                         goto again;             /* don't reset timer*/
                     } else {

--- a/elks/arch/i86/drivers/char/serial-pc98.c
+++ b/elks/arch/i86/drivers/char/serial-pc98.c
@@ -100,7 +100,7 @@ static int rs_write(struct tty *tty)
     int i = 0;
 
     while (tty->outq.len > 0) {
-	jiff_t timeout = jiffies() + 4*HZ/100   /* 40ms, 300 baud needs 33.3ms */
+	jiff_t timeout = jiffies() + 4*HZ/100;  /* 40ms, 300 baud needs 33.3ms */
 	/* Wait until transmitter hold buffer empty */
 	while (!(inb(port->io + UART_LSR) & UART_LSR_THRE)) {
 	    if (time_after(jiffies(), timeout)) /* waits 40ms max */

--- a/elks/arch/i86/drivers/char/serial-pc98.c
+++ b/elks/arch/i86/drivers/char/serial-pc98.c
@@ -100,10 +100,10 @@ static int rs_write(struct tty *tty)
     int i = 0;
 
     while (tty->outq.len > 0) {
-	unsigned long timeout = jiffies + 4*HZ/100; /* 40ms, 300 baud needs 33.3ms */
+	jiff_t timeout = jiffies() + 4*HZ/100   /* 40ms, 300 baud needs 33.3ms */
 	/* Wait until transmitter hold buffer empty */
 	while (!(inb(port->io + UART_LSR) & UART_LSR_THRE)) {
-	    if (time_after(jiffies, timeout)) /* waits 40ms max, jiffies updated by hw timer */
+	    if (time_after(jiffies(), timeout)) /* waits 40ms max */
 	        break;
 	}
 	outb((char)tty_outproc(tty), port->io + UART_TX);
@@ -220,10 +220,10 @@ static int rs_open(struct tty *tty)
 void rs_conout(dev_t dev, int c)
 {
     struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
-    unsigned long timeout = jiffies + 4*HZ/100; /* 40ms, 300 baud needs 33.3ms */
+    jiff_t timeout = jiffies() + 4*HZ/100;  /* 40ms, 300 baud needs 33.3ms */
 
     while (!(inb(sp->io + UART_LSR) & UART_LSR_THRE)) {
-	if (time_after(jiffies, timeout)) /* waits 40ms max, jiffies updated by hw timer */
+	if (time_after(jiffies(), timeout))
 	    break;
     }
     outb(c, sp->io + UART_TX);

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -17,7 +17,7 @@
  *        frequency. Christian Mardm"oller (chm@kdt.de)
  */
 
-volatile jiff_t jiffies = 0;
+volatile jiff_t jiffies;
 static int spin_on;
 
 extern void rs_pump(void);

--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -130,12 +130,12 @@ unsigned long get_ptime(void)
 void test_ptime_idle_loop(void)
 {
     static int v;
-    unsigned long timeout = jiffies + v;
+    jiff_t timeout = jiffies() + v;
     unsigned long pticks = get_ptime();
     printk("%lu %u = %lk\n", pticks, (unsigned)lastjiffies, pticks);
     if (++v > 5) v = 0;
     /* idle_halt() must be commented out to vary timings */
-    while (jiffies < timeout)
+    while (jiffies() < timeout)
         ;
 }
 #endif

--- a/elks/fs/select.c
+++ b/elks/fs/select.c
@@ -25,6 +25,7 @@
 
 #include <arch/segment.h>
 #include <arch/system.h>
+#include <arch/irq.h>
 
 #define ROUND_UP(x,y) (((x)+(y)-1)/(y))
 
@@ -212,7 +213,7 @@ int sys_select(int n, fd_set * inp, fd_set * outp, fd_set * exp,
 
         timeout = ROUND_UP(get_user_long(&tvp->tv_usec), (1000000 / HZ));
         timeout += get_user_long(&tvp->tv_sec) * (jiff_t) HZ;
-        if (timeout) timeout += jiffies + 1UL;
+        if (timeout) timeout += jiffies() + 1;
     }
     zero_fd_set(&res_in);
     zero_fd_set(&res_out);

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -78,6 +78,22 @@ void idle_halt(void);
             :"memory")
 #endif
 
+/* atomic access of 32-bit volatile jiffies */
+#define jiffies()                           \
+    __extension__ ({                        \
+        unsigned long v;                    \
+        asm volatile ("pushfw\n"            \
+                      "cli\n"               \
+                        : /* no input */    \
+                        : /* no output */   \
+                        : "memory");        \
+        v = jiffies;                        \
+        asm volatile ("popfw\n"             \
+                        : /* no input */    \
+                        : /* no output */   \
+                        : "memory");        \
+        v; })
+
 #ifdef CONFIG_ARCH_SWAN
 /* acknowledge interrupt */
 #define ack_irq(i)              \

--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -7,6 +7,7 @@
 #include <linuxmt/debug.h>
 #include <arch/segment.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 /*
  * Alarm system call
  *
@@ -52,7 +53,7 @@ static int setalarm(unsigned long jiffs)
             return 0;
         }
         del_timer(ap);
-        ap->tl_expires = jiffies + jiffs;
+        ap->tl_expires = jiffies() + jiffs;
         ap->tl_function = alarm_callback;
         ap->tl_data = (int)current; /* must delete timer on process exit*/
         add_timer(ap);

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -33,7 +33,7 @@
 
 #include <arch/system.h>
 #include <arch/segment.h>
-
+#include <arch/irq.h>
 
 /* this is the structure holding the base time (in UTC, of course) */
 struct timeval xtime;
@@ -53,7 +53,7 @@ void INITPROC tz_init(const char *tzstr)
 
 time_t current_time(void)
 {
-    return (xtime.tv_sec + (jiffies - xtime_jiffies)/HZ);
+    return (xtime.tv_sec + (jiffies() - xtime_jiffies)/HZ);
 }
 
 /* set the time of day */
@@ -90,7 +90,7 @@ int sys_settimeofday(register struct timeval *tv, struct timezone *tz)
      * current jiffies for later use as offset - ghaerr.
      */
     if (tv != NULL) {
-        xtime_jiffies = jiffies;
+        xtime_jiffies = jiffies();
         xtime.tv_sec = tmp_tv.tv_sec;
         xtime.tv_usec = tmp_tv.tv_usec;
     }
@@ -107,7 +107,7 @@ int sys_gettimeofday(register struct timeval *tv, struct timezone *tz)
 
     /* load the current time into the structures passed */
     if (tv != NULL) {
-        now = jiffies;
+        now = jiffies();
         tmp_tv.tv_sec = xtime.tv_sec + (now - xtime_jiffies) / HZ;
         tmp_tv.tv_usec = xtime.tv_usec + ((now - xtime_jiffies) % HZ) * (1000000L / HZ);
         if (tmp_tv.tv_usec >= 10000000L)

--- a/libc/debug/prectimer.c
+++ b/libc/debug/prectimer.c
@@ -130,12 +130,12 @@ unsigned long get_ptime(void)
 void test_ptime_idle_loop(void)
 {
     static int v;
-    unsigned long timeout = jiffies + v;
+    jiff_t timeout = jiffies() + v;
     unsigned long pticks = get_ptime();
     printk("%lu %u = %lk\n", pticks, (unsigned)lastjiffies, pticks);
     if (++v > 5) v = 0;
     /* idle_halt() must be commented out to vary timings */
-    while (jiffies < timeout)
+    while (jiffies() < timeout)
         ;
 }
 #endif


### PR DESCRIPTION
Corrects potential incorrect system behavior by disabling interrupts around 32-bit kernel jiffies variable access. Overhead is three  instructions per access and interrupts are disabled for only two instructions. 

Discussed in #2456 and https://github.com/Mellvik/TLVC/pull/189#issuecomment-3523171604.

Corrects all potential errors in system operation identified in #2456 except KBD polling and SCAN KBD. These latter two were left out due to the increased potential for high speed serial input data loss and lack of actual data corruption potential.

Introduces `jiffies()` macro which disables interrupts around accessing `jiffies`, then restores previous interrupt status.

Any 32-bit volatile global variable could suffer from the same problem if that variable's value is changed by an interrupt routine. Kernel source code was searched and no other variables found problematic.