### PR TITLE
[ktcp] recover from system hanging after lost TCP packet

### DIFF
--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -143,6 +143,15 @@ void eth_sendpacket(unsigned char *packet, int len, eth_addr_t eth_addr)
 	memcpy(ipll->ll_eth_src, eth_local_addr, 6);
 	ipll->ll_type_len = 0x08; //FIXME what is 0x0800
 
+//#define FORCE_MISSING_PACKET 128        /* 128 and 512 are good values for debugging */
+
+#if FORCE_MISSING_PACKET        /* For debugging: Create errors */
+        static failcnt = 0;
+        if (failcnt++ > FORCE_MISSING_PACKET)
+                failcnt = 0;
+        else
+#endif
+
 	eth_write((unsigned char *)ipll, sizeof(struct ip_ll) + len);
 }
 

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -143,7 +143,7 @@ void eth_sendpacket(unsigned char *packet, int len, eth_addr_t eth_addr)
 	memcpy(ipll->ll_eth_src, eth_local_addr, 6);
 	ipll->ll_type_len = 0x08; //FIXME what is 0x0800
 
-//#define FORCE_MISSING_PACKET 128        /* 128 and 512 are good values for debugging */
+#define FORCE_MISSING_PACKET 0  /* 128 and 512 are good values for debugging */
 
 #if FORCE_MISSING_PACKET        /* For debugging: Create errors */
         static failcnt = 0;

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -28,6 +28,8 @@
 #include "arp.h"
 #include "netconf.h"
 
+#define FORCE_MISSING_PACKET 0  /* 128 and 512 are good values for debugging */
+
 eth_addr_t eth_local_addr;
 
 static unsigned char sbuf[MAX_PACKET_ETH];
@@ -143,16 +145,13 @@ void eth_sendpacket(unsigned char *packet, int len, eth_addr_t eth_addr)
 	memcpy(ipll->ll_eth_src, eth_local_addr, 6);
 	ipll->ll_type_len = 0x08; //FIXME what is 0x0800
 
-#define FORCE_MISSING_PACKET 0  /* 128 and 512 are good values for debugging */
-
 #if FORCE_MISSING_PACKET        /* For debugging: Create errors */
-        static failcnt = 0;
-        if (failcnt++ > FORCE_MISSING_PACKET)
-                failcnt = 0;
-        else
+    static int failcnt = 0;
+    if (failcnt++ > FORCE_MISSING_PACKET)
+        failcnt = 0;
+    else
 #endif
-
-	eth_write((unsigned char *)ipll, sizeof(struct ip_ll) + len);
+    eth_write((unsigned char *)ipll, sizeof(struct ip_ll) + len);
 }
 
 /* raw ethernet packet send*/

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -296,7 +296,11 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	    /* adjust congestion window */
 	    if (cb->cwnd <= cb->ssthresh && !cb->retrans_act)
 	    	cb->cwnd++;
-	    cb->inflight--;
+        
+        if (cb->inflight == 1 || cb->send_una == cb->send_nxt)
+            cb->inflight = 0;       /* all outstanding packets ACKed */
+        else
+            cb->inflight--;
 	}
     }
 


### PR DESCRIPTION
Discussed here https://github.com/ghaerr/elks/issues/2487

Error description: After loosing a TCP packet in a telnet session the ELKS system hangs. Cause for the packet loss was a router with defect hardware/software. 

With the patch created by @Mellvik makes the system recover after packet loss. It was tested by me,  @swausd.

For testing @Mellvik created a new "packet loss simulation" in deveth.c