### PR TITLE
[libc] Add missing closedir to getcwd, other small cleanups

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -45,8 +45,8 @@
 #include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/memory.h>
-
 #include <arch/segment.h>
+#pragma GCC diagnostic ignored "-Wunused-label"
 
 /* for relocation debugging change to printk */
 #define debug_reloc     debug
@@ -359,14 +359,12 @@ static int FARPROC execve_aout(struct inode *inode, struct file *filp,
         retval = -ENOMEM;
 #ifdef CONFIG_ROMFS_FS
         if (filp->f_inode->i_sb->s_type->type == FST_ROMFS
-            && mh.hlen == EXEC_MINIX_HDR_SIZE
-        ) {
+            && mh.hlen == EXEC_MINIX_HDR_SIZE) {
             /* Point the code segment directly to in-memory ROMFS. This runs text
              * segments directly from ROM, as opposed to making copies of them in
-             * RAM. Not supported for compressed or relocatable binaries. */
-
-            seg_code = seg_alloc_fixed(
-                filp->f_inode->u.romfs.seg + (filp->f_pos >> 4),
+             * RAM. Not supported for compressed or relocatable binaries.
+             */
+            seg_code = seg_alloc_fixed(filp->f_inode->u.romfs.seg + (filp->f_pos >> 4),
                 paras, SEG_FLAG_CSEG);
             if (seg_code)
                 goto code_seg_found_exec;
@@ -382,8 +380,8 @@ static int FARPROC execve_aout(struct inode *inode, struct file *filp,
 #ifdef CONFIG_EXEC_MMODEL
         paras += bytes_to_paras((size_t)esuph.esh_ftseg);
 #endif
-        debug_reloc("EXEC: allocating %04x paras (%04x bytes) for text segment(s)\n", paras,
-            bytes);
+        debug_reloc("EXEC: allocating %04x paras (%04x bytes) for text segment(s)\n",
+            paras, bytes);
         seg_code = seg_alloc(paras, SEG_FLAG_CSEG);
         if (!seg_code) goto error_exec3;
         currentp->t_regs.ds = seg_code->base;

--- a/elks/include/linuxmt/biosparm.h
+++ b/elks/include/linuxmt/biosparm.h
@@ -82,12 +82,12 @@ struct biosparms {
 int call_bios(struct biosparms *);
 
 void BFPROC bios_disk_reset(int drive);
+struct drive_infot;
 int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
         unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset,
         struct drive_infot *drivep);
 void BFPROC bios_set_ddpt(int max_sectors);
 void BFPROC bios_copy_ddpt(void);
-struct drive_infot;
 void BFPROC bios_switch_device98(int target, unsigned int device,
         struct drive_infot *drivep);
 void BFPROC bios_disk_park_all(void);

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -125,7 +125,7 @@ void do_exit(int status)
     /* Let the parent know */
     kill_process(current->ppid, SIGCHLD, 1);
 
-    /* Free the text, pwd, and root inodes */
+    /* Free the text, chroot, and current working directory inodes */
     iput(current->t_inode);
     iput(current->fs.root);
     iput(current->fs.pwd);

--- a/emu86.sh
+++ b/emu86.sh
@@ -16,7 +16,7 @@
 #exec emu86 -w 0xe0000 -f image/rom-8088.bin -w 0x80000 -f image/romfs-8088.bin ${1+"$@"}
 
 # just built ROM version using 'make'
-exec emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin -I image/fd1440.img ${1+"$@"}
+exec emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin -I image/fd2880.img ${1+"$@"}
 
 # For ELKS Full ROM Configuration:
 # ELKS must be configured minimally with 'cp emu86-rom-full.config .config'

--- a/libc/misc/getcwd.c
+++ b/libc/misc/getcwd.c
@@ -52,6 +52,7 @@ search_dir(dev_t this_dev, ino_t this_ino)
       {
          if( slen + strlen(d->d_name) > path_size )
          {
+            closedir(dp);
             errno = ERANGE;
             return NULL;
          }


### PR DESCRIPTION
After recently chasing down several potential problems with `cd` and `pwd`, it was noticed that a rare bug exists in the C library getcwd() function, when the ERANGE error is produced. This PR primarily fixes that.

Other cleanups include getting ride of the GCC unused label warning produced from #2489 and a few small source code cleanups/clarifications in exec.c, exit.c and biosparm.h.

