### PR TITLE
[NEC V25] Add support for DS3231 I2C Realtime Clock

### DIFF
--- a/elks/arch/i86/drivers/block/spi-hw-necv25.S
+++ b/elks/arch/i86/drivers/block/spi-hw-necv25.S
@@ -17,6 +17,11 @@
  * serial has to be serial 0
  * /SCK0 connected with /CTS0, Tx clock (out) to Rx clock (in)
  * configure baud rate by setting BR_PRSCLR to desired value
+ *
+ **************************************************************************
+ * Attention: Direction and functions of port pins have to be set in a 
+ * central position (BIOS or startup code). See definitions in necv25.h
+ **************************************************************************
  */
 
 #include <arch/necv25.h>
@@ -62,11 +67,6 @@ spi_init_ll:
     movb    $0x47, (NEC_STIC0)               // STIC0: clear Tx ready flag
     movb    $0xc0, (NEC_SCM0)                // SCM0:  synchronous mode, enable Rx/Tx, external Rx clock
 
-    clr1    PIN_CS, NEC_PMC2                 // set to IO, not special function
-    clr1    PIN_CS, NEC_PM2                  // set to output
-    set1    PIN_CS, NEC_P2                   // de-select SPI
-    set1    PIN_SCK0, NEC_PMC1               // set to special function
-    clr1    PIN_SCK0, NEC_PM1                // set to output
     set1    PIN_CS, NEC_P2                   // de-select SPI
 
     pop     %ds

--- a/elks/arch/i86/drivers/block/spi-necv25.S
+++ b/elks/arch/i86/drivers/block/spi-necv25.S
@@ -26,6 +26,7 @@
 #define PIN_MOSI 6                           /* P2.6 */
 #define PIN_MISO 7                           /* P2.7 */
 
+#define PIN_MISO_BIT (1 << PIN_MISO)
     .text
 
 // NEC V25 "set1" set bit instruction

--- a/elks/arch/i86/drivers/block/spi-necv25.S
+++ b/elks/arch/i86/drivers/block/spi-necv25.S
@@ -9,32 +9,22 @@
  * 04. Nov. 2025 swausd
  *
  * Limitations: CLK, MOSI, MISP and CS have to be on the same port.
+ **************************************************************************
+ * Attention: Direction and functions of port pins have to be set in a 
+ * central position (BIOS or startup code). See definitions in necv25.h
+ **************************************************************************
  */
 
 #include <arch/necv25.h>
 
 // port definitions
 #define PORT_LATCH      NEC_P2               /* read port input or write port output      */
-#define PORT_CONTROL    NEC_PMC2             /* controll 0=I/O or 1=special chip function */
-#define PORT_DIRECTION  NEC_PM2              /* mode of I/O pins 1=input, 1=output        */
 
 // pin definitions                           /* V25 Port pin: */
 #define PIN_CS   4                           /* P2.4 */
 #define PIN_CLK  5                           /* P2.5 */
 #define PIN_MOSI 6                           /* P2.6 */
 #define PIN_MISO 7                           /* P2.7 */
-
-#define PIN_CS_BIT (1 << PIN_CS)
-#define PIN_CS_MASK (~(PIN_CS_BIT))
-
-#define PIN_CLK_BIT (1 << PIN_CLK)
-#define PIN_CLK_MASK (~(PIN_CLK_BIT))
-
-#define PIN_MOSI_BIT (1 << PIN_MOSI)
-#define PIN_MOSI_MASK (~(PIN_MOSI_BIT))
-
-#define PIN_MISO_BIT (1 << PIN_MISO)
-#define PIN_MISO_MASK (~(PIN_MISO_BIT))
 
     .text
 
@@ -102,11 +92,6 @@ spi_init_ll:
     push    %ds
     movw    $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
     movw    %bx, %ds
-
-    andb    $(PIN_CS_MASK & PIN_CLK_MASK & PIN_MOSI_MASK), (PORT_DIRECTION)                // set to output
-    orb     $PIN_MISO_BIT, (PORT_DIRECTION)                                                // set to input
-    nop     // delay? seems to be necessary
-    andb    $(PIN_CS_MASK & PIN_CLK_MASK & PIN_MOSI_MASK & PIN_MISO_MASK), (PORT_CONTROL)  // set to IO, not special function
 
     set1    PIN_CS, PORT_LATCH
     clr1    PIN_CLK, PORT_LATCH

