### PR TITLE
[mm, exec] Allow text segments pointing directly to ROMFS

### DIFF
--- a/elks/fs/config.in
+++ b/elks/fs/config.in
@@ -11,7 +11,7 @@ mainmenu_option next_comment
 
 	if [ "$CONFIG_ROMFS_FS" = "y" ]; then
 		hex 'Base in ROM (paragraphs)' CONFIG_ROMFS_BASE 0x8000
-		fi
+	fi
 
 	bool 'FAT filesystem' CONFIG_FS_FAT 'n'
 

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -55,6 +55,7 @@ int fs_memcmp(const void *,const void *,size_t);
 
 /* Memory allocation */
 
+segment_s * seg_alloc_romfs (seg_t, segext_t, word_t);
 segment_s * seg_alloc (segext_t, word_t);
 void seg_free (segment_s *);
 segment_s * seg_get (segment_s *);


### PR DESCRIPTION
The changes proved surprisingly small and independent, so here goes:

- `seg_alloc_fixed()` has been added, complete with a notion of "fixed segments" (that is, memory segments _not_ managed by the allocator). These can be distinguished by their linked list pointers being NULL. (Maybe it should be renamed to `seg_create_fixed()`?)
- `seg_free()` has been modified to support deallocating segments created by `seg_alloc_fixed()`.
- `exec()` has been modified to use the text segment directly when possible. It tries to be conservative about determining when that is the case:
    - The file system on which the inode is located has to be of the ROMFS type.
    - The text segment has to be stored at a multiple of 16 in the file. This is, thankfully, the case with the standard MINIX header.
    - The header has to be the standard MINIX header. This conveniently excludes cases of relocatable and compressed executables - none of which can be supported by this method.

I've tested this with `emu86.sh`, and it appears to work fine, with `ps -l` correctly showing the `CSEG` as pointing to ROM for processes.

The benefits are twofold:

- Any program loaded from ROM uses less memory - it's reduced by the size of its text segment. This can even be useful for setups where user programs are stored on a hard drive, if, say, the shell is kept in ROM.
- Avoiding a RAM allocation and copy means programs technically load slightly faster, though I expect the difference to be imperceptible.