### PR TITLE
[tools] Add WonderSwan emulator script.

### DIFF
--- a/emuswan.sh
+++ b/emuswan.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Run ELKS in wf-mednafen (WonderSwan emulator)
+# wf-mednafen can be built as part of the cross tools:
+# make -C tools swan
+# See https://github.com/WonderfulToolchain/wf-mednafen
+
+# For ELKS ROM Configuration:
+# ELKS must be configured minimally with 'cp swan.config .config'
+
+# Environment setup
+
+set -e
+
+SCRIPTDIR="$(dirname "$0")"
+
+. "$SCRIPTDIR/env.sh"
+
+# Create temporary directory housing the fake serial port and wrapper script
+temp=$(mktemp -d /tmp/emuswan.XXXXXXXX)
+
+# Create wrapper script
+cat <<EOF >$temp/serial.sh
+#!/usr/bin/env bash
+socat PTY,link=$temp/ttyS0,echo=0 STDIO
+EOF
+chmod +x $temp/serial.sh
+
+# Print banner
+echo ====================================================================
+echo
+echo Use the following file to access the emulated console\'s serial port:
+echo
+echo $temp/ttyS0
+echo
+echo ====================================================================
+echo
+
+# Run emulator
+export MEDNAFEN_HOME="$CROSSDIR/etc/mednafen"
+mkdir -p "$MEDNAFEN_HOME"
+exec wf-mednafen -wswan.excomm 1 -wswan.excomm.path $temp/serial.sh image/rom.wsc ${1+"$@"}
+
+# Clean up
+rm -r $temp

--- a/image/.gitignore
+++ b/image/.gitignore
@@ -1,6 +1,7 @@
 # Image files
 *.img
 *.bin
+*.wsc
 
 # Temporary files
 romfs.devices

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -192,6 +192,49 @@ $(CROSSDIR)/.emu86.install: $(BUILDDIR)/.emu86.build
 
 all:: $(CROSSDIR)/.emu86.install
 
+# wf-mednafen
+
+WF_MEDNAFEN_VER=6203a47cce4a0a44a5f9f58618bbfc50e0ab45e7
+WF_MEDNAFEN_DIST=wf-mednafen-$(WF_MEDNAFEN_VER)
+
+$(DISTDIR)/$(WF_MEDNAFEN_DIST).tar.gz:
+	mkdir -p $(DISTDIR)
+	rm -rf $(DISTDIR)/wf-mednafen-*.tar.gz \
+	       $(DISTDIR)/wf-mednafen-*.tmp \
+	       $(DISTDIR)/wf-mednafen-*.zip
+	set -e; \
+	cd $(DISTDIR); \
+	until gunzip -t $(WF_MEDNAFEN_DIST).tar.gz.tmp 2>/dev/null; do \
+		wget -c https://github.com/WonderfulToolchain/wf-mednafen/archive/$(WF_MEDNAFEN_VER).tar.gz \
+		     -O $(WF_MEDNAFEN_DIST).tar.gz.tmp; \
+	done
+	cd $(DISTDIR) && mv $(WF_MEDNAFEN_DIST).tar.gz.tmp $(WF_MEDNAFEN_DIST).tar.gz
+
+$(BUILDDIR)/.wf-mednafen.src: $(DISTDIR)/$(WF_MEDNAFEN_DIST).tar.gz
+	mkdir -p $(BUILDDIR)
+	rm -rf $(BUILDDIR)/$(WF_MEDNAFEN_DIST)
+	cd $(BUILDDIR) && tar -xzf $(DISTDIR)/$(WF_MEDNAFEN_DIST).tar.gz
+	rm -rf $(BUILDDIR)/wf-mednafen
+	cd $(BUILDDIR) && mv $(WF_MEDNAFEN_DIST) wf-mednafen
+	touch $(BUILDDIR)/.wf-mednafen.src
+
+$(BUILDDIR)/.wf-mednafen.build: $(BUILDDIR)/.wf-mednafen.src
+	cd $(BUILDDIR)/wf-mednafen/mednafen && ./autogen.sh
+	mkdir -p $(BUILDDIR)/wf-mednafen-build
+	# Disable most non-wswan emulator cores to save disk space and build time.
+	cd $(BUILDDIR)/wf-mednafen-build && ../wf-mednafen/mednafen/configure --disable-apple2 --disable-gb \
+		--disable-gba --disable-lynx --disable-md --disable-nes --disable-ngp --disable-psx \
+		--disable-sasplay --disable-sms --disable-snes --disable-snes-faust --disable-ssfplay \
+		--disable-ss --disable-vb --disable-nls --disable-fancy-scalers
+	$(MAKE) -C $(BUILDDIR)/wf-mednafen-build $(PARALLEL)
+	touch $(BUILDDIR)/.wf-mednafen.build
+
+$(CROSSDIR)/.wf-mednafen.install: $(BUILDDIR)/.wf-mednafen.build
+	install $(BUILDDIR)/wf-mednafen-build/src/mednafen $(CROSSDIR)/bin/wf-mednafen
+	touch $(CROSSDIR)/.wf-mednafen.install
+
+swan:: $(CROSSDIR)/.wf-mednafen.install
+
 # Tools pruning (to save disk space)
 
 prune:


### PR DESCRIPTION
> Ultimately, our naming issues come down to whose fork this stuff is in and how maintains it - I have to maintain the ELKS main fork and I'm unable to even test the Swan code, unfortunately.

This should help a little - it sets up an emulated serial port which you can use to talk to the ELKS instance on the console. Not sure if `wf-mednafen` will build out of the box on macOS, though, and you've brought that up as a potential concern in the past for some developers. Note also that the current `swan.config` as-is doesn't have enough RAM to launch a full `ash` shell from the login prompt - it probably needs to be tweaked to run `/bin/sash` directly.