### PR TITLE
[NECV25] Bottom Half interrupt drivers, Fast IRQ and Network support for the NEC V25 Port

### DIFF
--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -79,7 +79,7 @@ OBJS += console-serial-8018x.o
 endif
 
 ifdef CONFIG_CONSOLE_NECV25
-OBJS += console-serial-necv25.o
+OBJS += console-serial-necv25.o serfast.o
 endif
 
 ifdef CONFIG_ARCH_IBMPC

--- a/elks/arch/i86/drivers/char/console-serial-necv25.c
+++ b/elks/arch/i86/drivers/char/console-serial-necv25.c
@@ -324,14 +324,15 @@ static int sercon_open(struct tty *tty)
 {
     struct serial_info *port = &ports[0];
 
-    port->intrchar = 0;
-    init_bh(SERIAL_BH, serial_bh);
-
     /* increment use count, don't init if already open*/
     if (tty->usecount++)
         return 0;
     else
+    {
+        port->intrchar = 0;
+        init_bh(SERIAL_BH, serial_bh);
         return tty_allocq(tty, RSINQ_SIZE, RSOUTQ_SIZE);
+    }
 }
 
 /* check for SIGINT and wakeup waiting processes */

--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -76,3 +76,35 @@ asm_fast_irq3:
 	add	$4,%sp			// skip the trampoline DS:*irq
 	iret
 #endif
+
+#ifdef CONFIG_FAST_IRQ1_NECV25
+//
+// Entry for console-serial-necv25 top half interrupt handler, called by CALLF within dynamic handler
+//
+    .extern	sercon_fast_irq1_necv25
+    .global asm_fast_irq1_necv25
+asm_fast_irq1_necv25:
+    push    %ax         // save regs, uses 18 bytes of current stack
+    push    %bx
+    push    %cx
+    push    %dx
+    push    %ds
+
+    // Recover kernel data segment
+    // Was pushed by the CALLF of the dynamic handler
+    mov	%sp,%bx
+    mov	%ss:12(%bx),%ds
+
+    call	sercon_fast_irq1_necv25 // call special 2nd part of top half C handler
+                                    // which doesn't use any SS/SP/BP addressing
+
+    .word   0x920f                  // NEC V25 specific FINT (End Of Interrupt) instruction
+
+    pop     %ds			// restore regs
+    pop     %dx
+    pop     %cx
+    pop     %bx
+    pop     %ax
+    add     $4,%sp      // skip the trampoline DS:*irq
+    iret
+#endif

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -80,7 +80,7 @@ void timer_bh(void)
     calc_cpu_usage();
 #endif
 
-#if defined(CONFIG_CHAR_DEV_RS) && (defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3))
+#if defined(CONFIG_CHAR_DEV_RS) && (defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3)) || defined(CONFIG_FAST_IRQ1_NECV25)
     /* uncomment to process serial input every 10ms instead of serial irq bottom half */
     serial_bh();        /* check if received serial chars and call wake_up*/
 #endif

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -80,7 +80,8 @@ void timer_bh(void)
     calc_cpu_usage();
 #endif
 
-#if defined(CONFIG_CHAR_DEV_RS) && (defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3)) || defined(CONFIG_FAST_IRQ1_NECV25)
+#if (defined(CONFIG_CHAR_DEV_RS) && (defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3))) \
+    || defined(CONFIG_FAST_IRQ1_NECV25)
     /* uncomment to process serial input every 10ms instead of serial irq bottom half */
     serial_bh();        /* check if received serial chars and call wake_up*/
 #endif

--- a/elks/include/arch/necv25.h
+++ b/elks/include/arch/necv25.h
@@ -70,7 +70,7 @@
  *
  * Port.Pin  Name   Function Direction Used in
  * P1.0             special  in        do not change
- * P1.1             special  in        do not change
+ * P1.1      INTP0  special  in        NE200 NIC
  * P1.2             special  in        do not change
  * P1.3             special  in        do not change
  * P1.4             I/O      in
@@ -81,7 +81,7 @@
  * Port.Pin  Name   Function Direction Used in
  * P2.0      SDA    I/O      in/out    i2c-ll.S
  * P2.1      SCL    I/O      out       i2c-ll.S
- * P2.2             I/O      in        currently not used
+ * P2.2   ISA Reset I/O      out       startup code
  * P2.3      CS     I/O      out       spi-hw-necv25.S
  * P2.4      CS     I/O      out       spi-necv25.S
  * P2.5      CLK    I/O      out       spi-necv25.S
@@ -92,7 +92,7 @@
 // or startup code with these values before ELKS starts:
 #define NEC_PM1_DEF  0xbf
 #define NEC_PMC1_DEF 0x48
-#define NEC_PM2_DEF  0x84
+#define NEC_PM2_DEF  0x80
 #define NEC_PMC2_DEF 0x00
  
 // Other interrupt control registers
@@ -105,13 +105,17 @@
 #define NEC_TBIC  0xffec      /* Time base interrupt */
 
 // Interrupt Vector numbers