--- a/elks/include/arch/necv25.h
+++ b/elks/include/arch/necv25.h
@@ -61,6 +61,40 @@
 #define NEC_PM2   0xff11      /* P2M2 Direction */
 #define NEC_PMC2  0xff12      /* PMC2 Control */
 
+/************************************************************
+ * Configuration of port have to be remembert because
+ * PM and PMC registers can only be written to and
+ * only written as a whole byte (no bit set/clear).
+ *
+ * So this is the config for the current NEC V25 ELKS system
+ *
+ * Port.Pin  Name   Function Direction Used in
+ * P1.0             special  in        do not change
+ * P1.1             special  in        do not change
+ * P1.2             special  in        do not change
+ * P1.3             special  in        do not change
+ * P1.4             I/O      in
+ * P1.5             I/O      in
+ * P1.6      /SCK0  special  out       spi-hw-necv25.S
+ * P1.7             I/O      in
+ *
+ * Port.Pin  Name   Function Direction Used in
+ * P2.0      SDA    I/O      in/out    i2c-ll.S
+ * P2.1      SCL    I/O      out       i2c-ll.S
+ * P2.2             I/O      in        currently not used
+ * P2.3      CS     I/O      out       spi-hw-necv25.S
+ * P2.4      CS     I/O      out       spi-necv25.S
+ * P2.5      CLK    I/O      out       spi-necv25.S
+ * P2.6      MOSI   I/O      out       spi-necv25.S
+ * P2.7      MISO   I/O      in        spi-necv25.S
+ * *********************************************************/
+// PM1 PMC1, PM2 and PMC2 have to get initialized in BIOS
+// or startup code with these values before ELKS starts:
+#define NEC_PM1_DEF  0xbf
+#define NEC_PMC1_DEF 0x48
+#define NEC_PM2_DEF  0x84
+#define NEC_PMC2_DEF 0x00
+ 
 // Other interrupt control registers
 #define NEC_EXIC0 0xff4c      /* External interrupt 0 */
 #define NEC_EXIC1 0xff4d      /* External interrupt 1 */

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -83,8 +83,13 @@ meminfo: meminfo.o $(TINYPRINTF)
 who: who.o
 	$(LD) $(LDFLAGS) -o who who.o $(LDLIBS)
 
+ifneq ($(CONFIG_ARCH_NECV25), y)
 clock: clock.o
 	$(LD) $(LDFLAGS) -o clock clock.o $(LDLIBS)
+else
+clock: clock.o ds3231.o i2c-ll.o 
+	$(LD) $(LDFLAGS) -o clock clock.o ds3231.o i2c-ll.o $(LDLIBS)
+endif
 
 exitemu: exitemu.o
 	$(LD) $(LDFLAGS) -o exitemu exitemu.o $(LDLIBS)

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -83,13 +83,8 @@ meminfo: meminfo.o $(TINYPRINTF)
 who: who.o
 	$(LD) $(LDFLAGS) -o who who.o $(LDLIBS)
 
-ifneq ($(CONFIG_ARCH_NECV25), y)
 clock: clock.o
 	$(LD) $(LDFLAGS) -o clock clock.o $(LDLIBS)
-else
-clock: clock.o ds3231.o i2c-ll.o 
-	$(LD) $(LDFLAGS) -o clock clock.o ds3231.o i2c-ll.o $(LDLIBS)
-endif
 
 exitemu: exitemu.o
 	$(LD) $(LDFLAGS) -o exitemu exitemu.o $(LDLIBS)

--- a/elkscmd/sys_utils/clock.c
+++ b/elkscmd/sys_utils/clock.c
@@ -141,6 +141,8 @@
  * v1.7 (april 2024 hs/@mellvik TLVC): Add support for ASTCLOCK
  * (AST SixPackPlus), seemingly the common choice in pre-AT
  * systems. Supports both NS and Ricoh chips.
+ * 
+ * v1.8 (14. Nov. 2025 swausd) Adapted for NEC V25 and DS3231
  */
 
 #ifdef CONFIG_ARCH_IBMPC
@@ -190,6 +192,10 @@ void ast_settime(struct tm *);
 void ast_gettime(struct tm *);
 int  ast_chiptype(void);
 int  cmos_probe(void);
+#endif
+
+#ifdef CONFIG_ARCH_NECV25
+#include "ds3231.h"
 #endif
 
 int usage(void)
