### PR TITLE
[kernel] Move CONFIG_FAST_IRQ4 to config.h

### DIFF
--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -8,7 +8,6 @@
 // 25 June 2020 Greg Haerr
 //
 #include <linuxmt/config.h>
-#include <arch/ports.h>
 	.code16
 	.text
 
@@ -41,7 +40,7 @@ _irq_com1:
 	pop	%cx
 	pop	%bx
 	pop	%ax
-	add	$4,%sp		// skip the trampoline DS:*irq
+	add	$4,%sp			// skip the trampoline DS:*irq
 	iret
 #endif
 
@@ -74,6 +73,6 @@ _irq_com2:
 	pop	%cx
 	pop	%bx
 	pop	%ax
-	add	$4,%sp		// skip the trampoline DS:*irq
+	add	$4,%sp			// skip the trampoline DS:*irq
 	iret
 #endif

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -57,11 +57,6 @@
 #define COM4_PORT       0x2e8
 #define COM4_IRQ        7               /* unregistered unless COM4_PORT found*/
 
-#ifdef CONFIG_CHAR_DEV_RS
-//#define CONFIG_FAST_IRQ4             /* COM1 very fast serial driver, no ISIG handling*/
-//#define CONFIG_FAST_IRQ3             /* COM2 very fast serial driver, no ISIG handling*/
-#endif
-
 #endif
 
 #ifdef CONFIG_ARCH_PC98

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -36,6 +36,10 @@
 #endif
 #define UTS_MACHINE             "ibmpc i8086"
 
+/* Fast serial input handler for arrow keys or fast SLIP on very slow systems */
+//#define CONFIG_FAST_IRQ4                      /* com1 */
+//#define CONFIG_FAST_IRQ3                      /* com2 */
+
 /* The following can be set for minimal systems or for QEMU emulation testing:
  * 10 buffers (@20 = 200), 2 ttyq (@80 = 160), 4k L1 cache, 512 heap free,
  * 10 tasks (@876 = 8760), 64 inodes (@80 = 5120), 64 files (@14 = 896) = ~19744.


### PR DESCRIPTION
Moves CONFIG_FAST_IRQ4 and CONFIG_FAST_IRQ3 out of ports.h into config.h.

Cleanup of various files associated with fast serial handler. 

Doesn't (yet) add TTY signal processing, as discussed in https://github.com/ghaerr/elks/issues/2457#issuecomment-3538899648. Since the fast serial handler runs on any stack and DS != SS, calling most kernel functions from the handler isn't easily possible; still working on a good solution.