### PR TITLE
[kernel] Implement bottom half interrupt handlers!

### DIFF
--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -1,9 +1,9 @@
-// Fast custom serial input interrupt routines for ELKS
+// First part of top half of fast serial interrupt handlers for ELKS
 //
-// runs on any stack and skips all ELKS overhead
-// must run with interrupts disabled as could interrupt user, kernel or interrupt stack
-// reads character into ring buffer
-// timer interrupt runs serial_bh() which checks for non-zero queue and calls wake_up
+// Runs on any stack and skips ELKS _irqit stack switching overhead.
+// Must run with interrupts disabled as could interrupt user, kernel or interrupt stack.
+// Calls the second part of the top half (rs_fast_irq4) to read and queue received byte.
+// The bottom half (serial_bh) runs later, which processes queue and calls wake_up.
 //
 // 25 June 2020 Greg Haerr
 //
@@ -13,7 +13,7 @@
 
 #ifdef CONFIG_FAST_IRQ4
 //
-// fast ttyS0 interrupt routine, called by CALLF within dynamic handler
+// Entry for ttyS0 top half interrupt handler, called by CALLF within dynamic handler
 //
 	.extern	rs_fast_irq4
 	.global asm_fast_irq4
@@ -29,7 +29,7 @@ asm_fast_irq4:
 	mov	%sp,%bx
 	mov	%ss:12(%bx),%ds
 
-	call	rs_fast_irq4		// call special C interrupt routine
+	call	rs_fast_irq4		// call special 2nd part of top half C handler
 					// which doesn't use any SS/SP/BP addressing
 
 	mov	$0x20,%al		// EOI on primary controller
@@ -46,7 +46,7 @@ asm_fast_irq4:
 
 #ifdef CONFIG_FAST_IRQ3
 //
-// fast ttyS1 interrupt routine, called by CALLF within dynamic handler
+// Entry for ttyS1 top half interrupt handler, called by CALLF within dynamic handler
 //
 	.extern	rs_fast_irq3
 	.global	asm_fast_irq3
@@ -62,7 +62,7 @@ asm_fast_irq3:
 	mov	%sp,%bx
 	mov	%ss:12(%bx),%ds
 
-	call	rs_fast_irq3		// call special C interrupt routine
+	call	rs_fast_irq3		// call special 2nd part of top half C handler
 					// which doesn't use any SS/SP/BP addressing
 
 	mov	$0x20,%al		// EOI on primary controller

--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -3,7 +3,7 @@
 // runs on any stack and skips all ELKS overhead
 // must run with interrupts disabled as could interrupt user, kernel or interrupt stack
 // reads character into ring buffer
-// timer interrupt runs rs_pump() which checks for non-zero queue and calls wake_up
+// timer interrupt runs serial_bh() which checks for non-zero queue and calls wake_up
 //
 // 25 June 2020 Greg Haerr
 //

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -39,16 +39,15 @@ OBJS  = strace.o irq.o irqtab.o process.o \
 		entry.o signal.o timer.o softirq.o
 
 ifeq ($(CONFIG_ARCH_IBMPC), y)
-OBJS += irq-8259.o reset-ibm.o timer-8254.o nmi.o
-#OBJS += divzero.o
+OBJS += irq-8259.o reset-ibm.o timer-8254.o divzero.o nmi.o
 endif
 
 ifeq ($(CONFIG_ARCH_PC98), y)
-OBJS += irq-8259.o reset-pc98.o timer-8254.o nmi.o
+OBJS += irq-8259.o reset-pc98.o timer-8254.o divzero.o nmi.o
 endif
 
 ifeq ($(CONFIG_ARCH_SOLO86), y)
-OBJS += irq-solo86.o reset-stubs.o timer-8254.o nmi.o
+OBJS += irq-solo86.o reset-stubs.o timer-8254.o divzero.o nmi.o
 endif
 
 ifeq ($(CONFIG_ARCH_8018X), y)
@@ -60,7 +59,7 @@ OBJS += irq-necv25.o reset-stubs.o timer-necv25.o
 endif
 
 ifeq ($(CONFIG_ARCH_SWAN), y)
