### PR TITLE
[net] Add WD8013 NIC driver enhancements from TLVC

### DIFF
--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -4,8 +4,51 @@
  * and wd8013 (16 bit) in numerous variants, with (assumed) reliable detection
  * of 8 vs 16 bits.
  *
- * By @pawosm-arm September 2020. 16 bit support and various other enhancements by 
- * Helge Skrivervik (@mellvik) june 2022.
+ * Based on an early Linux WD driver by David Becker, 8003-port By @pawosm-arm
+ * September 2020. Rudimentary 16 bit support and various other enhancements by 
+ * Helge Skrivervik (@mellvik) june 2022. 
+ * Full 8013 (and probably 8216) support by @mellvik for TLVC March 2025
+ */
+/* 
+ * DEVELOPER NOTES - added March 2025 by @mellvik
+ *
+ * While the 8013 is basically compatible with the 8003, there are significant differences,
+ * in particular with the softconfig 8013 models (some early models have jumpers to
+ * select between jumper configuration or soft config).
+ *
+ * In particular, the soft-config units have a shadow register set containing the soft 
+ * settings. This shadow register set hides behind the upper half of the IO space used
+ * by the card, net_port+(8-15), and is enabled by setting the high bit in the
+ * (net_port+4) register. Specifically, the saved base address is at (net_port + 0xb) and
+ * the saved IRQ is at (net_port + 0xd).
+ *
+ * It appears (I'm getting this from various drivers, not from documentation) that both
+ * the 'main' and the shadow registers are actually NVRAM, or rather, they reflect the
+ * contents of the NVRAM. Both register sets, real and shadow, may be modified by first 
+ * writing to whatever reg(s) we want to change, then flip the high bit in register (net_port+1) 
+ * first on then off. That will supposedly make the changes permanent. I have not tested this.
+ *
+ * The *IMPORTANCE* of flipping these switches - the 'write NVRAM' and the 'open shadow register
+ * block' switches - back to their 'off' state, cannot be OVERSTATED. If the 'write NVRAM' switch
+ * is left on, writes (possibly accidental) to these registers may destroy the original
+ * contents and possibly leave the card unusable, if nothing else because the checksum is 
+ * now incorrect. Further, and this one hit me hard until I understood what was going on,
+ * if the 'enable shadow register set' bit in reg4 is left on, it will stay that way until
+ * power-cycled. Card reset doesn't change it back. Thus, after a reboot the driver will
+ * find garbage where the MAC address is supposed to be, the checksum is
+ * not a checksum but something else, and the card will be 'not found'.
+ *
+ * This knowledge may be used to get and change not only the MAC address (less useful), but
+ * the base address and the IRQ, most likely the shared memory address of the card, via
+ * bootopts. The current version of the driver makes no attempt to do that and it takes
+ * some code to do it because the information in NVRAM is encoded. Like, the irq must be 
+ * retreived like this:  irq = ((irqreg & 0x40) >> 4) + ((irqreg & 0x0c) >> 2)
+ * which still isn't the irq but an 'index' if you like. The driver needs an array that
+ * matches up the indexes to the actual IRQs, like irqmap[] = {0, 9, 3, 5, 7, 10, 11, 15}
+ *
+ * Maybe later. The kernel is already bursting at the seams, and /bootopts does a great
+ * job for system configuration.
+ *
  */
 
 #include <arch/io.h>
@@ -31,9 +74,9 @@
 #define net_ram		(netif_parms[ETH_WD].ram)
 #define net_flags	(netif_parms[ETH_WD].flags)
 
-#define WD_STAT_RX	0x0001U	/* packet received */
-#define WD_STAT_TX	0x0002U	/* packet sent */
-#define WD_STAT_OF	0x0010U	/* RX ring overflow */
+#define WD_STAT_RX	0x0001	/* packet received */
+#define WD_STAT_TX	0x0002	/* packet sent */
+#define WD_STAT_OF	0x0010	/* RX ring overflow */
 
 #define WD_START_PG	0x00U	/* First page of TX buffer */
 #define WD_STOP_PG4	0x10U	/* Only used for arithmetic */
@@ -41,21 +84,20 @@
 #define WD_STOP_PG16	0x40U	/* Last page + 1 of RX ring if 16bit i/f */
 #define WD_STOP_PG32	0x80U	/* Last page + 1 of RX ring if 32K buf space */
 
