### PR TITLE
[kernel] Return standard exit status on stopped jobs

### DIFF
--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -48,7 +48,7 @@ void do_signal(void)
 			(SM_SIGSTOP | SM_SIGTSTP | SM_SIGTTIN | SM_SIGTTOU)) {
 		debug_sig("SIGNAL pid %P stopped\n");
 		current->state = TASK_STOPPED;
-		current->exit_status = signr;		/* Let the parent know */
+		current->exit_status = (signr<<8)|0x7f;	/* Let the parent know */
 		wake_up(&current->p_parent->child_wait);
 		schedule();
 		/* task continues here after SIGCONT */

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -610,6 +610,8 @@ runcmd(char *cmd, int argc, char **argv)
 			if ((status & 0xff) == 0)
 				return;
 
+			if (WIFSTOPPED(status))	/* signo in high byte when stopped*/
+				status >>= 8;
 			fprintf(stderr, "pid %d: %s (signal %d)\n", pid,
 				(status & 0x80) ? "core dumped" :
 				(((status & 0x7f) == SIGTSTP)? "stopped" : "killed"),

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -561,7 +561,7 @@ trybuiltin(int wildargc, char **wildargv, int argc, char **argv)
 static void
 runcmd(char *cmd, int argc, char **argv)
 {
-	int		pid, status, ret;
+	int		pid, status, ret, signo;
 
 	endpwent();
 	endgrent();
@@ -611,11 +611,10 @@ runcmd(char *cmd, int argc, char **argv)
 				return;
 
 			if (WIFSTOPPED(status))	/* signo in high byte when stopped*/
-				status >>= 8;
+				signo = status >> 8;
+			else signo = status & 0xff;
 			fprintf(stderr, "pid %d: %s (signal %d)\n", pid,
-				(status & 0x80) ? "core dumped" :
-				(((status & 0x7f) == SIGTSTP)? "stopped" : "killed"),
-				status & 0x7f);
+				WIFSTOPPED(status)? "stopped" : "killed", signo);
 
 			return;
 		}


### PR DESCRIPTION
Corrects process exit values returned by `waitpid(..., &status, ...)` etc to Linux standard. This now aligns with the WIF\* macros in <sys/wait.h>.

The standard values for integer value of `status` are:
```
Process status       High byte Low Byte
Normal termination   exitvalue 0
Signal termination   0         signo
Stopped              signo     0x7f
```

`sash` was updated to properly report stopped jobs and the stopping signal number (either SIGSTOP or SIGTSTP for now).
The Mar 3 1991 version of `ash` ELKS is using is hopelessly out of date and is fighting hard not to report on Stopped jobs. Comparison with a later May 4 1995 version has tons of code updates in jobs.c when using `waitpid(..., WUNTRACED)` but unfortunately I've not been able to even get it to compile. 

Good shell jobs support in ELKS looks pretty grim, since real support needs the addition of SIGTTIN and SIGTTOU signals, along with the missing `tcsetpgrp` and `tcgetptrp` ioctls for working with the controlling terminal.