-OBJS += irq-swan.o reset-swan.o timer-swan.o system-swan.o nmi.o
+OBJS += irq-swan.o reset-swan.o timer-swan.o system-swan.o divzero.o nmi.o
 else
 OBJS += system.o
 endif

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -36,16 +36,19 @@ include $(BASEDIR)/Makefile-rules
 # Objects to be compiled.
 
 OBJS  = strace.o irq.o irqtab.o process.o \
-		entry.o signal.o timer.o
+		entry.o signal.o timer.o softirq.o
 
 ifeq ($(CONFIG_ARCH_IBMPC), y)
-OBJS += irq-8259.o reset-ibm.o timer-8254.o
-OBJS += divzero.o
+OBJS += irq-8259.o reset-ibm.o timer-8254.o nmi.o
+#OBJS += divzero.o
 endif
 
 ifeq ($(CONFIG_ARCH_PC98), y)
-OBJS += irq-8259.o reset-pc98.o timer-8254.o
-OBJS += nmi.o
+OBJS += irq-8259.o reset-pc98.o timer-8254.o nmi.o
+endif
+
+ifeq ($(CONFIG_ARCH_SOLO86), y)
+OBJS += irq-solo86.o reset-stubs.o timer-8254.o nmi.o
 endif
 
 ifeq ($(CONFIG_ARCH_8018X), y)
@@ -57,15 +60,9 @@ OBJS += irq-necv25.o reset-stubs.o timer-necv25.o
 endif
 
 ifeq ($(CONFIG_ARCH_SWAN), y)
-OBJS += irq-swan.o reset-swan.o system-swan.o timer-swan.o
-OBJS += divzero.o
+OBJS += irq-swan.o reset-swan.o timer-swan.o system-swan.o nmi.o
 else
 OBJS += system.o
-endif
-
-ifeq ($(CONFIG_ARCH_SOLO86), y)
-OBJS += irq-solo86.o reset-stubs.o timer-8254.o
-OBJS += divzero.o
 endif
 
 #########################################################################

--- a/elks/arch/i86/kernel/divzero.c
+++ b/elks/arch/i86/kernel/divzero.c
@@ -4,21 +4,19 @@
 
 /*
  * Divide by zero and divide overflow exception handler
- * NOTE: This handler is currently unused, see div0_handler_panic in irqtab.S
  *
  * 19 Aug 24 Greg Haerr
  */
 
-static char div0msg[] = { "Divide fault\n" };
+#define DEBUG       0   /* =1 for CS:IP detail of fault */
 
-void div0_handler(int i, struct pt_regs *regs)
+void div0_handler(int irq, struct pt_regs *regs)
 {
-    /* divide by 0 from nested interrupt or idle task means kernel code was executing */
     if (intr_count > 1 /*|| current->t_regs.ss == kernel_ds*/) {
         /*
-         * Trap from kernel code.
+         * Trap from kernel code or idle task.
          *
-         * Not panicing at this point involves determining the CS:IP of the
+         * Not calling panic at this point involves determining the CS:IP of the
          * faulting instruction, then doing two different things depending on
          * whether the CPU is 8088/8086/V20/V30 or 286/386+: the former trap
          * pushes the CS:IP following the DIV, while the latter pushes CS:IP of
@@ -26,20 +24,23 @@ void div0_handler(int i, struct pt_regs *regs)
          * all forms of DIV, while allowing either would introduce undefined
          * behaviour as a result of an incorrect calcuation. So we panic.
          */
-#if 0
+
+#if DEBUG
         struct uregs __far *sys_stack;
         sys_stack = _MK_FP(regs->ss, regs->sp);
-        printk("Div0 at CS:IP %x:%x\n", sys_stack->cs, sys_stack->ip);
+        printk("CS:IP %04x:%04x\n", sys_stack->cs, sys_stack->ip);
 #endif
-        panic(div0msg);
-    } else {
-        /* For user mode faults, display error message and kill the process */
-        printk(div0msg);
-#if 0
+
+        panic("DIVIDE FAULT\n");
+    } else {    /* For user mode faults, display error message and kill the process */
+        printk("DIVIDE FAULT\n");
+
+#if DEBUG
         struct uregs __far *user_stack;
         user_stack = _MK_FP(current->t_regs.ss, current->t_regs.sp);
-        printk("Div0 at CS:IP %x:%x\n", user_stack->cs, user_stack->ip);
+        printk("CS:IP %04x:%04x\n", user_stack->cs, user_stack->ip);
 #endif
+
         sys_kill(current->pid, SIGABRT);    /* no SIGFPE so send SIGABRT for now */
     }
 }