-#define TX_2X_PAGES	12U
-#define TX_1X_PAGES	6U
-#define TX_PAGES	TX_1X_PAGES
+#define TX_2X_PAGES	12		/* useful if 16+k buffer */
+#define TX_1X_PAGES	6
+#define TX_PAGES	TX_1X_PAGES	/* use one packet buffer for xmit */
 
 #define WD_FIRST_TX_PG	WD_START_PG
 #define WD_FIRST_RX_PG	(WD_FIRST_TX_PG + TX_PAGES)
 
 #define WD_RESET	0x80U	/* Board reset */
 #define WD_MEMENB	0x40U	/* Enable the shared memory */
-#define WD_IO_EXTENT	32U
-#define WD_8390_OFFSET	16U
+#define WD_IO_EXTENT	32
+#define WD_8390_OFFSET	16
 #define WD_8390_PORT	(net_port + WD_8390_OFFSET)
 #define WD_CMDREG5	5	/* Offset to 16-bit-only ASIC register 5. */
 
-#define	ISA16		0x80	/* Enable 16 bit access from the ISA bus. */
 #define	NIC16		0x40	/* Enable 16 bit access from the 8390. */
 
 #define E8390_RXCONFIG	0x04U	/* EN0_RXCR: broadcasts, no multicast or errors */
@@ -78,39 +120,39 @@
 #define E8390_RX_IRQ_MASK	0x05U
 
 /* Page 0 register offsets. */
-#define EN0_CLDALO	0x01U	/* Low byte of current local dma addr  RD */
-#define EN0_STARTPG	0x01U	/* Starting page of ring bfr WR */
-#define EN0_CLDAHI	0x02U	/* High byte of current local dma addr  RD */
-#define EN0_STOPPG	0x02U	/* Ending page +1 of ring bfr WR */
-#define EN0_BOUNDARY	0x03U	/* Boundary page of ring bfr RD WR */
-#define EN0_TSR		0x04U	/* Transmit status reg RD */
-#define EN0_TPSR	0x04U	/* Transmit starting page WR */
-#define EN0_NCR		0x05U	/* Number of collision reg RD */
-#define EN0_TCNTLO	0x05U	/* Low  byte of tx byte count WR */
-#define EN0_FIFO	0x06U	/* FIFO RD */
-#define EN0_TCNTHI	0x06U	/* High byte of tx byte count WR */
-#define EN0_ISR		0x07U	/* Interrupt status reg RD WR */
-#define EN0_CRDALO	0x08U	/* low byte of current remote dma address RD */
-#define EN0_RSARLO	0x08U	/* Remote start address reg 0 */
-#define EN0_CRDAHI	0x09U	/* high byte, current remote dma address RD */
-#define EN0_RSARHI	0x09U	/* Remote start address reg 1 */
-#define EN0_RCNTLO	0x0aU	/* Remote byte count reg WR */
-#define EN0_RCNTHI	0x0bU	/* Remote byte count reg WR */
-#define EN0_RSR		0x0cU	/* rx status reg RD */
-#define EN0_RXCR	0x0cU	/* RX configuration reg WR */
-#define EN0_TXCR	0x0dU	/* TX configuration reg WR */
-#define EN0_COUNTER0	0x0dU	/* Rcv alignment error counter RD */
-#define EN0_DCFG	0x0eU	/* Data configuration reg WR */
-#define EN0_COUNTER1	0x0eU	/* Rcv CRC error counter RD */
-#define EN0_IMR		0x0fU	/* Interrupt mask reg WR */
-#define EN0_COUNTER2	0x0fU	/* Rcv missed frame error counter RD */
+#define EN0_CLDALO	0x01	/* Low byte of current local dma addr  RD */
+#define EN0_STARTPG	0x01	/* Starting page of ring bfr WR */
+#define EN0_CLDAHI	0x02	/* High byte of current local dma addr  RD */
+#define EN0_STOPPG	0x02	/* Ending page +1 of ring bfr WR */
+#define EN0_BOUNDARY	0x03	/* Boundary page of ring bfr RD WR */
+#define EN0_TSR		0x04	/* Transmit status reg RD */
+#define EN0_TPSR	0x04	/* Transmit starting page WR */
+#define EN0_NCR		0x05	/* Number of collision reg RD */
+#define EN0_TCNTLO	0x05	/* Low  byte of tx byte count WR */
+#define EN0_FIFO	0x06	/* FIFO RD */
+#define EN0_TCNTHI	0x06	/* High byte of tx byte count WR */
+#define EN0_ISR		0x07	/* Interrupt status reg RD WR */
+#define EN0_CRDALO	0x08	/* low byte of current remote dma address RD */
+#define EN0_RSARLO	0x08	/* Remote start address reg 0 */
+#define EN0_CRDAHI	0x09	/* high byte, current remote dma address RD */
+#define EN0_RSARHI	0x09	/* Remote start address reg 1 */
+#define EN0_RCNTLO	0x0a	/* Remote byte count reg WR */
+#define EN0_RCNTHI	0x0b	/* Remote byte count reg WR */
+#define EN0_RSR		0x0c	/* rx status reg RD */
+#define EN0_RXCR	0x0c	/* RX configuration reg WR */
+#define EN0_TXCR	0x0d	/* TX configuration reg WR */
+#define EN0_COUNTER0	0x0d	/* Rcv alignment error counter RD */
+#define EN0_DCFG	0x0e	/* Data configuration reg WR */
+#define EN0_COUNTER1	0x0e	/* Rcv CRC error counter RD */
+#define EN0_IMR		0x0f	/* Interrupt mask reg WR */
+#define EN0_COUNTER2	0x0f	/* Rcv missed frame error counter RD */
 
 /* Page 1 register offsets. */
 #define EN1_PHYS	0x01U	/* This board's physical enet addr RD WR */
 #define EN1_CURPAG	0x07U	/* Current memory page RD WR */
 #define EN1_MULT	0x08U	/* Multicast filter mask array (8 bytes) RDWR */
 
