### PR TITLE
[net] Add debug_cwnd statements for TCP congestion control

### DIFF
--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -11,6 +11,7 @@
 #define DEBUG_TCP	0	/* TCP ops*/
 #define DEBUG_TCPPKT	0	/* TCP packets info*/
 #define DEBUG_TCPDATA	1	/* TCP packet data display*/
+#define DEBUG_CWND	0	/* TCP congestion control*/
 #define DEBUG_TUNE	1	/* tuning options*/
 #define DEBUG_RETRANS	0	/* TCP retransmissions*/
 #define DEBUG_WINDOW	0	/* TCP window size*/
@@ -44,6 +45,12 @@ void dprintf(const char *, ...);
 #define debug_tune	DPRINTF
 #else
 #define debug_tune(...)
+#endif
+
+#if DEBUG_CWND
+#define debug_cwnd	DPRINTF
+#else
+#define debug_cwnd(...)
 #endif
 
 #if DEBUG_TCPPKT

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -292,15 +292,18 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
     if (h->flags & TF_ACK) {		/* update unacked*/
 	acknum = ntohl(h->acknum);
 	if (SEQ_LT(cb->send_una, acknum)) {
+	    debug_cwnd("tcp:     ACK seq %lu unack %lu\n", acknum, cb->send_una);
 	    cb->send_una = acknum;
 	    /* adjust congestion window */
 	    if (cb->cwnd <= cb->ssthresh && !cb->retrans_act)
 	    	cb->cwnd++;
-        
-        if (cb->inflight == 1 || cb->send_una == cb->send_nxt)
-            cb->inflight = 0;       /* all outstanding packets ACKed */
-        else
-            cb->inflight--;
+	    if (cb->inflight == 1 || cb->send_una == cb->send_nxt) {
+		cb->inflight = 0;       /* all outstanding packets ACKed */
+                debug_cwnd("tcp: all ACK seq %lu inflt %d\n", acknum, cb->inflight);
+	    } else
+		cb->inflight--;
+	} else {
+	    debug_cwnd("tcp: DUP ACK seq %lu unack %lu\n", acknum, cb->send_una);
 	}
     }
 

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -403,11 +403,11 @@ void tcp_retrans_retransmit(void)
 	    	n->cb->ssthresh = n->cb->inflight/2;
 	    	if (n->cb->ssthresh < 2) n->cb->ssthresh = 2;
 	    }
+	    debug_cwnd("tcp: retrans inflt %d cwnd %d time %lu)\n",
+			n->cb->inflight, n->cb->cwnd, Now - n->next_retrans);
 	    /* EXPERIMENTAL - keep cwnd at 2 while retransmitting */
 	    n->cb->cwnd = TCP_INIT_CWND;
 	    n->cb->retrans_act++;
-	    //printf("retrans (%d,%d,%lu)\n",
-	    	//n->cb->inflight, n->len, Now - n->next_retrans);
 	    tcp_reoutput(n);
 
 	    /* Doesn't make all that sense to first retrans, then kill the connection */


### PR DESCRIPTION
Adds `debug_cwnd` and DEBUG_CWND definitions in config.h to allow closer inspection of `ktcp` congestion control algorithms for application writes, delayed writes, ACKs, DUP ACKs, showing sequence numbers and inflight and cwnd TCP control variables.

TCP congestion control is being discussed in more detail in https://github.com/ghaerr/elks/issues/2487 and https://github.com/Mellvik/TLVC/pull/211.