--- a/elks/arch/i86/kernel/divzero.c
+++ b/elks/arch/i86/kernel/divzero.c
@@ -4,6 +4,7 @@
 
 /*
  * Divide by zero and divide overflow exception handler
+ * NOTE: This handler is currently unused, see div0_handler_panic in irqtab.S
  *
  * 19 Aug 24 Greg Haerr
  */

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -120,24 +120,15 @@ int free_irq(int irq)
  */
 void INITPROC irq_init(void)
 {
-    /* use INT 0x80h for system calls */
-    int_handler_add(IDX_SYSCALL, 0x80, _irqit);
+    int_handler_add(IDX_SYSCALL, 0x80, _irqit); /* INT 80 for system calls */
 
 #if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98) || \
     defined(CONFIG_ARCH_SOLO86) || defined(CONFIG_ARCH_SWAN)
 
-#if 1
-    /* install direct panic-only DIV fault handler until known that
-     * the _irqit version doesn't overwrite the stack
-     */
-    int_handler_add(IDX_DIVZERO, 0x00, div0_handler_panic);
-#else
-    /* catch INT 0 divide by zero/divide overflow hardware fault */
-    irq_action[IDX_DIVZERO] = div0_handler;
+    irq_action[IDX_DIVZERO] = div0_handler;     /* INT 0 divide by 0/divide overflow */
     int_handler_add(IDX_DIVZERO, 0x00, _irqit);
-#endif
 
-    irq_action[IDX_NMI] = nmi_handler;              /* catch NMI (INT 2) */
+    irq_action[IDX_NMI] = nmi_handler;          /* INT 2 non-maskable interrupt */
     int_handler_add(IDX_NMI, 0x02, _irqit);
 #endif
 

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -123,22 +123,21 @@ void INITPROC irq_init(void)
     /* use INT 0x80h for system calls */
     int_handler_add(IDX_SYSCALL, 0x80, _irqit);
 
-#if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_SWAN)
-    /* catch INT 0 divide by zero/divide overflow hardware fault */
+#if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98) || \
+    defined(CONFIG_ARCH_SOLO86) || defined(CONFIG_ARCH_SWAN)
+
 #if 1
     /* install direct panic-only DIV fault handler until known that
      * the _irqit version doesn't overwrite the stack
      */
     int_handler_add(IDX_DIVZERO, 0x00, div0_handler_panic);
 #else
+    /* catch INT 0 divide by zero/divide overflow hardware fault */
     irq_action[IDX_DIVZERO] = div0_handler;
     int_handler_add(IDX_DIVZERO, 0x00, _irqit);
 #endif
-#endif
 
-#if defined(CONFIG_ARCH_PC98)
-    /* catch NMI */
-    irq_action[IDX_NMI] = nmi_handler;
+    irq_action[IDX_NMI] = nmi_handler;              /* catch NMI (INT 2) */
     int_handler_add(IDX_NMI, 0x02, _irqit);
 #endif
 
@@ -165,6 +164,7 @@ void INITPROC irq_init(void)
     if (request_irq(TIMER_IRQ, timer_tick, INT_GENERIC))
         panic("Unable to get timer");
 
+    init_bh(TIMER_BH, timer_bh);
     enable_timer_tick();        /* reprogram timer for 100 HZ */
 #endif
 }

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -100,6 +100,8 @@ int_vector_set:
         .extern trace_begin
         .extern trace_end
         .extern panic
