### PR TITLE
Dockerfile: Add bison and flex to Dockerfile for successful binutils build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV USER=builder \
 WORKDIR /elks
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
-  texinfo libncurses5-dev \
+  texinfo libncurses5-dev bison flex \
   bash make g++ git libelf-dev patch \
   xxd ca-certificates wget mtools \
  && rm -r /var/lib/apt/lists /var/cache/apt/archives \


### PR DESCRIPTION
First of all, congratulations on this great project! It’s really impressive to see ELKS in action.

While running the Docker build command, I encountered two errors related to missing packages required to build binutils:
```
make[3]: Entering directory '/elks/cross/build/binutils-build/binutils'
  YACC     arparse.c
/elks/cross/build/binutils-src/missing: 81: bison: not found
WARNING: 'bison' is missing on your system.
         You should only need it if you modified a '.y' file.
         You may want to install the GNU Bison package:
         <http://www.gnu.org/software/bison/>
```
```
/elks/cross/build/binutils-src/missing: 81: flex: not found
WARNING: 'flex' is missing on your system.
         You should only need it if you modified a '.l' file.
         You may want to install the Fast Lexical Analyzer package:
         <http://flex.sourceforge.net/>
```
These errors were solved simply by adding bison and flex to the list of dependencies in the Dockerfile