### PR TITLE
[kernel] Fix sys_kill to send to process group when pid < 0

### DIFF
--- a/elkscmd/man/man1/kill.1
+++ b/elkscmd/man/man1/kill.1
@@ -3,8 +3,11 @@
 kill \- Send a process a signal
 .SH SYNOPSIS
 .B kill
-.B [\-signal]
-.I pid...
+.RB [ \-signo ]
+.RB [ -INT ]
+.RB [ -KILL ]
+.RB [ -HUP ]
+.I pid ...
 .SH DESCRIPTION
 .B kill
 send a signal to the process specified by each
@@ -17,8 +20,8 @@ process  group can be signalled by the negative value of the process group
 ID.  Signals may be numerical, or the name of the signal without SIG.
 .SS OPTIONS
 .TP 10
-.B "\-signal"
-The signal to be sent. May be HUP, INT QUIT or KILL, or a numeric signal number.
+.B "\-signo"
+The signal to be sent. May be INT, HUP or KILL, or a numeric signal number.
 .SH EXAMPLES
 .TP 20
 .B kill \-HUP 45
@@ -29,7 +32,7 @@ The signal to be sent. May be HUP, INT QUIT or KILL, or a numeric signal number.
 .TP 20
 .B kill \-INT 4 6 -23
 # Send the INT signal to
-the processes with ids 4 and 6 and the process group with 23.
+the processes with ids 4 and 6 and the process group 23.
 .SH EXIT STATUS
 .TP
 .I 0

--- a/elkscmd/man/man2/kill.2
+++ b/elkscmd/man/man2/kill.2
@@ -11,7 +11,6 @@ kill \- send signal to a process
 .SH SYNOPSIS
 .nf
 .ft B
-#include <sys/types.h>
 #include <signal.h>
 
 int kill(pid_t \fIpid\fP, int \fIsig\fP)
@@ -24,7 +23,7 @@ to a process, specified by the process number
 .IR pid .
 .I Sig
 may be one of the signals specified in
-.BR sigaction (2),
+.BR signal (2),
 or it may be 0, in which case
 error checking is performed but no
 signal is actually sent. 
@@ -34,10 +33,8 @@ This can be used to check the validity of
 The sending and receiving processes must
 have the same effective user ID, otherwise
 this call is restricted to the super-user.
-.ig
 A single exception is the signal SIGCONT, which may always be sent
 to any descendant of the current process.
-..
 .PP
 If the process number is 0,
 the signal is sent to all processes in the
@@ -89,5 +86,5 @@ of the group could not be signaled.
 .SH "SEE ALSO"
 .BR getpid (2),
 .BR getpgrp (2),
-.BR sigaction (2),
+.BR signal (2),
 .BR raise (3).

--- a/elkscmd/sys_utils/kill.c
+++ b/elkscmd/sys_utils/kill.c
@@ -14,7 +14,7 @@
 
 static void usage()
 {
-	errmsg("usage: kill [-<signo>|-INT|-KILL|-HUP] PID...\n");
+	errmsg("usage: kill [-<signo>|-INT|-KILL|-HUP] pid ...\n");
 	exit(1);
 }
 


### PR DESCRIPTION
The `kill` system call didn't work when passed a negative pid, effectively ignoring the call. Proper behavior is to send the specified signal to the process group specified by the positive value of the passed negative pid.

Updates `kill(1)` and `kill(2)` man pages.

Heavy cleanup of DEBUG_SIG display, with much more uniform and readable messages.