### PR TITLE
[romfs] Implement all inode mode bits in ROMFS

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -359,6 +359,7 @@ static int FARPROC execve_aout(struct inode *inode, struct file *filp,
         retval = -ENOMEM;
 #ifdef CONFIG_ROMFS_FS
         if (filp->f_inode->i_sb->s_type->type == FST_ROMFS
+            && !(filp->f_inode->i_mode & S_ISVTX)
             && mh.hlen == EXEC_MINIX_HDR_SIZE) {
             /* Point the code segment directly to in-memory ROMFS. This runs text
              * segments directly from ROM, as opposed to making copies of them in

--- a/elks/include/linuxmt/romfs_fs.h
+++ b/elks/include/linuxmt/romfs_fs.h
@@ -28,15 +28,8 @@ struct romfs_super_mem {
 struct romfs_inode_mem {
 	word_t offset;  /* offset in paragraphs */
 	word_t size;    /* size in bytes */
-	word_t flags;
+	word_t mode;	/* inode mode bits */
 };
-
-#define ROMFS_TYPE 7
-#define ROMFH_REG 0
-#define ROMFH_DIR 1
-#define ROMFH_CHR 2
-#define ROMFH_BLK 3
-#define ROMFH_LNK 4
 
 struct romfs_super_info {
        word_t ssize;   /* size of superblock */

--- a/image/Make.image
+++ b/image/Make.image
@@ -47,6 +47,7 @@ template:
 	-chmod 777 $(DESTDIR)/tmp
 	find $(DESTDIR) -name .keep -delete
 	$(MAKE) -C $(ELKSCMD_DIR) -f Make.install install "CONFIG=$(CONFIG)"
+	#chmod 1755 $(DESTDIR)/bin/meminfo
 ifdef CONFIG_APPS_COMPRESS
 	awk /`echo ":nocomp" | tr -d ' '`/{print} $(TOPDIR)/elkscmd/Applications | sed '/^#/d' | sed 's#.*/##g' | cut -d" " -f 1 | sed 's#\(^.*\)#/\1/d#' > Nocomp
 	ls $(DESTDIR)/bin | sed -f Nocomp > Filelist

--- a/image/Make.image
+++ b/image/Make.image
@@ -47,7 +47,7 @@ template:
 	-chmod 777 $(DESTDIR)/tmp
 	find $(DESTDIR) -name .keep -delete
 	$(MAKE) -C $(ELKSCMD_DIR) -f Make.install install "CONFIG=$(CONFIG)"
-	#chmod 1755 $(DESTDIR)/bin/meminfo
+	-chmod 1755 $(DESTDIR)/bin/romprg
 ifdef CONFIG_APPS_COMPRESS
 	awk /`echo ":nocomp" | tr -d ' '`/{print} $(TOPDIR)/elkscmd/Applications | sed '/^#/d' | sed 's#.*/##g' | cut -d" " -f 1 | sed 's#\(^.*\)#/\1/d#' > Nocomp
 	ls $(DESTDIR)/bin | sed -f Nocomp > Filelist


### PR DESCRIPTION
Discussed in more detail in https://github.com/ghaerr/elks/pull/2479#issuecomment-3594079102.

Rewrites tools/mkromfs to transfer source file's mode bits for most file types, allowing finer-grained Read/eXecute modes on files or directories in a ROMFS filesystem. Any Any Write mode bit is masked off on file, directory, or symlinks and OR-ed in to character and block device special files.

Adding in full inode mode-bit capability then allowed the use of the "sticky" (i.e. S_ISVTX 01000) bit to be specified in any ROMFS file. 

For the time being, image/Make.images sets the sticky bit on /bin/romprg (if present), which should also solve the problem of requiring `romprg` to always be allocated its code segment in RAM, so that the ROM can be reprogrammed at runtime.

@swausd, let me know how this works for you. Should you need modifications to `romprg`, go ahead and submit them in a separate PR.