### PR TITLE
[kernel] Improve ^O and ^N buffer and inode debug display

### DIFF
--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -148,7 +148,6 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
 #if defined(CHECK_FREECNTS) && DEBUG_EVENT
 static void list_buffer_status(void)
 {
-    int i = 1;
     int inuse = 0;
     int isinuse, j;
     struct buffer_head *bh = bh_llru;
@@ -167,14 +166,13 @@ static void list_buffer_status(void)
                     }
                 }
             }
-            printk("\n#%3d: buf %3d blk/dev %5ld/%p %c%c%c %smapped L%02d %d count %d",
-                i, buf_num(bh), ebh->b_blocknr, ebh->b_dev,
+            printk("\n#%3d: blk/dev %5ld/%p %c%c%c %smapped L%02d %d count %d",
+                buf_num(bh), ebh->b_blocknr, ebh->b_dev,
                 ebh->b_locked?  'L': ' ',
                 ebh->b_dirty?   'D': ' ',
                 ebh->b_uptodate?'U': ' ',
                 j? "  ": "un", j, ebh->b_mapcount, ebh->b_count);
         }
-        i++;
         if (isinuse) inuse++;
     } while ((bh = ebh->b_prev_lru) != NULL);
     printk("\nTotal L2 buffers inuse %d/%d (%d free)", inuse, nr_bh, nr_free_bh);

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -80,18 +80,17 @@ void clear_inode(register struct inode *inode) /* and put_first_lru() */
 #if defined(CHECK_FREECNTS) && DEBUG_EVENT
 static void list_inode_status(void)
 {
-    int i = 1;
     int inuse = 0;
     struct inode *inode = inode_llru;
 
     do {
         if (inode->i_count || inode->i_dev || inode->i_dirt) {
             inode->i_path[sizeof(inode->i_path)-1] = '\0';
-            printk("\n#%2d: dev %p inode %5lu cnt %2d %c %06o %s", i, inode->i_dev,
-                (unsigned long)inode->i_ino, inode->i_count, inode->i_dirt? 'D':' ',
-                inode->i_mode, S_ISSOCK(inode->i_mode)? " [socket]": inode->i_path);
+            printk("\n#%2d: dev %p inode %5lu cnt %2d %c %06o %s", inode - inode_block,
+                inode->i_dev, (unsigned long)inode->i_ino, inode->i_count,
+                inode->i_dirt? 'D':' ', inode->i_mode,
+                S_ISSOCK(inode->i_mode)? " [socket]": inode->i_path);
         }
-        i++;
         if (inode->i_count) inuse++;
     } while ((inode = inode->i_prev) != NULL);
     printk("\nTotal inodes inuse %d/%d (%d free)\n", inuse, NR_INODE, nr_free_inodes);


### PR DESCRIPTION
After closely using the ^N inode debug display to fix #2478, it seemed that displaying the LLRU index for the inode was far less useful (changing constantly) than displaying the inode number itself, which only changes after an application closes a file *and* the use count decrements to 0. Likewise for the ^O buffer display, which also used the LLRU index rather than the buffer number.

This PR changes both debug displays to use the inode or buffer number, which stays constant for a much longer period, for superior understandability. 