### PR TITLE
[kernel] Fix ROMFS chdir use count bug

### DIFF
--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -174,8 +174,8 @@ static int romfs_followlink (struct inode * dir, register struct inode * inode,
 		dir = current->fs.root;
 		dir->i_count++;
 	}
-	if (!inode) return -ENOENT;
-	if (!S_ISLNK (inode->i_mode)) {
+	if (!inode) err = -ENOENT;
+	else if (!S_ISLNK (inode->i_mode)) {
 		*res_inode = inode;
 		err = 0;
 	} else {
@@ -190,6 +190,7 @@ static int romfs_followlink (struct inode * dir, register struct inode * inode,
 
 		err = open_namei (0, flag, mode, res_inode, dir);
 		*pds = user_ds;
+		return err;
 	}
 
 	iput(dir);

--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -162,7 +162,6 @@ static int romfs_followlink (struct inode * dir, register struct inode * inode,
 	int flag, mode_t mode, struct inode ** res_inode)
 {
 	int err;
-
 	seg_t user_ds;
 	seg_t *pds;
 
@@ -170,10 +169,17 @@ static int romfs_followlink (struct inode * dir, register struct inode * inode,
 	 * even if they are not links... maybe something to fix here ?
 	 */
 
+	*res_inode = NULL;
+	if (!dir) {
+		dir = current->fs.root;
+		dir->i_count++;
+	}
+	if (!inode) return -ENOENT;
 	if (!S_ISLNK (inode->i_mode)) {
 		*res_inode = inode;
 		err = 0;
 	} else {
+		iput(inode);
 		pds = &current->t_regs.ds;
 		user_ds = *pds;
 		*pds = inode->u.romfs.seg;
@@ -186,6 +192,7 @@ static int romfs_followlink (struct inode * dir, register struct inode * inode,
 		*pds = user_ds;
 	}
 
+	iput(dir);
 	return err;
 }
 

--- a/emu86.sh
+++ b/emu86.sh
@@ -13,10 +13,10 @@
 # Root filesystem @ segment 0x8000 (assumes 512K RAM & 512K ROM)
 
 # 8088 ROM version using emu-rom-full.config from './buildimages.sh fast'
-exec emu86 -w 0xe0000 -f image/rom-8088.bin -w 0x80000 -f image/romfs-8088.bin ${1+"$@"}
+#exec emu86 -w 0xe0000 -f image/rom-8088.bin -w 0x80000 -f image/romfs-8088.bin ${1+"$@"}
 
 # just built ROM version using 'make'
-#exec emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin -I image/fd1440.img ${1+"$@"}
+exec emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin -I image/fd1440.img ${1+"$@"}
 
 # For ELKS Full ROM Configuration:
 # ELKS must be configured minimally with 'cp emu86-rom-full.config .config'


### PR DESCRIPTION
Fixes the problems seen with improper root inode use count handling during chdir operation in #2478. Because the root inode use count was incremented too high, this prevented the filesystem from being unmounted.

The bug was found by comparing the complicated code in the `follow_link` file operation handlers between MINIX and ROMFS. This code is quite complicated so I'm not entirely sure it is fully tested in all cases.  It appears the VFS filesystem code calls the `follow_link` file operations handler for every `namei` call, regardless of whether the file is a symlink or not. This is evidenced by the following revealing comment in romfs.c:
```
    /* It is strange that the kernel calls this function for all inodes
     * even if they are not links... maybe something to fix here ?
     */
```
Close inspection showed that the romfs follow_link file operations handler didn't properly `iput` a couple of inodes, resulting in a continuous increment of inode use count, which is now fixed.

Also added support for the chroot() system call on ROMFS seen in the MINIX handler.

Tested on `emu86`.

