### PR TITLE
[kernel] Enable fast serial IRQ4/IRQ3 drivers by default

### DIFF
--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -1,4 +1,4 @@
-// Fast custom serial COM interrupt routine for ELKS
+// Fast custom serial input interrupt routines for ELKS
 //
 // runs on any stack and skips all ELKS overhead
 // must run with interrupts disabled as could interrupt user, kernel or interrupt stack
@@ -13,11 +13,11 @@
 
 #ifdef CONFIG_FAST_IRQ4
 //
-// fast com1 interrupt routine, uses "jmp _irq_com1" from interrupt vector
+// fast ttyS0 interrupt routine, called by CALLF within dynamic handler
 //
-	.extern	fast_com1_irq
-	.global	_irq_com1
-_irq_com1:
+	.extern	rs_fast_irq4
+	.global asm_fast_irq4
+asm_fast_irq4:
 	push	%ax			// save regs, uses 18 bytes of current stack
 	push	%bx
 	push	%cx
@@ -29,7 +29,7 @@ _irq_com1:
 	mov	%sp,%bx
 	mov	%ss:12(%bx),%ds
 
-	call	fast_com1_irq		// call special C interrupt routine
+	call	rs_fast_irq4		// call special C interrupt routine
 					// which doesn't use any SS/SP/BP addressing
 
 	mov	$0x20,%al		// EOI on primary controller
@@ -46,11 +46,11 @@ _irq_com1:
 
 #ifdef CONFIG_FAST_IRQ3
 //
-// fast com2 interrupt routine, uses "jmp _irq_com2" from interrupt vector
+// fast ttyS1 interrupt routine, called by CALLF within dynamic handler
 //
-	.extern	fast_com2_irq
-	.global	_irq_com2
-_irq_com2:
+	.extern	rs_fast_irq3
+	.global	asm_fast_irq3
+asm_fast_irq3:
 	push	%ax			// save regs, uses 18 bytes of current stack
 	push	%bx
 	push	%cx
@@ -62,7 +62,7 @@ _irq_com2:
 	mov	%sp,%bx
 	mov	%ss:12(%bx),%ds
 
-	call	fast_com2_irq		// call special C interrupt routine
+	call	rs_fast_irq3		// call special C interrupt routine
 					// which doesn't use any SS/SP/BP addressing
 
 	mov	$0x20,%al		// EOI on primary controller

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -37,8 +37,8 @@
 #define UTS_MACHINE             "ibmpc i8086"
 
 /* Fast serial input handler for arrow keys or fast SLIP on very slow systems */
-//#define CONFIG_FAST_IRQ4                      /* com1 */
-//#define CONFIG_FAST_IRQ3                      /* com2 */
+#define CONFIG_FAST_IRQ4                        /* com1 */
+#define CONFIG_FAST_IRQ3                        /* com2 */
 
 /* The following can be set for minimal systems or for QEMU emulation testing:
  * 10 buffers (@20 = 200), 2 ttyq (@80 = 160), 4k L1 cache, 512 heap free,

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -173,12 +173,11 @@ static void INITPROC kernel_init(void)
 
     set_irq();                      /* interrupts enabled early for jiffie timers */
 
-    /* set console from /bootopts console= or 0=default*/
-    set_console(boot_console);
 #ifdef CONFIG_CHAR_DEV_RS
-    serial_init();                  /* init serial first for printk */
+    serial_init();                  /* must init serial before console for ser console */
 #endif
-    console_init();                 /* init direct, bios or headless console*/
+    set_console(boot_console);      /* change to /bootopts console= or default */
+    console_init();                 /* init direct, bios or headless console */
 
     inode_init();
     if (buffer_init())  /* also enables xms and unreal mode if configured and possible*/


### PR DESCRIPTION
Sets CONFIG_FAST_IRQ4 and CONFIG_FAST_IRQ3 by default in config.h for the IBM PC.

Continuation of work performed in https://github.com/ghaerr/elks/pull/2459 and https://github.com/ghaerr/elks/pull/2460.

Enables the fast serial input interrupt handlers for /dev/ttyS0 and /dev/ttyS1 by default (for IBM PC architecture only). This should allow for bursts of 38400 baud serial input and working arrow keys from a serial terminal by default, as discussed in #2457 and #2459.

Also corrects a problem in #2501 from calling serial_init early in kernel initialization without serial console set. The kernel will use early_putchar through serial_init, then switch to the /bootopts or default console afterwards, before calling console_init.

An additional problem is fixed allowing ttyS2 or ttyS3 to work when CONFIG_FAST_IRQ4 or CONFIG_FAST_IRQ3 are set.

Cleans up fast interrupt handler routine names for consistency.

@swausd, this all gets us one step closer to getting the arrow keys to work from the serial terminal on your NEC V25 port (as discussed in #2457) which you will be able to implement using Linux-style "top-" and "bottom-half" interrupt handlers, which I plan on adding to the ELKS kernel shortly. This will work similar to the way rs_fast_irq4() works in this PR, which will become the "top-half" of the interrupt handler; it will run in interrupt context and quickly read the UART and queue the character, then return. After the EOI is sent and interrupt context exited, ELKS will run the "bottom-half" handler, which runs in normal kernel context, which can all wake_up etc that are currently taking way too much time within the interrupt handler prior to sending an EOI for that interrupt (thus disabling all lower priority interrupts even though interrupts are enabled). With any luck, deferring non-hardware-interrupt handling code to later bottom-half execution should allow ELKS to receive serial input continuously at 38400+ baud continuously with no data loss. I'm pretty sure the reason now we're getting some data loss is that the IRQ 0 interrupt handler is being used to "pump" the received serial input queue, but effectively disables all further serial input interrupts while taking far too long before the EOI. The IRQ 0 timer handler also spends time running the I/O console pinwheel and calculating CPU usage, which on the IBM PC architecture prevents any other interrupts from occurring until the entire handler is exited.
See https://github.com/Mellvik/TLVC/pull/211#issuecomment-3620566893 for more explanation.