### PR TITLE
[kernel] Implement signal handling within CONFIG_FAST_IRQx handlers

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -328,7 +328,7 @@ again:
             nonblock = 1;
         }
 
-        if (chq_peekch(&tty->inq))
+        if (chq_peek(&tty->inq))
             ch = chq_getch(&tty->inq);
         else {
             if (!icanon && !vtime && (i >= vmin))

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -16,6 +16,7 @@ extern int chq_wait_rd(register struct ch_queue *,int);
 extern void chq_addch(register struct ch_queue *,unsigned char);
 extern void chq_addch_nowakeup(register struct ch_queue *,unsigned char);
 extern int chq_peekch(register struct ch_queue *);
+extern int chq_peek(register struct ch_queue *);
 extern int chq_getch(register struct ch_queue *);
 /*extern int chq_full(register struct ch_queue *);*/
 

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -118,10 +118,24 @@ int chq_getch(register struct ch_queue *q)
     return retval;
 }
 
-int chq_peekch(struct ch_queue *q)
+int chq_peek(struct ch_queue *q)
 {
     return (q->len != 0);
 }
+
+#if defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3)
+int chq_peekch(struct ch_queue *q)
+{
+    int retval;
+
+    if (!q->len)
+        return 0;
+    clr_irq();
+    retval = q->base[q->tail];
+    set_irq();
+    return retval;
+}
+#endif
 
 #if UNUSED
 int chq_full(register struct ch_queue *q)


### PR DESCRIPTION
Implements TTY signal handling in fast serial drivers. Discussed in #2459. 

Will only generate SIGINT signals on ^C input, ignores VINTR stty setting. ^N-^O-^P debug displays work, as should VQUIT and VSUSP processing.

Tested fast serial driver on QEMU. High speed SLIP input not tested on real hardware. Should work well, but there's a bit more processing involved every clock interrupt and almost all of that executes with interrupts disabled, so the serial input queue fill and UART receive data overruns should be unaffected.

chq_peekch renamed chq_peek. New chq_peekch routine added.