@@ -248,11 +254,6 @@ int main(int argc, char **argv)
     time_t systime;
     int    arg;
 
-#ifdef CONFIG_ARCH_NECV25
-    errmsg("Sorry, clock not supported on this system.\n");
-    exit(1);
-#endif
-
     while ((arg = getopt(argc, argv, "rwsuvA")) != -1) {
         switch (arg) {
         case 'r':
@@ -287,11 +288,16 @@ int main(int argc, char **argv)
     }
 #endif
 
+#ifdef CONFIG_ARCH_NECV25
+    ds3231_init();
+#endif
+
     if (readit + writeit + setit > 1)
         usage();                /* only allow one of these */
 
     if (!(readit | writeit | setit))    /* default to read */
         readit = 1;
+
 
     if (readit || setit) {
         do_gettime(&tm);
@@ -864,3 +870,29 @@ int cmos_probe(void)
     return 0;
 }
 #endif /* AST_SUPPORT */
+
+#ifdef CONFIG_ARCH_NECV25
+void do_gettime(struct tm *tm)
+{
+   tm->tm_sec  = bcd_hex(ds3231_read(REG_SEC));
+   tm->tm_min  = bcd_hex(ds3231_read(REG_MIN));
+   tm->tm_hour = bcd_hex(ds3231_read(REG_HOUR)  & 0x3f);
+
+   tm->tm_wday = bcd_hex(ds3231_read(REG_DAY)   & 0x07) - 1; 
+   tm->tm_mday = bcd_hex(ds3231_read(REG_DATE)  & 0x3f);
+   tm->tm_mon  = bcd_hex(ds3231_read(REG_MONTH) & 0x1f);
+   tm->tm_year = bcd_hex(ds3231_read(REG_YEAR));
+}
+
+void do_settime(struct tm *tm)
+{
+   ds3231_write(REG_SEC,   hex_bcd(tm->tm_sec));
+   ds3231_write(REG_MIN,   hex_bcd(tm->tm_min));
+   ds3231_write(REG_HOUR,  hex_bcd(tm->tm_hour));
+
+   ds3231_write(REG_DAY,   hex_bcd(tm->tm_wday + 1));
+   ds3231_write(REG_DATE,  hex_bcd(tm->tm_mday));
+   ds3231_write(REG_MONTH, hex_bcd(tm->tm_mon + 1));
+   ds3231_write(REG_YEAR,  hex_bcd(tm->tm_year));
+}
+#endif

--- a/elkscmd/sys_utils/clock.c
+++ b/elkscmd/sys_utils/clock.c
@@ -141,6 +141,8 @@
  * v1.7 (april 2024 hs/@mellvik TLVC): Add support for ASTCLOCK
  * (AST SixPackPlus), seemingly the common choice in pre-AT
  * systems. Supports both NS and Ricoh chips.
+ * 
+ * v1.8 (14. Nov. 2025 swausd) Adapted for NEC V25 and DS3231
  */
 
 #ifdef CONFIG_ARCH_IBMPC
@@ -190,6 +192,10 @@ void ast_settime(struct tm *);
 void ast_gettime(struct tm *);
 int  ast_chiptype(void);
 int  cmos_probe(void);
+#endif
+
+#ifdef CONFIG_ARCH_NECV25
+#include "ds3231.h"
 #endif
 
 int usage(void)
@@ -248,11 +254,6 @@ int main(int argc, char **argv)
     time_t systime;
     int    arg;
 
-#ifdef CONFIG_ARCH_NECV25
-    errmsg("Sorry, clock not supported on this system.\n");
-    exit(1);
-#endif
-
     while ((arg = getopt(argc, argv, "rwsuvA")) != -1) {
         switch (arg) {
         case 'r':
@@ -285,6 +286,10 @@ int main(int argc, char **argv)
             astclock = 1;
         }
     }
+#endif
+
+#ifdef CONFIG_ARCH_NECV25
+    ds3231_init();
 #endif
 
     if (readit + writeit + setit > 1)
@@ -864,3 +869,29 @@ int cmos_probe(void)
     return 0;
 }
 #endif /* AST_SUPPORT */
