### PR TITLE
[kernel] Don't disable interrupts in block device request queue unless async I/O enabled

### DIFF
--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -21,6 +21,10 @@
 /* enable for async callback testing, requires CONFIG_ASYNCIO */
 //#define IODELAY     (5*HZ/100)  /* async time delay 5/100 sec = 50msec */
 
+#if defined(IODELAY) && !defined(CONFIG_ASYNCIO)
+#error  SSD IOTEST driver requires CONFIG_ASYNCIO
+#endif
+
 jiff_t ssd_timeout;
 
 sector_t ssd_num_sects;         /* max # sectors on SSD device */


### PR DESCRIPTION
Prompted from discussion in https://github.com/ghaerr/elks/pull/2506#issuecomment-3637742855.

Removes special handling of request queue lists when CONFIG_ASYNCIO is not configured. This allows execution of block driver read/writes with interrupts always enabled, which should allow for fast serial input during SD card I/O on systems without the direct floppy driver compiled in.

@swausd: Close inspection showed that the low level block device request queue management routines disabled interrupts while traversing the request queue. When CONFIG_ASYNCIO is not enabled (which is only required by the direct floppy driver when compiled in), the request queue size is 1, and thus no special handling is required.

Tested on IBM PC direct floppy on QEMU, and ROMFS build on emu86.