### PR TITLE
[kernel,cmds] Revise waitpid for stopped jobs, enhance ash, sash & kill signal handling

### DIFF
--- a/elkscmd/man/man1/kill.1
+++ b/elkscmd/man/man1/kill.1
@@ -4,9 +4,13 @@ kill \- Send a process a signal
 .SH SYNOPSIS
 .B kill
 .RB [ \-signo ]
-.RB [ -INT ]
-.RB [ -KILL ]
 .RB [ -HUP ]
+.RB [ -INT ]
+.RB [ -STOP ]
+.RB [ -TSTP ]
+.RB [ -CONT ]
+.RB [ -KILL ]
+.RB [ -TERM ]
 .I pid ...
 .SH DESCRIPTION
 .B kill
@@ -14,24 +18,24 @@ send a signal to the process specified by each
 .I pid
 operand listed.
 .sp
-By default signal 15 (SIGTERM) is
-sent.  Process 0 means all the processes in the sender's process group.  A
-process  group can be signalled by the negative value of the process group
+By default signal 15 (SIGTERM) is sent.
+.\" Process 0 means all the processes in the sender's process group.
+A process  group can be signalled by the negative value of the process group
 ID.  Signals may be numerical, or the name of the signal without SIG.
 .SS OPTIONS
 .TP 10
 .B "\-signo"
-The signal to be sent. May be INT, HUP or KILL, or a numeric signal number.
+The signal to be sent. May be HUP, INT, STOP, TSTP, CONT, KILL or TERM, or a numeric signal number.
 .SH EXAMPLES
 .TP 20
 .B kill \-HUP 45
-# Send the HUP signal to process 45.
+# Send the SIGHUP signal to process 45.
 .TP 20
 .B kill \-9 2
-# Send 9, KILL, to the process with id 2.
+# Send 9, SIGKILL, to the process with id 2.
 .TP 20
 .B kill \-INT 4 6 -23
-# Send the INT signal to
+# Send the SIGINT signal to
 the processes with ids 4 and 6 and the process group 23.
 .SH EXIT STATUS
 .TP


### PR DESCRIPTION
Revised kernel handling of `waitpid` for stopped processes; now returns the stopped status just once, per spec. Note that the WUNTRACED flag has to be passed in order to get status of any stopped processes. This simplifies the kernel implementation a bit, since the kernel will never wait for a process to restart when WUNTRACED is passed, regardless of the WNOHANG flag.

The above fix allowed `ash` to be made to work with its builtin `jobs` command, which is now useful for displaying all background processes (both asynchronous commands started with '&' as well as any stopped commands). Note that actual "jobs" support is not implemented, so `fg` is not present. Nonetheless, the `jobs` enhancement allows a quicker way of finding background jobs without all the details of `ps`.

The `kill` command and the `sash` kill builtin now support many more signal names (rather than signal numbers) to be specified in the command line. This now allows using `kill -CONT pid` to continue a stopped process, or `kill -STOP pid` to stop one, for instance. The kill man page is also updated for full details.

Here's an example of running a program `a.out` which displays X's until stopped by ^Z or interrupted by ^C, and using `jobs` for displaying processes running under the shell:
<img width="832" height="540" alt="Screenshot 2025-12-12 at 1 41 09 PM" src="https://github.com/user-attachments/assets/3d63346e-b9c0-4cf5-a816-d5f9f82d472b" />

Note that stopping jobs that are waiting for input on the same terminal as the shell doesn't work well, and likely won't ever, due to the complications of implementing full job control in both the shell and kernel.