+
+#ifdef CONFIG_ARCH_NECV25
+void do_gettime(struct tm *tm)
+{
+   tm->tm_sec  = bcd_hex(ds3231_read(REG_SEC));
+   tm->tm_min  = bcd_hex(ds3231_read(REG_MIN));
+   tm->tm_hour = bcd_hex(ds3231_read(REG_HOUR)  & 0x3f);
+
+   tm->tm_wday = bcd_hex(ds3231_read(REG_DAY)   & 0x07) - 1; 
+   tm->tm_mday = bcd_hex(ds3231_read(REG_DATE)  & 0x3f);
+   tm->tm_mon  = bcd_hex(ds3231_read(REG_MONTH) & 0x1f);
+   tm->tm_year = bcd_hex(ds3231_read(REG_YEAR));
+}
+
+void do_settime(struct tm *tm)
+{
+   ds3231_write(REG_SEC,   hex_bcd(tm->tm_sec));
+   ds3231_write(REG_MIN,   hex_bcd(tm->tm_min));
+   ds3231_write(REG_HOUR,  hex_bcd(tm->tm_hour));
+
+   ds3231_write(REG_DAY,   hex_bcd(tm->tm_wday + 1));
+   ds3231_write(REG_DATE,  hex_bcd(tm->tm_mday));
+   ds3231_write(REG_MONTH, hex_bcd(tm->tm_mon + 1));
+   ds3231_write(REG_YEAR,  hex_bcd(tm->tm_year));
+}
+#endif

--- a/elkscmd/sys_utils/ds3231.c
+++ b/elkscmd/sys_utils/ds3231.c
@@ -1,0 +1,68 @@
+// DS3231 RTC device driver
+//
+// 14. Nov. 2025 swausd
+
+#include "ds3231.h"
+#include "i2c-ll.h"
+
+
+// Initialize the I2C bus
+void ds3231_init(void)
+{
+   i2c_init();
+
+   write_rtc(REG_CNTRL, 0x00);
+   write_rtc(REG_STAT,  0x08);
+}
+
+
+// Read from a DS3231 register
+unsigned char ds3231_read(unsigned char clock_reg)
+{
+   unsigned char val = 0;
+
+   i2c_start();
+
+   i2c_write(DS3231_WRITE);
+
+   if (i2c_ack())
+   {
+      i2c_write(clock_reg);
+
+      if (i2c_ack())
+      {
+         i2c_start();
+         i2c_write(DS3231_READ);
+
+         if (i2c_ack())
+            val = i2c_read();
+      }
+   }
+
+   i2c_nak();
+   i2c_stop();
+
+   return val;
+}
+
+
+// Write to a DS3231 register
+void ds3231_write(unsigned char clock_reg, unsigned char val)
+{
+   i2c_start();
+
+   i2c_write(DS3231_WRITE);
+
+   if (i2c_ack())
+   {
+      i2c_write(clock_reg);
+
+      if (i2c_ack())
+      {
+         i2c_write(val);
+         i2c_ack();
+      }
+   }
+
+   i2c_stop();
+}

--- a/elkscmd/sys_utils/ds3231.c
+++ b/elkscmd/sys_utils/ds3231.c
@@ -11,8 +11,8 @@ void ds3231_init(void)
 {
    i2c_init();
 
-   write_rtc(REG_CNTRL, 0x00);
-   write_rtc(REG_STAT,  0x08);
+   ds3231_write(REG_CNTRL, 0x00);
+   ds3231_write(REG_STAT,  0x08);
 }
 
 

--- a/elkscmd/sys_utils/ds3231.h
+++ b/elkscmd/sys_utils/ds3231.h
@@ -1,0 +1,26 @@
+// High level DS3231 RTC driver
+//
+// 14. Nov. 2025 swausd
+
+#pragma once
+
+/* I2C address and registers to access DS3231 */
+#define RTC_ADDRESS        0x68                           // Slave address of ds3231
+
+#define DS3231_READ        ((RTC_ADDRESS << 1) | 0x01)    // Read address for RTC
+#define DS3231_WRITE       ((RTC_ADDRESS << 1) & 0xFE)    // Write address for RTC
+
+#define REG_SEC            0x00
+#define REG_MIN            0x01
+#define REG_HOUR           0x02
+#define REG_DAY            0x03
+#define REG_DATE           0x04
+#define REG_MONTH          0x05
+#define REG_YEAR           0x06
+#define REG_CNTRL          0x0E
+#define REG_STAT           0x0F
+
+void ds3231_init(void);
+unsigned char ds3231_read(unsigned char clock_reg);
+void ds3231_write(unsigned char clock_reg, unsigned char val);
+

