### PR TITLE
[bios] Add bios_check_sector98() and removed bios call to check sector size from bios_disk_rw for PC-98 hardware.

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -433,10 +433,10 @@ void BFPROC bios_check_sector98(int target, unsigned int device,
     BD_CX = 0;
     BD_DX = 0;
     call_bios(&bdt);
-    if((BD_CX & 0x300)==0x300)
-        *drivep = fd_types[FD1232];
-    else
+    if((BD_CX & 0x300)==0x200)
         *drivep = fd_types[FD1200];
+    else
+        *drivep = fd_types[FD1232];
 }
 #endif
 

--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -62,6 +62,22 @@ static struct biosparms bdt;
 static unsigned char DDPT[14];  /* our copy of diskette drive parameter table*/
 static unsigned long __far *vec1E = _MK_FP(0, 0x1E << 2);
 
+#ifdef CONFIG_ARCH_PC98
+/* check sector size */
+static void BFPROC bios_check_sector98(int target, unsigned int device,
+    struct drive_infot *drivep)
+{
+    BD_AX = BIOSHD_READ_ID |device|(bios_drive_map[target + DRIVE_FD0] & 0x0F);
+    BD_CX = 0;
+    BD_DX = 0;
+    call_bios(&bdt);
+    if((BD_CX & 0x300)==0x200)
+        *drivep = fd_types[FD1200];
+    else
+        *drivep = fd_types[FD1232];
+}
+#endif
+
 /* As far as I can tell this doesn't actually work, but we might
  * as well try it -- Some XT controllers are happy with it.. [AC]
  */
@@ -423,20 +439,6 @@ void BFPROC bios_switch_device98(int target, unsigned int device,
     else if (device == 0x90) {
         bios_check_sector98(target, device, drivep);
     }
-}
-
-/* check sector size */
-void BFPROC bios_check_sector98(int target, unsigned int device,
-    struct drive_infot *drivep)
-{
-    BD_AX = BIOSHD_READ_ID |device|(bios_drive_map[target + DRIVE_FD0] & 0x0F);
-    BD_CX = 0;
-    BD_DX = 0;
-    call_bios(&bdt);
-    if((BD_CX & 0x300)==0x200)
-        *drivep = fd_types[FD1200];
-    else
-        *drivep = fd_types[FD1232];
 }
 #endif
 

--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -79,7 +79,8 @@ void BFPROC bios_disk_reset(int drive)
 }
 
 int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
-        unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset)
+        unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset,
+        struct drive_infot *drivep)
 {
 #ifdef CONFIG_ARCH_PC98
     BD_AX = cmd | drive;
@@ -90,12 +91,7 @@ int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
     }
     else {
         if ((0xF0 & drive) == 0x90) {
-            BD_AX = 0x5a00|drive;
-            BD_CX = 0;
-            BD_DX = 0;
-            call_bios(&bdt);
-            BD_AX = cmd | drive;
-            if((BD_CX & 0x300)==0x200) goto notMFM1024;
+            if (drivep->sector_size == 512) goto notMFM1024;
             BD_BX = (unsigned int) (num_sectors << 10);
             BD_CX = (3 << 8) | cylinder;
         }

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -108,10 +108,11 @@ static void BFPROC set_cache_invalid(void)
 }
 
 #ifdef CONFIG_BLK_DEV_BFD