-#define NEC_INTTU0  0x1e      /* Timer 0 Interrupt */
-#define NEC_INTTU1  0x1e      /* Timer 1 Interrupt */
+#define NEC_INTTU0  0x1c      /* Timer 0 Interrupt */
+#define NEC_INTTU1  0x1d      /* Timer 1 Interrupt */
 #define NEC_INTTU2  0x1e      /* Timer 1 Interrupt */
 
 #define NEC_INTSE1  0x10      /* SIO1 Error Interrupt */
 #define NEC_INTSR1  0x11      /* SIO1 RX Interrupt */
 #define NEC_INTST1  0x12      /* SIO1 TX Interrupt */
+
+#define NEC_INTP0   0x18      /* External Interrupt 0 */
+#define NEC_INTP1   0x19      /* External Interrupt 1 */
+#define NEC_INTP2   0x1A      /* External Interrupt 2 */
 
 #define UART1_IRQ_RX  1       /* maps to interrupt NEC_INTSR1 */
 #define UART1_IRQ_TX  2       /* maps to interrupt NEC_INTST1 */

--- a/elks/include/arch/necv25.inc
+++ b/elks/include/arch/necv25.inc
@@ -92,6 +92,7 @@
 .set TMIC1,    0xff9d   /* Timer unit interrupt request control register 1 */
 .set TMIC2,    0xff9e   /* Timer unit interrupt request control register 2 */
 
+.set INTM,     0xff40   /* Interrupt mode register */
 .set EXIC0,    0xff4c   /* External interrupt 0 */
 .set EXIC1,    0xff4d   /* External interrupt 1 */
 .set EXIC2,    0xff4e   /* External interrupt 2 */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -106,6 +106,8 @@
 #define SYS_CAPS                0       /* no XT/AT capabilities */
 #define UTS_MACHINE             "NECV25"
 #define CONFIG_NECV25_FCPU      22118400UL /* external CPU crystal clock in Hz 14745600UL or 22118400UL */
+#define CONFIG_DEF_BAUD         B115200
+#define CONFIG_FAST_IRQ1_NECV25        /* Serial 1 */
 #endif /* CONFIG_ARCH_NECV25 */
 
 #ifdef CONFIG_ARCH_SWAN

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     else {
         /* default to /dev/ttyS0 if not run from serial port and no argument */
         if (strncmp(ttyname(STDIN_FILENO), "/dev/ttyS", 9) != 0)
-            port = "/dev/ttyS0";
+            port = DEFAULT_PORT;
     }
     if (port) {
         if ((fd = open(port, O_RDONLY|O_EXCL)) < 0) {

--- a/necv25.config
+++ b/necv25.config
@@ -28,7 +28,7 @@ CONFIG_CONSOLE_NECV25=y
 
 # CONFIG_BOOTOPTS is not set
 # CONFIG_ASYNCIO is not set
-CONFIG_CPU_USAGE=y
+# CONFIG_CPU_USAGE is not set
 # CONFIG_TIME_RTC_LOCALTIME is not set
 # CONFIG_TRACE is not set
 # CONFIG_TIMER_INT0F is not set
@@ -59,7 +59,9 @@ CONFIG_ROM_CHECKSUM_SIZE=64
 # Networking Support
 #
 
-# CONFIG_SOCKET is not set
+CONFIG_SOCKET=y
+CONFIG_INET=y
+# CONFIG_UNIX is not set
 
 #
 # Filesystem Support
@@ -68,7 +70,7 @@ CONFIG_ROM_CHECKSUM_SIZE=64
 CONFIG_MINIX_FS=y
 CONFIG_ROMFS_FS=y
 CONFIG_ROMFS_BASE=0x8000
-CONFIG_FS_FAT=y
+# CONFIG_FS_FAT is not set
 CONFIG_FS_EXTERNAL_BUFFER=y
 CONFIG_FS_NR_EXT_BUFFERS=16
 # CONFIG_FS_XMS is not set
@@ -118,7 +120,10 @@ CONFIG_PSEUDO_TTY=y
 # Network device drivers
 #
 
-# CONFIG_ETH is not set
+CONFIG_ETH=y
+CONFIG_ETH_NE2K=y
+# CONFIG_ETH_WD is not set
+# CONFIG_ETH_EL3 is not set
 
 #
 # Userland
@@ -138,12 +143,14 @@ CONFIG_APP_SYS_UTILS=y
 # CONFIG_APP_MISC_UTILS is not set
 # CONFIG_APP_TUI is not set
 # CONFIG_APP_NANOX is not set
-CONFIG_APP_BASIC=y
+# CONFIG_APP_BASIC is not set
 # CONFIG_APP_SCREEN is not set
 # CONFIG_APP_CRON is not set
 # CONFIG_APP_OTHER is not set
 # CONFIG_APP_TEST is not set
 # CONFIG_APP_BUSYELKS is not set
+CONFIG_APP_TAGS=":romprg|:ktcp|ftpd|"
+# CONFIG_APP_KTCP is not set
 # CONFIG_APP_MAN_PAGES is not set
 CONFIG_SYS_DEFSHELL_SASH=y
 # CONFIG_SYS_NO_BININIT is not set


### PR DESCRIPTION
This PR includes all changes for support of

- the Bottom Half interrupt handling
- Fast IRQ for serial port 1
- ISA bus IRQ interfacing for NE200 NIC in 8 bit mode

for the NEC V25 port.

And a small change to the sercat App (constant value for the default port was defined but not used)