--- a/elkscmd/sys_utils/i2c-ll.S
+++ b/elkscmd/sys_utils/i2c-ll.S
@@ -1,0 +1,203 @@
+/**
+ * Low level I2C driver using bit-banging for DS3231 RTC
+ * Target is the NEC V25 CPU
+ *
+ * Uses special V25 opcodes set1 and clr1
+ *
+ * Note: SDA is open drain, so high output is archieved through pull up resistor
+ *       while the port pin is switched to input!
+ *       Low output is archieved through switching the port to output while data
+ *       register remains set to low
+ *
+ * 14. Nov. 2025 swausd
+ *
+ * Limitations: SDA and CLK have to be on the same port.
+ **************************************************************************
+ * Attention: Direction and functions of port pins have to be set in a 
+ * central position (BIOS or startup code). See definitions in necv25.h
+ **************************************************************************
+ */
+
+   .code16
+
+#include <arch/necv25.h>
+
+// pin definitions                           /* V25 Port pin: */
+#define PIN_SDA   0                          /* P2.7 */
+#define PIN_SCL   1                          /* P2.6 */
+
+#define PIN_SDA_BIT (1 << PIN_SDA)
+
+   .text
+
+// NEC V25 "set1" set bit instruction
+.macro set1 bit addr
+   .word    0x1c0f                           // set1 $bit,(addr)
+   .byte    0x06
+   .word    \addr
+   .byte    \bit
+.endm
+
+
+// NEC V25 "clr1" clear bit instruction
+.macro clr1 bit addr
+   .word    0x1a0f                           // clr1 $bit,(addr)
+   .byte    0x06
+   .word    \addr
+   .byte    \bit
+.endm
+
+
+.global i2c_init
+// Initialise I2C interface
+// void i2c_init(void)
+i2c_init:
+   push     %ds
+   movw     $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
+   movw     %bx, %ds
+
+   movb     $NEC_PM2_DEF, (NEC_PM2)          // set SDA to input - see note in header! -> set SDA line to high by external pullup
+   set1     PIN_SCL, NEC_P2                  // set SCL to high
+
+   pop      %ds
+   ret
+
+
+.global i2c_start
+// I2C Start condition
+// void i2c_start(void)
+i2c_start:
+   push     %ds
+   movw     $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
+   movw     %bx, %ds
+
+   clr1     PIN_SCL, NEC_P2                  // SCL to low
+   movb     $(NEC_PM2_DEF | PIN_SDA_BIT), (NEC_PM2) // release SDA, pulled up external to high
+   set1     PIN_SCL, NEC_P2                  // SCL to high
+   clr1     PIN_SDA, NEC_P2
+   movb     $NEC_PM2_DEF, (NEC_PM2)          // SDA to low
+
+   pop      %ds
+   ret
+
+
+.global i2c_stop
+// I2C Stop condition
+// void i2c_stop(void)
+i2c_stop:
+   push     %ds
+   movw     $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
+   movw     %bx, %ds
+
+   clr1     PIN_SCL, NEC_P2                  // SCL to low
+   clr1     PIN_SDA, NEC_P2
+   movb     $NEC_PM2_DEF, (NEC_PM2)          // SDA to low
+   set1     PIN_SCL, NEC_P2                  // SCL to high
+   movb     $(NEC_PM2_DEF | PIN_SDA_BIT), (NEC_PM2) // release SDA, pulled up external to high
+
+   pop      %ds
+   ret
+
+
+.global i2c_nak
+// Send I2C not acknowledgement
+// void i2c_nak(void)
+i2c_nak:
+   push     %ds
+   movw     $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
+   movw     %bx, %ds
+
+   clr1     PIN_SCL, NEC_P2                  // SCL to low
+   movb     $(NEC_PM2_DEF | PIN_SDA_BIT), (NEC_PM2) // release SDA, pulled up external to high
+   set1     PIN_SCL, NEC_P2                  // SCL to high
+
+   pop      %ds
+   ret
+
+
+.global i2c_ack
+// read I2C acknowledgement
+// unsigned char i2c_ack(void)
+// returns true if ACK
+i2c_ack:
+   push     %ds
+   movw     $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
+   movw     %bx, %ds
+
+   clr1     PIN_SCL, NEC_P2                  // SCL to low
+   movb     $(NEC_PM2_DEF | PIN_SDA_BIT), (NEC_PM2) // release SDA, pulled up external to high
+   set1     PIN_SCL, NEC_P2                  // SCL to high
+
+   xorw     %ax, %ax
+   testb    $PIN_SDA_BIT, (NEC_P2)           // SDA read
+   jnz      1f
+
+   decw     %ax
+
+1:
+   pop      %ds
+   ret
+
+
+.global i2c_read
+// Read a byte from the I2C bus
+// unsigned char i2c_read(void)
+i2c_read:
+   push     %ds
+   movw     $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
+   movw     %bx, %ds
+
+   xorw     %ax, %ax
+   movw     $8, %cx                          // set loop/bit counter
+
+1:
+   clr1     PIN_SCL, NEC_P2                  // SCL to low
+   set1     PIN_SCL, NEC_P2                  // SCL to high
+
+   sal      %al
+   testb    $PIN_SDA_BIT, (NEC_P2)           // SDA read
+   jz       2f
+
+   orb      $0x01, %al
+
+2:
+   loop     1b
+
+   pop      %ds
+   ret
+
+
+.global i2c_write
+// Write a byte to the I2C bus
+// void i2c_write(unsigned char data)
+i2c_write:
+   push     %bp
+   movw     %sp, %bp
+   push     %ds
+
+   movw     $NEC_HW_SEGMENT, %bx             // load DS to access memmory mapped CPU registers
+   movw     %bx, %ds
+
+   movw     4(%bp), %ax                      // get byte to send
+   movw     $8, %cx                          // set loop/bit counter
+
+1:
+   clr1     PIN_SCL, NEC_P2                  // SCL to low
+   testb    $0x80, %al                       // bit for bit...
+   jz       2f
+
+   movb     $(NEC_PM2_DEF | PIN_SDA_BIT), (NEC_PM2) // release SDA, pulled up external to high
+   jmp      3f
+
+2:
+   clr1     PIN_SDA, NEC_P2
+   movb     $NEC_PM2_DEF, (NEC_PM2)          // SDA to low
+
+3:
+   set1     PIN_SCL, NEC_P2                  // SCL to high
+   sal      %al
+   loop     1b
+
+   pop      %ds
+   pop      %bp
+   ret