+        .extern bh_active
+        .extern do_bottom_half
 
         .global _irqit
 _irqit:
@@ -332,14 +334,42 @@ was_trap:
 //
 //      Look at rescheduling
 //
-        cmpw    $1,intr_count
+        cmpw    $1,intr_count   // Syscall or interrupted user mode code?
         jne     restore_regs    // No
 //      cmp     $0,_need_resched // Schedule needed ?
 //      je      restore_regs    // No
 //
 // This path will return directly to user space
 //
-        sti                     // Enable interrupts to help fast devices
+
+//
+// Check for any active bottom-half handlers and if we're able to run them now.
+//  Bottom half handlers can run now only if this interrupt is from user mode,
+//  otherwise handlers will be run during next call to schedule().
+//  Interrupts from the idle task have to return now since they're running on
+//  the interrupt stack and can't be switched. On return the idle task will call
+//  schedule() in its main loop, which then runs the bottom half handlers.
+//
+//  At this time, intr_count values mean:
+//  intr_count==0   not possible
+//  intr_count==1   syscall or interrupted user code (using process's kernel stack)
+//  intr_count==2   interrupted kernel code or idle task (using interrupt stack)
+//  intr_count>2    interrupted handler code (using interrupt stack)
+//  The idle task always runs at intr_count==1, since it is actually kernel code.
+//  This means that interrupts of idle task or kernel run on the interrupt stack
+//  and thus calling schedule() cannot be allowed. This also means that
+//  task rescheduling doesn't happen on return from a timer interrupt from the idle task.
+//  Instead, the idle task is resumed and it calls schedule which calls bottom half.
+//
+        cmpw    $0,bh_active    // Any active bottom halfs?
+        je      1f              // No
+        //incw    intr_count    // Don't rerun bottom half if interrupted
+        sti                     // interrupts enabled but handlers not reentrant
+        call    do_bottom_half
+        //cli
+        //decw    intr_count
+
+1:      sti                     // Enable interrupts to help fast devices
         call    schedule        // Task switch
         call    do_signal       // Check signals
         cli
@@ -401,6 +431,10 @@ setsp:
         pop     %ax
         mov     %ax,%sp
         jmp     *%bx
+
+        .global getsp
+getsp:  mov     %sp,%ax
+        ret
 
 // Halt - wait for next interrupt to save CPU power
         .global idle_halt

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -334,7 +334,7 @@ was_trap:
 //
 //      Look at rescheduling
 //
-        cmpw    $1,intr_count   // Syscall or interrupted user mode code?
+        cmpw    $1,intr_count   // Interrupted user mode code?
         jne     restore_regs    // No
 //      cmp     $0,_need_resched // Schedule needed ?
 //      je      restore_regs    // No

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -352,7 +352,7 @@ was_trap:
 //
 //  At this time, intr_count values mean:
 //  intr_count==0   not possible
-//  intr_count==1   syscall or interrupted user code (using process's kernel stack)
+//  intr_count==1   interrupted user code (using process's kernel stack)
 //  intr_count==2   interrupted kernel code or idle task (using interrupt stack)
 //  intr_count>2    interrupted handler code (using interrupt stack)
 //  The idle task always runs at intr_count==1, since it is actually kernel code.
@@ -432,8 +432,10 @@ setsp:
         mov     %ax,%sp
         jmp     *%bx
 
+// short *getsp(void) - get stack pointer
         .global getsp
-getsp:  mov     %sp,%ax
+getsp:
+        mov     %sp,%ax
         ret
 
 // Halt - wait for next interrupt to save CPU power
@@ -441,35 +443,6 @@ getsp:  mov     %sp,%ax
 idle_halt:
         hlt
         ret
