### PR TITLE
[ktcp] Don't delete retransmit buffers when retrans memory full

### DIFF
--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -146,12 +146,13 @@ void eth_sendpacket(unsigned char *packet, int len, eth_addr_t eth_addr)
 	ipll->ll_type_len = 0x08; //FIXME what is 0x0800
 
 #if FORCE_MISSING_PACKET        /* For debugging: Create errors */
-    static int failcnt = 0;
-    if (failcnt++ > FORCE_MISSING_PACKET)
-        failcnt = 0;
-    else
+	static int failcnt = 0;
+	if (failcnt++ > FORCE_MISSING_PACKET)
+		failcnt = 0;
+	else
 #endif
-    eth_write((unsigned char *)ipll, sizeof(struct ip_ll) + len);
+
+	eth_write((unsigned char *)ipll, sizeof(struct ip_ll) + len);
 }
 
 /* raw ethernet packet send*/

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -135,7 +135,7 @@ struct tcpcb_s {
 
 	__u8	state;
 	__u8	unaccepted;		/* boolean */
-	__u8	retrans_act;		/* set when a retrans has been sent */
+	__u8	retrans_act;		/* set when a retrans has been sent on a connection */
 	__u16	rtt;			/* roundtriptime */
 	__u16	cwnd;			/* congestion window */
 	__u16	inflight;		/* # of unacked packets for this cb */
@@ -169,7 +169,7 @@ struct tcpcb_s {
 	__u8	buf_base[];
 };
 
-/* TCP options*/
+/* TCP options */
 #define TCP_OPT_EOL		0
 #define TCP_OPT_NOP		1
 #define TCP_OPT_MSS		2
@@ -183,19 +183,17 @@ struct	tcpcb_list_s {
 };
 
 struct	tcp_retrans_list_s {
-	struct tcp_retrans_list_s	*prev;
-	struct tcp_retrans_list_s	*next;
-
-	int				retrans_num;
-	__u16	 			rto;
-	timeq_t 			next_retrans;
-	timeq_t 			first_trans;
-
-	struct tcpcb_s			*cb;
-	struct addr_pair		apair;
-	__u16				len;
-	struct tcphdr_s 		tcphdr[];
-
+	struct tcp_retrans_list_s *prev;
+	struct tcp_retrans_list_s *next;
+	int		retrans_num;	/* retrans counter for this packet */
+	__u16	 	rto;		/* retrans timeout */
+	timeq_t 	next_retrans;	/* time to resend, initially first_trans + rto */
+	timeq_t 	first_trans;	/* time initially sent */
+	struct tcpcb_s *cb;		/* connection this packet belongs to */
+	struct addr_pair apair;		/* actual addr, may be different
+					 * from packet addr for routing */
+	__u16		len;		/* data length, placed after header */
+	struct tcphdr_s tcphdr[];
 };
 
 extern int tcp_timeruse;        /* retrans timer active, call tcp_retrans */

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -135,7 +135,7 @@ struct tcpcb_s {
 
 	__u8	state;
 	__u8	unaccepted;		/* boolean */
-	__u8	retrans_act;		/* set when a retrans has been sent on a connection */
+	__u8	retrans_act;		/* set when a retrans has been sent */
 	__u16	rtt;			/* roundtriptime */
 	__u16	cwnd;			/* congestion window */
 	__u16	inflight;		/* # of unacked packets for this cb */

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -138,14 +138,14 @@ static void tcpdev_accept(void)
 
     n = tcpcb_find_by_sock(sock);
     if (!n || n->tcpcb.state != TS_LISTEN) {
-	retval_to_sock(db->sock,-EINVAL);
+	retval_to_sock(db->sock, -EINVAL);
 	return;
     }
     cb = &n->tcpcb;
     newn = tcpcb_find_unaccepted(sock);
     if (!newn) {			/* SYN not yet received by listen*/
 	if (db->nonblock)
-	    retval_to_sock(db->sock,-EAGAIN);
+	    retval_to_sock(db->sock, -EAGAIN);
 	else
 	    cb->newsock = db->newsock;	/* save new sock in listen CB for later*/
 	debug_accept("tcp accept: WAIT (on SYN) sock[%p] saving newsock[%p]\n",
@@ -360,10 +360,8 @@ static void tcpdev_write(void)
      */
     size = db->size;
 
-    /* This is a bit ugly but I'm too lazy right now */
     if (tcp_retrans_memory > TCP_RETRANS_MAXMEM) {
 	printf("ktcp: RETRANS memory limit exceeded\n");
-	//retval_to_sock(sock, -ENOMEM);
 	retval_to_sock(sock, -ERESTARTSYS);	/* source will wait for 100ms, then retry */
 	return;
     }
@@ -379,6 +377,7 @@ static void tcpdev_write(void)
 
     if (cb->state != TS_ESTABLISHED
 		/*&& cb->state != TS_CLOSE_WAIT*/) {	// No write data if in CLOSE_WAIT
+	/* FIXME: May want to delete the printf below, this is not uncommon */
 	printf("tcpdev_write: write to socket in improper state %d\n", cb->state);
 	retval_to_sock(sock, -EPIPE);
 	return;


### PR DESCRIPTION
This PR adds @Mellvik's TLVC enhancement where the retransmit buffer was deleted when retrans memory was getting full on an active connection, causing a hang if any retransmission was needed.

As described in https://github.com/Mellvik/TLVC/pull/211, when the retransmit buffer memory is nearing capacity, an -ERESTARTSYS is already returned to the sending application to retry the write 100ms later.

Other changes in this PR updates ktcp with descriptive comments from TLVC ktcp. Thanks @Mellvik!

This concludes the changes made in ELKS and TLVC for https://github.com/ghaerr/elks/issues/2487, and our ktcp should now be in sync with TLVC.

@swausd, when you find time, please test this latest version on your hardware, as the final fix for #2487.