### PR TITLE
[kernel] Enable interrupts as early as possible in kernel init

### DIFF
--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -36,9 +36,6 @@ int boot_rootdev;       /* set by /bootopts options if configured*/
 void INITPROC device_init(void)
 {
     chr_dev_init();
-
-    set_irq();          /* interrupts enabled for possible disk I/O or timers */
-
     blk_dev_init();
 
 #if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD) || \

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -191,6 +191,16 @@ static void update_port(register struct serial_info *port)
     }
 }
 
+/* printk console out */
+void rs_conout(dev_t dev, int Ch)
+{
+    register struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
+
+    while (!(INB(sp->io + UART_LSR) & UART_LSR_THRE))
+        continue;
+    outb(Ch, sp->io + UART_TX);
+}
+
 /* serial write - busy loops until transmit buffer available */
 static int rs_write(struct tty *tty)
 {
@@ -489,16 +499,6 @@ static void rs_init(void)
         }
         tty++;
     } while (++sp < &ports[NR_SERIAL]);
-}
-
-/* note: this function will be called prior to serial_init if serial console set*/
-void rs_conout(dev_t dev, int Ch)
-{
-    register struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
-
-    while (!(INB(sp->io + UART_LSR) & UART_LSR_THRE))
-        continue;
-    outb(Ch, sp->io + UART_TX);
 }
 
 #ifdef CONFIG_BOOTOPTS

--- a/elks/arch/i86/drivers/char/serial-swan.c
+++ b/elks/arch/i86/drivers/char/serial-swan.c
@@ -20,6 +20,13 @@
 static struct tty *tty;
 extern struct tty ttys[];
 
+/* printk console out */
+void rs_conout(dev_t dev, int c)
+{
+    while (!(inb(UART_CONTROL_PORT) & UART_TX_READY));
+    outb(c, UART_DATA_PORT);
+}
+
 /* serial write - busy loops until transmit buffer available */
 static int rs_write(struct tty *tty)
 {
@@ -96,13 +103,6 @@ static int rs_open(struct tty *tty)
     update_port(1);
 
     return 0;
-}
-
-/* note: this function will be called prior to serial_init if serial console set*/
-void rs_conout(dev_t dev, int c)
-{
-    while (!(inb(UART_CONTROL_PORT) & UART_TX_READY));
-    outb(c, UART_DATA_PORT);
 }
 
 void INITPROC serial_init(void)

--- a/elks/arch/i86/drivers/char/serial-template.c
+++ b/elks/arch/i86/drivers/char/serial-template.c
@@ -65,6 +65,16 @@ static unsigned int divisors[] = {
 
 extern struct tty ttys[];
 
+/* printk console out */
+void rs_conout(dev_t dev, int c)
+{
+    struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
+
+    while (!(inb(sp->io + UART_LSR) & UART_LSR_THRE))
+	continue;
+    outb(c, sp->io + UART_TX);
+}
+
 /* serial write - busy loops until transmit buffer available */
 static int rs_write(struct tty *tty)
 {
@@ -183,16 +193,6 @@ static int rs_open(struct tty *tty)
     inb(port->io + UART_MSR);
 
     return 0;
-}
-
-/* note: this function will be called prior to serial_init if serial console set*/
-void rs_conout(dev_t dev, int c)
-{
-    struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
-
-    while (!(inb(sp->io + UART_LSR) & UART_LSR_THRE))
-	continue;
-    outb(c, sp->io + UART_TX);
 }
 
 /* initialize UART, interrupts off */


### PR DESCRIPTION
This PR enables interrupts as early as possible during kernel initialization. The initialization order of some components was also changed so that the various serial console drivers can use kernel jiffies timers, as is required for the PC98 when no serial card is installed to avoid a hang.

The overall (re)architecture of enabling interrupts earlier is discussed in https://github.com/ghaerr/elks/pull/2355 and https://github.com/Mellvik/TLVC/issues/205.

@Mellvik, I've gone through all the drivers and think this approach is quite safe, although it has yet to be tested on real hardware. The current NIC drivers have been checked, and with this approach it is usually OK to just use cli/sti rather than saving the previous interrupt state, since now all char and block driver init, as well as all interrupt handlers, operate with interrupts enabled - so no need to save interrupt state unless the routine is shared and called from another routine with interrupts disabled (rare).

The serial driver init routine is now called as the very first routine after enabling interrupts, since when serial console is enabled all `printk` is rerouted to serial before any serial open routine is called. The rs_conout routine may need a jiffies timer for TBE timeouts (required on PC98). Enabling interrupts early will also be required should interrupt-driven serial output be implemented and serial console enabled.

Before the serial and console init routines are called (now in the opposite order), the IRQ 0 timer interrupt is active, and subsequent hardware interrupts continue to be setup using request_irq within each driver. Normally, the driver init routine won't need interrupts (deferred to device open routine), but driver interrupt operation is now available if desired.

The rs_conout routine(s) were moved next to rs_write for all serial drivers for maintenance, as the routines are very similar.