### PR TITLE
[kernel] Minor comments and variables cleanup

### DIFF
--- a/elks/arch/i86/kernel/divzero.c
+++ b/elks/arch/i86/kernel/divzero.c
@@ -13,7 +13,7 @@ static char div0msg[] = { "Divide fault\n" };
 void div0_handler(int i, struct pt_regs *regs)
 {
     /* divide by 0 from nested interrupt or idle task means kernel code was executing */
-    if (_gint_count > 1 /*|| current->t_regs.ss == kernel_ds*/) {
+    if (intr_count > 1 /*|| current->t_regs.ss == kernel_ds*/) {
         /*
          * Trap from kernel code.
          *

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -72,18 +72,18 @@ int_vector_set:
 !
 !       There are three possible cases to cope with
 !
-!       Syscall or Interrupted user mode (_gint_count == 0)
+!       Syscall or Interrupted user mode (intr_count == 0)
 !               Switch to process's kernel stack
 !               Optionally, check (SS == current->t_regs.ss)
 !               and panic on failure
 !               On return, task switch allowed
 !
 !       Interrupted kernel mode, interrupted kernel task
-!               or second interrupt (_gint_count == 1)
+!               or second interrupt (intr_count == 1)
 !               Switch to interrupt stack
 !               On return, no task switch allowed
 !
-!       Interrupted interrupt service routine (_gint_count > 1)
+!       Interrupted interrupt service routine (intr_count > 1)
 !               Already using interrupt stack, keep using it
 !               On return, no task switch allowed
 !
@@ -119,7 +119,7 @@ _irqit:
 //
 //      Determine which stack to use
 //
-        cmpw    $1,_gint_count
+        cmpw    $1,intr_count
         jc      utask           // We were in user mode
         jz      itask           // Using a process's kernel stack
 ktask:                          // Already using interrupt stack
@@ -162,7 +162,7 @@ utask1:
 //      Save segment, index, BP and SP registers
 //
 save_regs:
-        incw    _gint_count
+        incw    intr_count
         pop     (%si)           // DI
         pop     2(%si)          // SI
         pop     8(%si)          // DS
@@ -332,7 +332,7 @@ was_trap:
 //
 //      Look at rescheduling
 //
-        cmpw    $1,_gint_count
+        cmpw    $1,intr_count
         jne     restore_regs    // No
 //      cmp     $0,_need_resched // Schedule needed ?
 //      je      restore_regs    // No
@@ -347,7 +347,7 @@ was_trap:
 //      Restore registers and return
 //
 restore_regs:
-        decw    _gint_count
+        decw    intr_count
         pop     %ax
         pop     %bx
         pop     %cx
@@ -438,7 +438,7 @@ div0_handler_panic:
 //      iret
 
         .data
-        .global _gint_count
+        .global intr_count
         .global endistack
         .global endtstack
         .global istack
@@ -450,14 +450,14 @@ bios_call_cnt:                  // call BIOS IRQ 0 handler every 5th interrupt
         .word   5
 org_irq0:                       // original BIOS IRQ 0 vector
         .long   0
-_gint_count:                    // General interrupts count. Start with 1
+intr_count:                     // stacked interrupts count. Start with 1
         .word   1               // because init_task() is in kernel mode
 #ifdef CHECK_SS
 pmsg:   .ascii "Running unknown code\0"
 #endif
 dmsg:   .ascii  "DIVIDE FAULT\0"
 
-	.bss
+        .bss
         .p2align 1
 endistack:
         .skip ISTACK_BYTES,0    // interrupt stack

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -3,27 +3,26 @@
  *
  * PC IRQ default mappings (* = possible conflicting uses)
  *
- *  IRQ ELKS Device         Config Option           Status
+ *  IRQ ELKS Device          Config Option          Status
  *  0   Timer                                       Required
- *  1   Keyboard            CONFIG_CONSOLE_DIRECT   Optional
- *  2*  Cascade -> 9 on AT  CONFIG_ETH_WD           Optional on XT, not available on AT
- *  3   Com2 (/dev/ttyS1)   CONFIG_CHAR_DEV_RS      Optional
- *  4   Com1 (/dev/ttyS0)   CONFIG_CHAR_DEV_RS      Optional
- *  5*  Unused
- *  5*  Com3 (/devb/ttyS2)  CONFIG_CHAR_DEV_RS      Optional
- *  5*  HW IDE hard drive   CONFIG_BLK_DEV_HD       Driver doesn't work
- *  6*  Unused
- *  6*  HW floppy drive     CONFIG_BLK_DEV_FD       Driver doesn't compile
+ *  1   Keyboard             CONFIG_CONSOLE_DIRECT  Optional
+ *  2*  Cascade -> 9 on AT                          Optional on XT, not available on AT
+ *  2*  WD 80x3   (/dev/wd0) CONFIG_ETH_WD          Optional on XT, not available on AT
+ *  3   Com2    (/dev/ttyS1) CONFIG_CHAR_DEV_RS     Optional
+ *  4   Com1    (/dev/ttyS0) CONFIG_CHAR_DEV_RS     Optional
+ *  5*  Com3    (/dev/ttyS2) CONFIG_CHAR_DEV_RS     Optional
+ *  5*  HW IDE hard drive    CONFIG_BLK_DEV_HD      Non-working directhd.c
+ *  6   HW floppy drive      CONFIG_BLK_DEV_FD      Optional
  *  7   Unused (LPT, Com4)
  *  8   Unused (RTC)
- *  9   3C509/EL3 (/dev/eth) CONFIG_ETH_EL3         Optional
- * 10   Unused (USB)                                Turned off
- * 11   Unused (Sound)                              Turned off
- * 12   NE2K (/dev/eth)     CONFIG_ETH_NE2K         Optional
- * 12*  Unused (Mouse)                              Turned off
- * 13   Unused (Math coproc.)                       Turned off
- * 14*  AT HD IDE (/dev/hda) CONFIG_BLK_DEV_HD      Driver doesn't work
- * 15*  AT HD IDE (/dev/hdb) CONFIG_BLK_DEV_HD      Driver doesn't work
+ *  9*  3C509/EL3 (/dev/3c0) CONFIG_ETH_EL3         Optional
+ * 10*  WD 80x3   (/dev/wd0) CONFIG_ETH_WD          Optional
+ * 11*  3C509/EL3 (/dev/3c0) CONFIG_ETH_EL3         Optional
+ * 12*  NE2K      (/dev/ne0) CONFIG_ETH_NE2K        Optional
+ * 12*  Unused (Mouse)                              No driver
+ * 13   Unused (Math coproc)                        No driver
+ * 14   AT HD IDE (/dev/hda) CONFIG_BLK_DEV_HD      Non-working hd.c
+ * 15   AT HD IDE (/dev/hdb) CONFIG_BLK_DEV_HD      Non-working hd.c
  *
  * Edit settings below to change port address or IRQ:
  *   Change I/O port and driver IRQ number to match your hardware

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -63,12 +63,6 @@ struct proto_ops {
     int (*listen) ();
     int (*send) ();
     int (*recv) ();
-    int (*sendto) ();
-    int (*recvfrom) ();
-    int (*shutdown) ();
-    int (*setsocketopt) ();
-    int (*getsocketopt) ();
-    int (*fcntl) ();
 };
 #endif
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -114,7 +114,7 @@ extern int task_slots_unused;
 
 extern volatile jiff_t jiffies; /* ticks updated by the timer interrupt*/
 extern pid_t last_pid;
-extern int _gint_count;
+extern int intr_count;
 
 extern struct timeval xtime;
 extern jiff_t xtime_jiffies;

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -115,7 +115,7 @@ void start_kernel(void)
 
     /*
      * We are now the idle task. We won't run unless no other process can run.
-     * The idle task always runs with _gint_count == 1 (switched from user mode syscall)
+     * The idle task always runs with intr_count == 1 (switched from user mode syscall)
      */
     while (1) {
         schedule();

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -67,10 +67,10 @@ void schedule(void)
     prev = current;
 
 #ifdef CHECK_SCHED
-    if (_gint_count > 1) {      /* neither user nor idle task was running */
+    if (intr_count > 1) {   /* neither user nor idle task was running */
         /* Taking a timer IRQ during another IRQ or while in kernel space is
          * quite legal. We just dont switch then */
-         panic("schedule from int\n");
+         panic("sched from int\n");
     }
 #endif
 

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -462,12 +462,6 @@ static struct proto_ops inet_proto_ops = {
     inet_listen,
     inet_send,
     inet_recv,
-    not_implemented,    /* inet_sendto */
-    not_implemented,    /* inet_recvfrom */
-    not_implemented,    /* inet_shutdown */
-    not_implemented,    /* inet_setsockopt */
-    not_implemented,    /* inet_getsockopt */
-    not_implemented,    /* inet_fcntl */
 };
 
 void inet_proto_init(struct net_proto *pro)

--- a/elks/net/nano/af_nano.c
+++ b/elks/net/nano/af_nano.c
@@ -559,12 +559,6 @@ struct proto_ops nano_proto_ops = {
     nano_listen,
     nano_send,
     nano_recv,
-    NULL,			/* sendto */
-    NULL,			/* recvfrom */
-    NULL,			/* shutdown */
-    NULL,			/* setsockopt */
-    NULL,			/* getsockopt */
-    NULL			/* fcntl */
 };
 
 void nano_proto_init(struct net_proto *pro)

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -30,7 +30,7 @@
 
 #define socki_lookup(inode)	(&inode->u.socket_i)
 
-static struct proto_ops *pops[NPROTO] = { NULL, NULL, NULL };
+static struct proto_ops *pops[NPROTO];
 
 extern struct net_proto protocols[];	/* Network protocols */
 

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -570,12 +570,6 @@ struct proto_ops unix_proto_ops = {
     unix_listen,
     unix_send,
     unix_recv,
-    NULL,			/* sendto */
-    NULL,			/* recvfrom */
-    NULL,			/* shutdown */
-    NULL,			/* setsockopt */
-    NULL,			/* getsockopt */
-    NULL			/* fcntl */
 };
 
 void unix_proto_init(struct net_proto *pro)


### PR DESCRIPTION
Rewrites comments in ports.h.
Renames \_gint_count to intr_count (stacked interrupt counter).
Removes unused function pointer entries in proto_ops struct.