-
-        .global div0_handler_panic
-// Divide Fault hander - just panic for now
-div0_handler_panic:
-        push    %ax                     // save regs, uses 4+4+10 bytes of current stack
-        push    %bx
-        push    %cx
-        push    %dx
-        push    %ds
-
-        // Recover kernel data segment
-        // Was pushed by the CALLF of the dynamic handler
-        mov     %sp,%bx
-        mov     %ss:12(%bx),%ds
-
-        mov     $dmsg,%ax
-        push    %ax
-        call    panic
-        pop     %ax
-1:      hlt
-        jmp     1b
-
-//      pop     %ds                     // restore regs
-//      pop     %dx
-//      pop     %cx
-//      pop     %bx
-//      pop     %ax
-//      add     $4,%sp                  // skip the trampoline lcall
-//      iret
 
         .data
         .global intr_count

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -462,7 +462,6 @@ intr_count:                     // stacked interrupts count. Start with 1
 #ifdef CHECK_SS
 pmsg:   .ascii "Running unknown code\0"
 #endif
-dmsg:   .ascii  "DIVIDE FAULT\0"
 
         .bss
         .p2align 1

--- a/elks/arch/i86/kernel/nmi.c
+++ b/elks/arch/i86/kernel/nmi.c
@@ -6,7 +6,7 @@
  * NMI handler
  */
 