-/* Bits in received packet status byte and EN0_RSR. */
+/* Bits in received packet status byte and EN0_RSR */
 #define ENRSR_RXOK	0x01U	/* Received a good packet */
 #define ENRSR_CRC	0x02U	/* CRC error */
 #define ENRSR_FAE	0x04U	/* frame alignment error */
@@ -120,17 +162,35 @@
 #define ENRSR_DIS	0x40U	/* receiver disable. set in monitor mode */
 #define ENRSR_DEF	0x80U	/* deferring */
 
-/* Bits in EN0_ISR - Interrupt status register. */
-#define ENISR_RX	0x01U	/* Receiver, no error */
-#define ENISR_TX	0x02U	/* Transmitter, no error */
-#define ENISR_RX_ERR	0x04U	/* Receiver, with error */
-#define ENISR_TX_ERR	0x08U	/* Transmitter, with error */
-#define ENISR_OFLOW	0x10U	/* Receiver overwrote the ring */
+/* Bits in EN0_ISR - Interrupt status register */
+#define ENISR_RX	0x01U	/* Packet received */
+#define ENISR_TX	0x02U	/* Transmit packet completed */
+#define ENISR_RX_ERR	0x04U	/* Receive error */
+#define ENISR_TX_ERR	0x08U	/* Transmit error */
+#define ENISR_OFLOW	0x10U	/* Receiver out of buffer space */
 #define ENISR_COUNTERS	0x20U	/* Counters need emptying */
-#define ENISR_RDC	0x40U	/* remote dma complete */
+#define ENISR_RDC	0x40U	/* Remote dma complete */
 #define ENISR_RESET	0x80U	/* Reset completed */
 #define ENISR_ALL	0x1fU	/* Enable these interrupts, skip RDC and stats */
 