--- a/elkscmd/sys_utils/i2c-ll.h
+++ b/elkscmd/sys_utils/i2c-ll.h
@@ -1,0 +1,13 @@
+// Low level I2C driver using bit-banging for DS3231 RTC
+//
+// 14. Nov. 2025 swausd
+
+#pragma once
+
+void i2c_init(void);
+void i2c_start(void);
+void i2c_stop(void);
+void i2c_nak(void);
+unsigned char i2c_ack(void);
+unsigned char i2c_read(void);
+void i2c_write(unsigned char data);


### PR DESCRIPTION
DS3231 RTC modules with battery backup are used in the Arduino cosmos, are cheap and readily available. To use these modules, a serial I2C bus interface is needed. This PR implements a very simple bit-banged interface for use with the DS3231. It is specific to the NEC V25 ELKS port and is only useful to setup the software clock from the DS3231 at startup.

This is no ELKS device driver - just a simple interface for use with the clock app! May be the I2C interface can be used for other devices too, but I did not test this, nor do I see a use case for now. If someone wanta to try this, the code has to be changed into a device driver to serialize access!

Added the necessary parts to sys-utils/clock app, which already has many #ifdefs. The specific DS3231 and I2C code was separated to own source files sys-utils/ds3231.c/h and sys-utils/i2c-ll.S/h. The Makefile had to be modified too, so these NEC V25 specific files are only used for the V25 build.

While working on the I2C part, I noticed a major pitfall. The configuration and direction registers of the NEC V25 parallel ports are "write-only" and can only be used with byte-access. So I had to rework my existing SPI drivers and moved the initialization of the parallel ports P1/P2 to my startup code in the ROM-monitor, from where I start ELKS. The used initialization values are now documented in necv25.h and are used to rewrite the configuration of the I2C SDA pin in i2c-ll.S This is a rather tricky work around, but I think it is ok for now.

I tested all combinations of sw/hw SPI drivers with the I2C code and it worked. I also run elks/buildimages.sh and everything looked ok to me.

Oh ... and I struggled a little bit with git again. I reverted one of the commits to change the commit note because of a typing error. Not the most elegant way to do this....