-void nmi_handler(int i, struct pt_regs *regs)
+void nmi_handler(int irq, struct pt_regs *regs)
 {
     printk("NMI FAULT\n");
 

--- a/elks/arch/i86/kernel/nmi.c
+++ b/elks/arch/i86/kernel/nmi.c
@@ -1,15 +1,14 @@
 #include <linuxmt/config.h>
+#include <linuxmt/kernel.h>
 #include <arch/io.h>
 
 /*
  * NMI handler
  */
 
-static char nmi_msg[] = { "NMI occurred\n" };
-
 void nmi_handler(int i, struct pt_regs *regs)
 {
-    printk(nmi_msg);
+    printk("NMI FAULT\n");
 
 #ifdef CONFIG_ARCH_PC98
     if (inb(0x33) & 0x02)

--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -4,14 +4,25 @@
 #include <arch/irq.h>
 
 /*
- * Run bottom-half interrupt handlers
+ * Bottom half interrupt handler support (softirq's)
+ *
+ * Top half interrupt handlers should quickly perform hardware data acquisition,
+ * then call mark_bh to request deferred execution of the bottom half handler
+ * registered with init_bh, for non-interrupt-priority tasks like wake_up, etc.
+ *
+ * All BH handlers run in interrupt context, which means they can't sleep,
+ * can't access user space through current, and can't reschedule.
+ *
+ * Interrupts are enabled and a BH handler may be interrupted by any hardware
+ * interrupt, but are protected from being re-entered, so don't need to be reentrant.
  *
  * 6 Dec 25 Greg Haerr
  */
 
-unsigned int bh_active;
-void (*bh_base[MAX_SOFTIRQ])(void);
+unsigned int bh_active;             /* bitmask of handlers flagged to run by mark_bh */
+void (*bh_base[MAX_SOFTIRQ])(void); /* registered handlers from init_bh */
 
+/* run any bottom half handlers flagged in bh_active */
 void do_bottom_half(void)
 {
     unsigned int active;

--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -6,15 +6,19 @@
 /*
  * Bottom half interrupt handler support (softirq's)
  *
- * Top half interrupt handlers should quickly perform hardware data acquisition,
- * then call mark_bh to request deferred execution of the bottom half handler
- * registered with init_bh, for non-interrupt-priority tasks like wake_up, etc.
+ * Top half interrupt handlers should quickly perform hardware data acquisition or
+ * extremely high-priority tasks, then call mark_bh to request deferred execution of a
+ * bottom half handler registered with init_bh for lesser-priority tasks like wake_up,
+ * etc. that can be performed after the end of hardware interrupt is sent to the PIC.
  *
- * All BH handlers run in interrupt context, which means they can't sleep,
- * can't access user space through current, and can't reschedule.
+ * BH handlers run with interrupts enabled in an interrupt context similar to the
+ * top half, but while TH handlers run before the PIC EOI is sent, BH handlers
+ * execute afterwards, thus allowing further PIC interrupts of any priority to run.
+ * A BH handler may be interrupted by any top-half interrupt, but are protected
+ * from being re-entered, so they don't need to be reentrant.
  *
- * Interrupts are enabled and a BH handler may be interrupted by any hardware
- * interrupt, but are protected from being re-entered, so don't need to be reentrant.
+ * Since BH handlers run in an interrupt context, they can't sleep, can't access user
+ * space, and can't reschedule.
  *
  * 6 Dec 25 Greg Haerr
  */

--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -1,0 +1,38 @@
+#include <linuxmt/config.h>
+#include <linuxmt/mm.h>
+#include <linuxmt/sched.h>
+#include <arch/irq.h>
+
+/*
+ * Run bottom-half interrupt handlers
+ *
+ * 6 Dec 25 Greg Haerr
+ */
+
+unsigned int bh_active;
+void (*bh_base[MAX_SOFTIRQ])(void);
+
+void do_bottom_half(void)
+{
+    unsigned int active;
+    unsigned int mask, left;
+    void (**bh)(void);
+
+#if DEBUG
+    /* running on interrupt or kernel stack? - may run on either */
+    if (getsp() >= endistack && getsp() < istack)
+        printk("I");                /* called from idle task */
+    else printk("K");               /* called after syscall or user mode interrupt */
+    printk("{B%d}", intr_count);
+#endif
+
+    bh = bh_base;
+    active = bh_active;
+    for (mask = 1, left = ~0; left & active; bh++, mask += mask, left += left) {
+        if (mask & active) {
+            bh_active &= ~mask;
+            if (*bh)
+                (*bh)();
+        }
+    }
+}

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -19,15 +19,17 @@ typedef void (* int_proc) (void);  // any INT handler
 typedef void (* irq_handler) (int,struct pt_regs *);   // IRQ handler
 
 void do_IRQ(int,struct pt_regs *);
-void div0_handler(int, struct pt_regs *);
-void nmi_handler(int, struct pt_regs *);
 int request_irq(int,irq_handler,int hflag);
 int free_irq(int irq);
 
 /* irqtab.S */
 void _irqit (void);
 void int_vector_set (int vect, word_t proc, word_t seg);
+void idle_halt(void);
 void div0_handler_panic(void);
+
+void div0_handler(int, struct pt_regs *);   /* UNUSED for now*/
+void nmi_handler(int, struct pt_regs *);
 
 /* irq-8259.c, irq-8018x.c, irq-necv25.c */
 void initialize_irq(void);
@@ -36,7 +38,18 @@ void disable_irq(unsigned int irq);
 int remap_irq(int);
 int irq_vector(int irq);
 
-void idle_halt(void);
+/* softirq.c */
+enum {
+    TIMER_BH = 0,
+    SERIAL_BH,
+    MAX_SOFTIRQ
+};
+extern unsigned int bh_active;
+extern void (*bh_base[MAX_SOFTIRQ])(void);
+#define init_bh(nr, routine)    { bh_base[nr] = routine; }
+#define mark_bh(nr)             { bh_active |= 1 << nr;  }
+void do_bottom_half(void);
+
 #endif /* __ASSEMBLER__ */
 #endif /* __KERNEL__ */
 

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -26,10 +26,9 @@ int free_irq(int irq);
 void _irqit (void);
 void int_vector_set (int vect, word_t proc, word_t seg);
 void idle_halt(void);
-void div0_handler_panic(void);
 
-void div0_handler(int, struct pt_regs *);   /* UNUSED for now*/
-void nmi_handler(int, struct pt_regs *);
+void div0_handler(int irq, struct pt_regs *regs);
+void nmi_handler(int irq, struct pt_regs *regs);
 
 /* irq-8259.c, irq-8018x.c, irq-necv25.c */
 void initialize_irq(void);

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -5,8 +5,8 @@
 
 extern seg_t kernel_cs, kernel_ds;
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
-extern short endistack[];
-extern short endtstack[];
+extern short endistack[], istack[];
+extern short endtstack[], tstack[];
 extern unsigned int heapsize;
 
 #endif

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -114,6 +114,8 @@ extern void set_serial_irq(int tty, int irq);
 
 extern void set_console(dev_t dev);
 
+extern void serial_bh(void);
+
 #ifdef CONFIG_CONSOLE_DIRECT
 extern unsigned VideoSeg;
 #endif

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -169,6 +169,7 @@ extern void put_ustack(register struct task_struct *,int,int);
 
 extern void tswitch(void);
 extern void setsp(void *);
+extern short *getsp(void);
 extern int run_init_process(const char *cmd);
 extern int run_init_process_sptr(const char *cmd, char *sptr, int slen);
 extern void ret_from_syscall(void);

--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -25,10 +25,11 @@ struct timer_list {
 /* sched.c*/
 void add_timer(struct timer_list *);
 int del_timer(struct timer_list *);
-void do_timer(void);
+void run_timer_list(void);
 
 /* timer.c*/
 void timer_tick(int, struct pt_regs *);
+void timer_bh(void);
 void spin_timer(int);
 
 /* timer-8254.c*/

--- a/elks/include/linuxmt/trace.h
+++ b/elks/include/linuxmt/trace.h
@@ -30,7 +30,7 @@
 #define CHECK_BLOCKIO
 
 /* integrity check application SS on interrupts from user mode */
-#define CHECK_SS
+#undef CHECK_SS
 
 /* check buffer and inode free counts, list inodes w/^N and buffers w/^O */
 #define CHECK_FREECNTS

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -74,6 +74,9 @@ void schedule(void)
     }
 #endif
 
+    if (bh_active)
+        do_bottom_half();
+
     /* Disallow rescheduling during startup when idle task is the only task */
     if ((int)last_pid <= 0)
         return;
@@ -164,7 +167,7 @@ int del_timer(struct timer_list * timer)
     return 0;
 }
 
-static void run_timer_list(void)
+void run_timer_list(void)
 {
     struct timer_list *timer;
 
@@ -176,17 +179,6 @@ static void run_timer_list(void)
         clr_irq();
     }
     set_irq();
-}
-
-void do_timer(void)
-{
-    jiffies++;
-
-    /***if (!((int) jiffies & 7))
-        need_resched = 1;***/       /* how primitive can you get? */
-
-    run_timer_list();
-
 }
 
 void INITPROC sched_init(void)

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -123,14 +123,12 @@ int chq_peek(struct ch_queue *q)
     return (q->len != 0);
 }
 
