### PR TITLE
[kernel] Fix problems associated with ^Z/SIGTSTP (terminal stop)

### DIFF
--- a/dosbox.sh
+++ b/dosbox.sh
@@ -1,19 +1,22 @@
-# Helper to run PC98 images in DosBoxX (dosbox-x-sdl2)
+# Helper to run PC98 or IBM PC images in DosBoxX (dosbox-x-sdl2)
 #
 
-# 1232k image from './buildimages.sh fast'
+# PC98 1232k image from './buildimages.sh fast'
 #exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd1232-pc98.img"
 
-# just-built 1232k image
-exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd1232.img"
+# just-built PC98 1232k image
+#exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd1232.img"
 
 #exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "imgmount -size 1024,8,2,77 C image/fd1232.img"
 
-# 1440k image
+# 1440k PC98 image
 #exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd1440-pc98.img"
 
-# 1440k IBM image
+# 1440k IBM MINIX image
 #exec ./dosbox-x-sdl2 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd1440.img"
 
-# 2880k IBM image
+# 2880k IBM MINIX image
+exec ./dosbox-x-sdl2 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd2880.img"
+
+# 2880k IBM FAT image
 #exec ./dosbox-x-sdl2 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd2880-fat.img"

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -162,6 +162,8 @@ int tty_open(struct inode *inode, struct file *file)
     if (MINOR(inode->i_rdev) == 255)
         return 0;
 
+    debug_tty("TTY open pid %P session %d pgrp %d ttygrp %d tty %x\n",
+        current->session, current->pgrp,  otty->pgrp, current->tty);
     err = otty->ops->open(otty);
     if (!err) {
         if (!(file->f_flags & O_NOCTTY) && current->session == current->pid

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -48,8 +48,8 @@ int do_signal(void)
 			(SM_SIGSTOP | SM_SIGTSTP | SM_SIGTTIN | SM_SIGTTOU)) {
 		debug_sig("SIGNAL pid %P stopped\n");
 		current->state = TASK_STOPPED;
-		/* Let the parent know */
-		current->exit_status = signr;
+		current->exit_status = signr;		/* Let the parent know */
+		wake_up(&current->p_parent->child_wait);
 		schedule();
 	    }
 	    else {					/* Default Core or Terminate */

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -40,14 +40,15 @@ int sys_wait4(pid_t pid, int *status, int options, void *usage)
     register struct task_struct *p;
     int waitagain;
 
-    debug_wait("WAIT(%P) for %d %s\n", pid, (options & WNOHANG)? "nohang": "");
+    debug_wait("WAIT(%P) for %d opts %x\n", pid, options);
 
  for (;;) {
     waitagain = 0;
 
     for_each_task(p) {
         if (p->p_parent == current && p->state != TASK_UNUSED) {
-          if (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED) {
+          if (p->state == TASK_ZOMBIE ||
+             (p->state == TASK_STOPPED && (options & WUNTRACED))) {
             if (pid == (pid_t)-1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
                 if (status) {
                     if (verified_memcpy_tofs(status, &p->exit_status, sizeof(int)))
@@ -65,7 +66,7 @@ int sys_wait4(pid_t pid, int *status, int options, void *usage)
                 debug_wait("WAIT(%P) got %d\n", p->pid);
                 return p->pid;
             }
-        } else {
+        } else if (p->state != TASK_STOPPED || (options & WUNTRACED)) {
             /* keep waiting while process has non-zombie/stopped children*/
             debug_wait("WAIT(%P) again for pid %d state %d\n", p->pid, p->state);
             waitagain = 1;
@@ -138,7 +139,6 @@ void do_exit(int status)
     current->state = TASK_ZOMBIE;
     wake_up(&parent->child_wait);
     schedule();
-    panic("sys_exit");
 }
 
 void sys_exit(int status)

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -27,6 +27,12 @@ static void reparent_children(void)
             if (p->state != TASK_UNUSED) {
                 debug_wait("Reparenting orphan pid %d ppid %d to init\n",
                     p->pid, p->p_parent->pid);
+
+                /* release TTY process group and original session */
+                if (p->tty && (p->tty->pgrp == current->pid))
+                    p->tty->pgrp = 0;
+                p->session = p->pgrp = p->pid;
+
                 p->p_parent = &task[1];
                 p->ppid = task[1].pid;
             }
@@ -139,6 +145,8 @@ void do_exit(int status)
     current->state = TASK_ZOMBIE;
     wake_up(&parent->child_wait);
     schedule();
+    /* no return */
+    halt();
 }
 
 void sys_exit(int status)

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -602,7 +602,7 @@ runcmd(char *cmd, int argc, char **argv)
 			status = 0;
 			intcrlf = FALSE;
 
-			while ((ret = waitpid(pid, &status, 0)) != pid)
+			while ((ret = waitpid(pid, &status, 0)) != pid && ret != -1)
 				continue;
 
 			intcrlf = TRUE;


### PR DESCRIPTION
Fixes various problems with the ELKS kernel and `sash` not working when a process is stopped via the terminal using ^Z (SIGTSTP). 

Discovered in https://github.com/ghaerr/elks/pull/2506#issuecomment-3633500546.

Previously, when the VSUSP character was typed (default ^Z), the process was stopped but any waiting processes (e.g. the shell) weren't awakened, so the system appeared hung.

It was also found that `sash` was hanging in a `waitpid` loop waiting for the last job to complete which looped forever when a process was stopped, a separate problem. The `waitpid` syscall was waiting for stopped jobs, which is only supposed to happen when the WUNTRACED option is passed, so this was fixed too.

Finally, when a stopped job's parent died (e.g. the shell was exited after stopping a process), the stopped child process was not releasing its TTY group or session. This prevented the new shell from becoming a process group leader, which led to ^C or ^Z signals not working when typed.

This took awhile to get right, and I'm still wondering what the difference between a process session and a process group is.

It was also learned that one can't `kill` a stopped job with anything other than SIGCONT (8, to continue), or SIGKILL (9, to force exit). Since the `ash` shell is not currently configured for jobs support (for size reasons), and `sash` doesn't support them, using `kill -8` is the only way to continue a stopped job, for now.