### PR TITLE
[kernel] Allow stopped jobs to be killed, update sash kill/SIGTERM handling

### DIFF
--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -27,6 +27,7 @@ void do_signal(void)
     unsigned int signr;
     sigset_t mask;
 
+top:
     signr = 1;
     mask = (sigset_t)1;
     while (current->signal) {
@@ -53,8 +54,8 @@ void do_signal(void)
 		wake_up(&current->p_parent->child_wait);
 		schedule();
 		/* task continues here after SIGCONT */
-		current->signal = 0;                    /* clear any SIGINT/SIGQUIT */
-		return;
+		current->signal &= ~(SM_SIGINT|SM_SIGQUIT|SM_SIGSTOP|SM_SIGTSTP);
+		goto top;
 	    }
 	    else {					/* Default Terminate */
 #if UNUSED
@@ -80,7 +81,7 @@ void do_signal(void)
 	    }
 	    return;
 	}
-	else /* else (*sd == SIGDISP_IGN) Ignore */
+	else /* (*sd == SIGDISP_IGN) Ignore */
 	    debug_sig("SIGNAL(%P) sig %d ignored\n", signr);
     }
 }

--- a/elkscmd/sash/cmds.c
+++ b/elkscmd/sash/cmds.c
@@ -864,11 +864,8 @@ do_kill(argc, argv)
 
 	while (argc-- > 1) {
 		cp = *++argv;
-		pid = 0;
-		while (isdecimal(*cp))
-			pid = pid * 10 + *cp++ - '0';
-
-		if (*cp) {
+		pid = atoi(cp);
+		if (!pid) {
 			fprintf(stderr, "Non-numeric pid\n");
 			return;
 		}

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -210,6 +210,7 @@ int main(int argc, char **argv)
 
 	signal(SIGINT, catchint);
 	signal(SIGQUIT, catchquit);
+	signal(SIGTERM, SIG_IGN);
 	signal(SIGTSTP, SIG_IGN);
 
 	/* check if we are /bin/sh*/


### PR DESCRIPTION
Previously, all of a stopped process' received signals were cleared when restarted via SIGCONT, which prevented sending SIGKILL via `kill -9 pid`. Now, only the SIGINT and SIGQUIT signals are cleared (as they may be sent to the process group by the TTY device), along with SIGSTOP and SIGTSTP. This allows all other signals to accumulate while the process is stopped, and then acted on immediately when continued.