### PR TITLE
[kernel] Fix handling of shared text segments when pointing to ROM

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -116,7 +116,7 @@ static void seg_merge (segment_s * s1, segment_s * s2)
 
 // Allocate fixed segment for romfs (outside of memory allocator)
 
-segment_s * seg_alloc_romfs (seg_t base, segext_t size, word_t type)
+segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
 {
     segment_s * seg = heap_alloc(sizeof(segment_s),
         HEAP_TAG_SEG | HEAP_TAG_CLEAR);
@@ -150,7 +150,7 @@ void seg_free (segment_s * seg)
 {
 #ifdef CONFIG_ROMFS_FS
     // Handle segments created outside of the memory allocator
-    // (via seg_alloc_romfs).
+    // (via seg_alloc_fixed).
     if (seg->all.prev == NULL && seg->all.next == NULL) {
         heap_free(seg);
         return;

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -55,7 +55,7 @@ int fs_memcmp(const void *,const void *,size_t);
 
 /* Memory allocation */
 
-segment_s * seg_alloc_romfs (seg_t, segext_t, word_t);
+segment_s * seg_alloc_fixed (seg_t, segext_t, word_t);
 segment_s * seg_alloc (segext_t, word_t);
 void seg_free (segment_s *);
 segment_s * seg_get (segment_s *);


### PR DESCRIPTION
As discussed, this PR:

- renames `seg_alloc_romfs` back to `seg_alloc_fixed`,
- fixes handling of shared text segments when a program from ROMFS is loaded.

It does not tackle the configuration issue yet, however.