-static int BFPROC read_sector(int drive, int cylinder, int sector, struct drive_infot *drivep)
+static int BFPROC read_sector(int drive, int cylinder, int sector)
 {
     int count = 2;              /* one retry on probe or boot sector read */
 
+    struct drive_infot *drivep = &drive_info[DRIVE_FD0+drive];
 #ifdef CONFIG_ARCH_PC98
     drive = bios_drive_map[DRIVE_FD0+drive];
 #endif
@@ -156,7 +157,7 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
         /* Try to look for an ELKS or DOS parameter block in the first sector.
          * If it exists, we can obtain the disk geometry from it.
          */
-        if (!read_sector(target, 0, 1, drivep)) {
+        if (!read_sector(target, 0, 1)) {
             struct elks_disk_parms __far *parms = _MK_FP(DMASEG, drivep->sector_size -
                 2 - sizeof(struct elks_disk_parms));
 
@@ -230,9 +231,9 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
             if (count)
                 bios_switch_device98(target, 0x30, drivep);  /* 1.44 MB */
             /* skip probing first entry */
-            if (count && read_sector(target, track_probe[count] - 1, 1, drivep)) {
+            if (count && read_sector(target, track_probe[count] - 1, 1)) {
                 bios_switch_device98(target, 0x10, drivep);  /* 720 KB */
-                if (read_sector(target, track_probe[count] - 1, 1, drivep))
+                if (read_sector(target, track_probe[count] - 1, 1))
                     bios_switch_device98(target, 0x90, drivep);  /* 1.200 MB or 1.232 MB */
                 else
                     pc98_720KB = 1;
@@ -242,7 +243,7 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
         do {
             /* skip probing first entry */
             if (count) {
-                int res = read_sector(target, track_probe[count] - 1, 1, drivep);
+                int res = read_sector(target, track_probe[count] - 1, 1);
 #if DEBUG_PROBE
                 printk("CYL %d %s, ", track_probe[count]-1, res? "fail": "ok");
 #endif
@@ -265,12 +266,12 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
             if (count == 3)
                 bios_switch_device98(target, 0x30, drivep);  /* 1.44 MB */
             /* skip reading first entry */
-            if ((count == 3) && read_sector(target, 0, sector_probe[count], drivep)) {
+            if ((count == 3) && read_sector(target, 0, sector_probe[count])) {
                 if (pc98_720KB) {
                     bios_switch_device98(target, 0x10, drivep);  /* 720 KB */
                     /* Read BPB to find 8 sectors, 640KB format. Currently, it is not supported */
                     unsigned char __far *boot = _MK_FP(DMASEG, 0);
-                    if (!read_sector(target, 0, 1, drivep) && (boot[24] == 8))
+                    if (!read_sector(target, 0, 1) && (boot[24] == 8))
                         bios_switch_device98(target, 0x90, drivep);
                 }
                 else
@@ -279,7 +280,7 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
         } while (++count < sizeof(sector_probe)/sizeof(sector_probe[0]));
 #else
         do {
-            int res = read_sector(target, 0, sector_probe[count], drivep);
+            int res = read_sector(target, 0, sector_probe[count]);
 #if DEBUG_PROBE
             printk("SEC %d %s, ", sector_probe[count], res? "fail": "ok");
 #endif

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -56,11 +56,7 @@
 
 #define PER_DRIVE_INFO  1       /* =1 for per-line display of drive info at init */
 #define DEBUG_PROBE     0       /* =1 to display more floppy probing information */
-#ifdef CONFIG_ARCH_PC98
-#define FORCE_PROBE     1       /* =1 to force floppy probing */
-#else
 #define FORCE_PROBE     0       /* =1 to force floppy probing */
-#endif
 #define TRACK_SPLIT_BLK 0       /* =1 to read extra sector on track split block */
 #define SPLIT_BLK       0       /* =1 to read extra sector on single split block */
 #define FULL_TRACK      0       /* =1 to read full tracks when track caching */

--- a/elks/include/linuxmt/biosparm.h
+++ b/elks/include/linuxmt/biosparm.h
@@ -82,7 +82,8 @@ int call_bios(struct biosparms *);
 
 void BFPROC bios_disk_reset(int drive);
 int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
-        unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset);
+        unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset,
+        struct drive_infot *drivep);
 void BFPROC bios_set_ddpt(int max_sectors);
 void BFPROC bios_copy_ddpt(void);
 struct drive_infot;

--- a/elks/include/linuxmt/biosparm.h
+++ b/elks/include/linuxmt/biosparm.h
@@ -90,8 +90,6 @@ void BFPROC bios_copy_ddpt(void);
 struct drive_infot;
 void BFPROC bios_switch_device98(int target, unsigned int device,
         struct drive_infot *drivep);
-void BFPROC bios_check_sector98(int target, unsigned int device,
-        struct drive_infot *drivep);
 void BFPROC bios_disk_park_all(void);
 
 #endif

--- a/elks/include/linuxmt/biosparm.h
+++ b/elks/include/linuxmt/biosparm.h
@@ -69,6 +69,7 @@ struct biosparms {
 #define BIOSHD_DRIVE_PARMS      0x8400
 #define BIOSHD_DEVICE_TYPE      0x1400
 #define BIOSHD_MODESET          0x8E00
+#define BIOSHD_READ_ID          0x5A00
 #else
 #define BIOSHD_INT              0x13
 #define BIOSHD_RESET            0x0000
@@ -88,6 +89,8 @@ void BFPROC bios_set_ddpt(int max_sectors);
 void BFPROC bios_copy_ddpt(void);
 struct drive_infot;
 void BFPROC bios_switch_device98(int target, unsigned int device,
+        struct drive_infot *drivep);
+void BFPROC bios_check_sector98(int target, unsigned int device,
         struct drive_infot *drivep);
 void BFPROC bios_disk_park_all(void);
 


### PR DESCRIPTION
Hello @ghaerr 

This is a PR for https://github.com/ghaerr/elks/issues/2398#issuecomment-3538918975

This worked well on my hardware,
expect detecting ELKS boot parameter when boot FD1200 on the 3rd FD drive.
It goes to probe.
I may change something if I found the reason,
but I will leave it for now and go back to the original issue.

Thank you!