### PR TITLE
[irq] Add NMI handler

### DIFF
--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -45,6 +45,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_PC98), y)
 OBJS += irq-8259.o reset-pc98.o timer-8254.o
+OBJS += nmi.o
 endif
 
 ifeq ($(CONFIG_ARCH_8018X), y)

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -136,6 +136,12 @@ void INITPROC irq_init(void)
 #endif
 #endif
 
+#if defined(CONFIG_ARCH_PC98)
+    /* catch NMI */
+    irq_action[IDX_NMI] = nmi_handler;
+    int_handler_add(IDX_NMI, 0x02, _irqit);
+#endif
+
 #if defined(CONFIG_TIMER_INT0F) || defined(CONFIG_TIMER_INT1C)
     /* Use IRQ 7 vector (simulated by INT 0Fh) for timer interrupt handler */
     if (request_irq(7, timer_tick, INT_GENERIC))

--- a/elks/arch/i86/kernel/nmi.c
+++ b/elks/arch/i86/kernel/nmi.c
@@ -1,0 +1,21 @@
+#include <linuxmt/config.h>
+#include <arch/io.h>
+
+/*
+ * NMI handler
+ */
+
+static char nmi_msg[] = { "NMI occurred\n" };
+
+void nmi_handler(int i, struct pt_regs *regs)
+{
+    printk(nmi_msg);
+
+#ifdef CONFIG_ARCH_PC98
+    if (inb(0x33) & 0x02)
+        printk("Extended slot memory parity error\n");
+
+    outb(0x08,0x37); /* Disable parity check to clear the error */
+    outb(0x09,0x37); /* Enable parity check */
+#endif
+}

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -5,7 +5,8 @@
 /* irq numbers >= 16 are hardware exceptions/traps or syscall */
 #define IDX_SYSCALL     16
 #define IDX_DIVZERO     17
-#define NR_IRQS         18      /* = # IRQs plus special indexes above */
+#define IDX_NMI         18
+#define NR_IRQS         19      /* = # IRQs plus special indexes above */
 
 #define INT_GENERIC  0  // use the generic interrupt handler (aka '_irqit')
 #define INT_SPECIFIC 1  // use a specific interrupt handler
@@ -19,6 +20,7 @@ typedef void (* irq_handler) (int,struct pt_regs *);   // IRQ handler
 
 void do_IRQ(int,struct pt_regs *);
 void div0_handler(int, struct pt_regs *);
+void nmi_handler(int, struct pt_regs *);
 int request_irq(int,irq_handler,int hflag);
 int free_irq(int irq);
 


### PR DESCRIPTION
Hello @ghaerr 

This is the NMI for PC-98 discussed on https://github.com/ghaerr/elks/issues/2398#issuecomment-3621045231

Although the real NMI is not detected,
I have made int02 test program with C86 on the PC-98 and confirmed the routine is working.
 
![int02_20251207_173508](https://github.com/user-attachments/assets/02778370-e3ee-4fee-8fab-8dff19cef64f)

Thank you.