-#if defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3)
 int chq_peekch(struct ch_queue *q)
 {
     if (q->len)
         return q->base[q->tail];
     return 0;
 }
-#endif
 
 #if UNUSED
 int chq_full(register struct ch_queue *q)

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -126,14 +126,9 @@ int chq_peek(struct ch_queue *q)
 #if defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3)
 int chq_peekch(struct ch_queue *q)
 {
-    int retval;
-
-    if (!q->len)
-        return 0;
-    clr_irq();
-    retval = q->base[q->tail];
-    set_irq();
-    return retval;
+    if (q->len)
+        return q->base[q->tail];
+    return 0;
 }
 #endif
 


### PR DESCRIPTION
This PR implements Linux 2.0-style "bottom-half" or "softirq" interrupt handlers into the ELKS kernel. This is a major enhancement, that with proper reprogramming of various device drivers, allows interrupt handlers to be effectively split in half, where the "top" portion runs under the "original" interrupt context for extreme hardware time-sensitive tasks, while less important code can be deferred for execution outside of the 8259 PIC (or other) interrupt priority, which effectively disallows  other hardware devices to be serviced promptly.

The "bottom half" deferred execution handler names by convention end with \_bh, and this PR implements the timer_bh and serial_bh bottom halves for the IRQ 0 hardware timer and IRQ 4 and 3 serial receive interrupt. To do this, the original timer_irq and rs_fast_irq4 (with CONFIG_FAST_IRQ4 now default enabled) routines are halved. The timer_bh bottom half increments jiffies, then calls `mark_bh(TIMER_BH)` which schedules timer_bh for later execution outside the IRQ 0 interrupt. During kernel init, `init_bh(TIMER_BH, timer_bh)` is called to set the function to call when marked.