+/*
+ * Model name codes from device register net_port+0xe:
+ * 0x03 - 8003
+ * 0x26 - 8013W
+ * 0x27 - 8013EP
+ * 0x28 - 8013WC
+ * 0x29 - 8013EPC or EWC
+ * 0x2A - 8216T
+ * 0x2B - 8216C or BT
+ * 0x2C - 8216EBP
+ * The letter suffixes seem to mean:
+ * T - Twisted Pair
+ * B - BNC
+ * C - Combo (all 3)
+ * E, P, W - ???
+ */
+
+#define DEBUG 0
 
 typedef struct {
 	unsigned char status;	/* status */
@@ -143,7 +203,7 @@ static struct wait_queue txwait;
 
 static byte_t usecount;
 static byte_t is_8bit;
-static byte_t model_name[] = "wd80x3";
+static byte_t model_name[] = "wd8013";
 static byte_t dev_name[] = "wd0";
 static byte_t stop_page; 	/* actual last pg of ring (+1) */
 static unsigned char found;
@@ -156,6 +216,7 @@ static word_t wd_rx_stat(void);
 static word_t wd_tx_stat(void);
 static void wd_int(int irq, struct pt_regs * regs);
 static void fmemcpy(void *, seg_t, void *, seg_t, size_t, int);
+static void wd_stop(void);
 
 extern struct eth eths[];
 
@@ -163,7 +224,7 @@ extern struct eth eths[];
  * Get MAC
  */
 
-static void wd_get_hw_addr(word_t * data)
+static void wd_get_hw_addr(word_t *data)
 {
 	unsigned u;
 
@@ -177,46 +238,54 @@ static void wd_get_hw_addr(word_t * data)
  */
 
 static int INITPROC wd_probe(void) {
-	int i, tmp = 0;
+	int i, type, tmp = 0;
 
+#if DEBUG
+	for (i = 0; i < 16; i++)
+		printk("%x;", type = inb(net_port+i));
+	printk("\n");
+#endif
 	for (i = 0; i < 8; i++)
 		tmp += inb(net_port + 8 + i);
-	if (inb(net_port + 8) == 0xff	/* Extra check to avoid soundcard. */
-		|| inb(net_port + 9) == 0xff
-		|| (tmp & 0xff) != 0xFF)
+	if (inb(net_port + 8) == 0xff
+		|| inb(net_port + 9) == 0xff	/* Extra check to avoid soundcard. */
+		|| (tmp & 0xff) != 0xFF)	/* checksum test */
 		return -ENODEV;	
+
+	/* config flag processing */
+	verbose = (net_flags&ETHF_VERBOSE);	/* set verbose messages */
+	if (net_flags&ETHF_8BIT_BUS)  is_8bit = 1;
+	if (net_flags&ETHF_16BIT_BUS) is_8bit = 0;
 
 	/*  device found - check what type */
 	tmp = inb(net_port+1);			/* fiddle with 16bit bit */
+
 	outb(tmp ^ 0x01, net_port+1 );		/* attempt to clear 16bit bit */
-	if (((inb(net_port+1) & 0x01) == 0x01)	/* A 16 bit card */
-				&& (tmp & 0x01) == 0x01	) {		/* In a 16 slot. */
+	if (((type = (inb(net_port+1) & 0x01)) == 0x01)	/* A 16 bit card */
+				&& (tmp & 0x01) == 0x01	/* In a 16 slot */
+				&& (is_8bit != 1)) {	/* and not forced to 8bit mode */
 		int asic_reg5 = inb(net_port+WD_CMDREG5);
 		/* Magic to set ASIC to word-wide mode. */
 		outb(NIC16 | (asic_reg5&0x1f), net_port+WD_CMDREG5);
-		outb(tmp, net_port+1);
-		model_name[4] = '1';
-		is_8bit = 0;		/* We have a 16bit board here! */
-		stop_page = WD_STOP_PG16;	// FIXME: calculate from config parameter
-						// since some interfaces have large (32k)
-						// buffer ram
-		netif_stat.oflow_keep = 3;
+		is_8bit = 0;		/* may be unset at this point, indicate 16bit */
+		netif_stat.oflow_keep = 3;	/* should be scaled by RAM size */
 	} else {
-		model_name[4] = '0';	// FIXME: Incorrect if 16bit i/f in 8bit slot */
-		is_8bit = 1;		/* board must be 8 bit */
-		if (!(net_flags & (ETHF_8BIT_BUS | ETHF_16BIT_BUS)))
-			 netif_stat.if_status |= NETIF_AUTO_8BIT;
+		if (!type) model_name[4] = '0';	
+		is_8bit = 1;	/* We're running 8bit regardless of bus and type */
 		netif_stat.oflow_keep = 1;
-		stop_page = WD_STOP_PG8;
 	}
-	/* do the config flag processing */
-	if (net_flags&ETHF_8BIT_BUS)  is_8bit = 1;
-	if (net_flags&ETHF_16BIT_BUS) is_8bit = 0;	/* overrides 8bit */
-	if (net_flags&0x07)				/* Force buffer size */
-		stop_page = WD_STOP_PG4 << (net_flags&0x03);
-	verbose = (net_flags&ETHF_VERBOSE);	/* set verbose messages */
-	//printk("net_flags %04x stop_page %02x verbose %d\n", net_flags, stop_page, verbose);
+	if ((unsigned)inb(net_port+0xe) > 0x29) {	/* update to wd8216 */
+		model_name[3] = '2';
+		model_name[5] = '6';
+	}
 	outb(tmp, net_port+1);			/* Restore original reg1 value. */
+	stop_page = WD_STOP_PG8;	/* this is always the default */
+	if (net_flags&0x07)		/* Force buffer size */
+		stop_page = WD_STOP_PG4 << (net_flags&0x03);
+#if DEBUG
+	printk("net_flags %04x stop_page %02x verbose %d\n", net_flags, stop_page, verbose);
+#endif
+	wd_stop();	/* make sure interrupts are off */
 
 	return 0;
 }
@@ -227,9 +296,17 @@ static int INITPROC wd_probe(void) {
 
 static void wd_reset(void)
 {
+	int asic_reg5 = inb(net_port+WD_CMDREG5);
+
 	outb(WD_RESET, net_port);
-	// FIXME: should wait until reset has completed, works OK on slow machines.
-	outb(((net_ram >> 9U) & 0x3fU) | WD_MEMENB, net_port);
+
+	/* Important: re-enable shared memory, set 16 bit mode if required.
+	 * Some (newer) cards will hang unless these settings are restored immediately
+	 * after reset.
+	 */
+	outb(((net_ram >> 9) & 0x3f) | WD_MEMENB, net_port);
+	if (!is_8bit)
+		outb(NIC16 | (asic_reg5&0x1f), net_port+WD_CMDREG5);
 }
 
 /*
@@ -259,8 +336,8 @@ static void wd_init_8390(int strategy)
 	outb(E8390_TXOFF, WD_8390_PORT + EN0_TXCR);
 
 	/* Clear the pending interrupts and mask. */
-	outb(0xffU, WD_8390_PORT + EN0_ISR);
-	outb(0x00U, WD_8390_PORT + EN0_IMR);
+	outb(0xff, WD_8390_PORT + EN0_ISR);
+	outb(0x00, WD_8390_PORT + EN0_IMR);
 
 	if (strategy == 0) {	/* full initialization */
 		/* Set the transmit page and receive ring. */
@@ -306,15 +383,17 @@ static void wd_init_8390(int strategy)
 
 static void wd_start(void)
 {
-	if (inb(net_port + 14U) & 0x20U) /* enable IRQ on softcfg card */
-		outb(inb(net_port + 4U) | 0x80U, net_port + 4U);
-	outb(((net_ram >> 9U) & 0x3fU) | WD_MEMENB, net_port);
+	outb(((net_ram >> 9U) & 0x3f) | WD_MEMENB, net_port);
 
 	outb(E8390_TXCONFIG, WD_8390_PORT + EN0_TXCR); /* xmit on */
 	outb(E8390_RXCONFIG, WD_8390_PORT + EN0_RXCR); /* rx on */
 
 	outb(E8390_NODMA | E8390_PAGE0 | E8390_START, WD_8390_PORT + E8390_CMD);
 	outb(ENISR_ALL, WD_8390_PORT + EN0_IMR);	/* enable interrupts */
+	if (inb(net_port + 14) & 0x20)	/* enable IRQ on 8013 and later */
+		outb(1, net_port + 6);	/* enabled by default, turned off in wd_stop()
+					 * which is important in order to release the 
+					 * IRQ line for other uses .. */
 }
 
 /*
@@ -323,20 +402,22 @@ static void wd_start(void)
 
 static void wd_stop(void)
 {
-	outb(((net_ram >> 9U) & 0x3fU) & ~WD_MEMENB, net_port);
-	outb(0, WD_8390_PORT + EN0_IMR);	/* disable interrupts */
+	outb(((net_ram >> 9) & 0x3f) & ~WD_MEMENB, net_port);	/* turn off shared mem */
+	outb(0, WD_8390_PORT + EN0_IMR);	/* mask all interrupts */
+	if (inb(net_port + 14) & 0x20)
+		outb(0, net_port + 6); 		/* turn off interrupts on 8013, 8216 */
 }
 
 /*
  * Clear overflow
  *
- *	For ELKS, when an overflow occurs, the kernel will probably just have
+ *	For TLVC/ELKS, when an overflow occurs, the kernel will probably just have
  *	received a wakeup() from a RxComplete interrupt. 
  *	If the overflow handler purges the receive buffer
  *	completely, the next read will fail - there is nothing to read. No big
  *	deal, but noisy (error messages) and inefficient since the buffer is at
- *	least 8k. So we let 1 or more packets survive the overflow recovery (as
- *	specified by the parameter to wd_init_8390() ).
+ *	least 8k. So in most cases we let 1 or more packets survive the overflow 
+ *	recovery (as specified by the parameter to wd_init_8390() ).
  */
 
 static void wd_clr_oflow(int keep)
@@ -357,7 +438,7 @@ static size_t wd_pack_get(char *data, size_t len)
 	size_t res = -EIO;
 
 	//clr_irq();	// EXPERIMENTAL
-	outb(0x00U, WD_8390_PORT + EN0_IMR);	// Block interrupts
+	outb(0x00, WD_8390_PORT + EN0_IMR);	// Block interrupts
 	do {
 		/* Remove one frame from the ring. */
 		/* Boundary is always a page behind. */
@@ -367,10 +448,10 @@ static size_t wd_pack_get(char *data, size_t len)
 		if (this_frame != current_rx_page)	/* Very useful for debugging ! */
 			printk("eth: mismatched read page pointers %2x vs %2x.\n",
 				this_frame, current_rx_page);
-		hdr_start = (this_frame - WD_START_PG) << 8U;
+		hdr_start = (this_frame - WD_START_PG) << 8;
 		rxhdr = _MK_FP(net_ram, hdr_start);
 
-		if ((rxhdr->count < 64U) ||
+		if ((rxhdr->count < 64) ||
 		    (rxhdr->count > (MAX_PACKET_ETH + sizeof(e8390_pkt_hdr)))) {
 
 			/* This should not happen! The NIC is programmed to drop
@@ -518,12 +599,12 @@ static word_t wd_rx_stat(void)
 	outb(E8390_NODMA | E8390_PAGE0, WD_8390_PORT + E8390_CMD);
 	restore_flags(flags);
 
-	return (current_rx_page == rxing_page) ? 0U : WD_STAT_RX;
+	return (current_rx_page == rxing_page) ? 0 : WD_STAT_RX;
 }
 
 static word_t wd_tx_stat(void)
 {
-	return (inb(WD_8390_PORT + E8390_CMD) & E8390_TRANS) ? 0U :
+	return (inb(WD_8390_PORT + E8390_CMD) & E8390_TRANS) ? 0 :
 		WD_STAT_TX;
 }
 
@@ -556,7 +637,7 @@ static int wd_select(struct inode * inode, struct file * filp, int sel_type)
  * I/O control
  */
 
-static int wd_ioctl(struct inode * inode, struct file * file,
+static int wd_ioctl(struct inode *inode, struct file *file,
 	unsigned int cmd, unsigned int arg)
 {
 	int err = 0;
@@ -566,7 +647,7 @@ static int wd_ioctl(struct inode * inode, struct file * file,
 		err = verified_memcpy_tofs((char *)arg, &netif_stat.mac_addr, 6U);
 		break;
 
-#if UNUSED
+#if 0 /* unused*/
 	case IOCTL_ETH_ADDR_SET:
 		err = -ENOSYS;
 		break;
@@ -597,7 +678,7 @@ static int wd_ioctl(struct inode * inode, struct file * file,
  * Device open
  */
 
-static int wd_open(struct inode * inode, struct file * file)
+static int wd_open(struct inode *inode, struct file *file)
 {
 	int err = 0;
 
@@ -613,9 +694,13 @@ static int wd_open(struct inode * inode, struct file * file)
 			printk(EMSG_IRQERR, dev_name, net_irq, err);
 			break;
 		}
+		wd_reset();
 		wd_init_8390(0);
 		wd_start();
 	} while (0);
+#if DEBUG
+	printk("wd0: open status %d\n", err);
+#endif
 	return err;
 }
 
@@ -623,11 +708,13 @@ static int wd_open(struct inode * inode, struct file * file)
  * Release (close) device
  */
 
-static void wd_release(struct inode * inode, struct file * file)
+static void wd_release(struct inode *inode, struct file *file)
 {
+#if DEBUG
+	printk("wd0: release: usecnt %d\n", usecount);
+#endif
 	if (--usecount == 0) {
 		wd_stop();
-		wd_reset();
 		free_irq(net_irq);
 	}
 }
@@ -699,7 +786,9 @@ static void wd_int(int irq, struct pt_regs * regs)
 		}
 		if (stat & (ENISR_RDC|ENISR_COUNTERS)) {  /* Remaining bits - should not happen */
 			// FIXME: Need to add handling of the statistics registers
-			printk("eth: RDC/Stat error, status 0x%x\n", stat & 0xe0);
+			// On 8216 cards, the RDC bit is set with every RX interrupt
+			// even when the RDC interrupt has been masked.
+			//printk("eth: RDC/Stat error, status 0x%x\n", stat);
 			outb(ENISR_RDC|ENISR_COUNTERS, WD_8390_PORT + EN0_ISR);
 		}
 	}
@@ -714,22 +803,26 @@ static void wd_int(int irq, struct pt_regs * regs)
 void INITPROC wd_drv_init(void)
 {
 	unsigned u;
-	word_t hw_addr[6U];
+	word_t hw_addr[6];
 	byte_t *mac_addr = (byte_t *)&netif_stat.mac_addr;
 
-	u = wd_probe();
-	printk("eth: %s at %x, irq %d, ram %04x",
+	if (!net_port) {
+		printk("eth: %s ignored\n", dev_name);
+		return;
+	}
+	printk("eth: %s at 0x%x, irq %d, ram 0x%x",
 		dev_name, net_port, net_irq, net_ram);
-	if (u) {
+	if (wd_probe()) {
 		printk(" not found\n");
 	} else {
 		found++;
 		wd_get_hw_addr(hw_addr);
 		for (u = 0; u < 6; u++) 
-			mac_addr[u] = hw_addr[u]&0xffU;
-		printk(", (%s) MAC %02X", model_name, mac_addr[0]);
-		for (u = 1U; u < 6U; u++) 
+			mac_addr[u] = hw_addr[u]&0xff;
+		printk(", (%s%s) MAC %02X", model_name, is_8bit?", 8bit":"", mac_addr[0]);
+		for (u = 1; u < 6; u++) 
 			printk(":%02X", mac_addr[u]);
+		if (verbose) printk(", type 0x%x", inb(net_port+0xe)&0xff);
 		printk(", flags 0x%x\n", net_flags);
 	}
 	eths[ETH_WD].stats = &netif_stat;


### PR DESCRIPTION
Adds TLVC's WD 8013 driver enhancements to ELKS, unchanged with the exception of CLI/STI statements. Thanks @Mellvik!

I have reviewed all changes but am unable to test. It appears most of the changes are much enhanced documentation, code cleanup, ability to force 8- or 16-bit operation, some overflow processing, and the ability to disable the driver from /bootopts.

@Mellvik, if you get a chance to pull the latest ELKS repo and test that this driver runs on one of your WD cards, that would be greatly appreciated!

The hard interrupt CLI/STI calls were updated to the newer approach of saving/restoring interrupt state. These were the only changes made.

Here's the complete diff between ELKS and TLVC now, for this driver:
```
55d54
< #include <arch/irq.h>
324d322
< 	flag_t flags;
352d349
< 		save_flags(flags);
361c358
< 		restore_flags(flags);
---
> 		set_irq();
591d587
< 	flag_t flags;
593d588
< 	save_flags(flags);
600c595
< 	restore_flags(flags);
---
> 	set_irq();
751a747
> 	//kputchar('I');
```

This is pretty cool that the ELKS can use the much-enhanced and better-maintained network drivers from TLVC! :) 