### PR TITLE
[kernel] Fix more problems with SIGTSPT (terminal stop)

### DIFF
--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -134,6 +134,7 @@ char *host_readLine() {
     static char buf[TOKEN_BUF_SIZE+1];
 
     tty_isig();
+    clearerr(stdin);
     while (!fgets(buf, sizeof(buf), stdin)) {
         if (ferror(stdin) && (errno == EINTR)) {
              clearerr(stdin);

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -321,6 +321,7 @@ static void readfile(char *name) {
 		}
 #endif
 
+		clearerr(fp);
 		if (fgets(buf, CMDLEN - 1, fp) == NULL) {
 			if (ferror(fp) && (errno == EINTR)) {
 				clearerr(fp);
@@ -600,9 +601,9 @@ runcmd(char *cmd, int argc, char **argv)
 
 		if (pid) {
 			status = 0;
-			intcrlf = FALSE;
+			//intcrlf = FALSE;
 
-			while ((ret = waitpid(pid, &status, 0)) != pid && ret != -1)
+			while ((ret = waitpid(pid, &status, WUNTRACED)) != pid)
 				continue;
 
 			intcrlf = TRUE;


### PR DESCRIPTION
More problems were found when playing with `sash` and `basic` when trying out the terminal stop ^Z facility. These fixes make terminal stop barely usable, but not recommended. 

Sash had to be further modified to wait also inspecting for stopped jobs before forking another command, since otherwise somehow `waitpid` was returning -1 early and not waiting for the previous command to complete.

This fix clears the error set in fread() when a stop signal ends up returning -EINTR and thus setting \_\_MODE_ERR in the stdin FILE \* handle. This caused either basic or sash to continue to cycle in their "fast" input fgets loop when trying to read stdin.

There are a lot of complications with using a non-job control shell and terminal stop. One of the major still unhandled problems has to do with continuing a process that was reading from stdin, when the shell is also reading from stdin. This causes multiple simultaneous reads on the same device, and is not currently handled. 

Using ^Z/stop with `sh` works terribly, due to `ash` setting raw mode on the file descriptor that both it and basic are using, while basic is expecting non-raw input. it's a mess.

It is highly recommended that ^Z/stop only be used for stopping jobs that are output-only, as any other use likely won't operate according to user expectations, due to two programs reading at the same time. I am considering disabling ^Z entirely but am leaving it in for experimentation.