The backend timer_bh routine, usually run directly after the IRQ 0 EOI (but not always, its complicated) runs with interrupts enabled, just like the interrupt handler still does, but is guaranteed non-reentrant by the kernel. For timer_bh, it runs the kernel timer lists, the CPU usage calculations for `ps`, "pumps" the received serial characters that are queued by the fast IRQ4 interrupt to wake_up waiting tasks, and runs the disk I/O spinwheel. All of these were previously run *during* the PIC's IRQ 0 interrupt, which effectively disabled any other interrupts for quite a long period every 10ms. Now, the timer_bh runs after the IRQ 0 EOI, but remains interruptible (but not reschedule-able) so that fast serial input or network packet interrupts can execute immediately, interrupting the bottom half.

Essentially, the bottom half portion of any interrupt handler now runs outside of interrupt context, but still runs in kernel context, which, just like the kernel, is non-reentrant (except for top-half interrupt handlers, of course, except they're also protected from reentry by the PIC).

Sound complicated? It is. But for the driver writer, it's not too bad, as an old-style handler can be split into two, servicing the hardware (as quick as possible into a queue/buffer), then scheduling the backend to run with mark_bh. It is very important to run the wake_up() etc calls in the bottom half, as wake_up is very time consuming.

A quick discussion of bottom halves in Linux Kernel Internals 2.0 is [here (page 205, Section 7.2.4)](http://www.staroceans.org/kernel-and-driver/Addison%20Wesley%20-%20Linux%20Kernel%20Internals%202Nd%20Ed.pdf). Another [article](https://thinkty.net/general/2024/04/29/bottom_half.html) is available. Note that Linux implements many different types of "bottom halves" - SoftIRQs, Tasklets, Task Queues, Work Queues, and Threaded Interrupts. I've only implemented SoftIRQs, which are very basic but all we need for ELKS.

Also discussed a bit in https://github.com/Mellvik/TLVC/pull/211#issuecomment-3620566893, https://github.com/ghaerr/elks/issues/2457#issuecomment-3551620305,  https://github.com/ghaerr/elks/issues/2457#issuecomment-3551620305 and https://github.com/ghaerr/elks/pull/2502#issuecomment-3623082246.

Right now, include/arch/irq.h defines the following bottom halves:
```
enum {
    TIMER_BH = 0,
    SERIAL_BH,
    MAX_SOFTIRQ
};
```
Which means that a developer may need to add a new type for their own device driver(s), such as NETWORK_IRQ. All this does is allocate another entry in an array of function pointer to call when mark_bh is called. The new function `do_bottom_half` in elks/arch/i86/kernel/softirq.c then loops through the active_bh (mask bits) to see which, if any, bottom halves to call.

@swausd, look at the IBM PC 8250 serial driver in serial-8250.c::rs_fast_irq4(). While a bit complicated since it's called directly from an interrupt vector outside of \_irqit (for speed) and runs with SS != DS, it effectively just queues a received character during serial interrupt pre-EOI period, then the timer interrupt bottom half (every 10ms) ends up calling serial_bh that calls wake_up. This can be done slightly differently, as noted in the driver, where mark_bh(SERIAL_BH) is called which will then run the wake_up directly after the hardware interrupt. Let me know if you have questions.

@Mellvik, this will be a little more complicated for the network drivers, since after reviewing them, I notice that wake_up and other admin stuff is called potentially in multiple places in the interrupt handler. So you'll have to think about how or whether you can easily split them into two parts. Note this is entirely optional though, and the NIC interrupt is much lower priority than serial or timer, so you might get away with doing nothing, since the serial and timer interrupts now run much quicker.

Enough theory for now. I've tested this only on QEMU, and ~think~hope that it will work well on real hardware. I'd like to see if either of you can test this PR on real hardware before I commit, just in case, since going backwards will be harder. I've tested it pretty hard throughout the day and it seems pretty solid, since the basic hardware interrupt path remains unchanged.

Finally, this PR fixes a terribly broken divide-by-zero handler, which now works from both kernel and user mode (displays DIVIDE FAULT and kills the program), and also introduces an NMI handler (displays NMI FAULT).

Feel free to ask questions.
