### PR TITLE
[cmds] Set CRNL input translation in sercat by default

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -362,7 +362,7 @@ again:
             ch = chq_getch(&tty->inq);
         }
 
-        if ((tty->termios.c_iflag & ICRNL) && (ch == '\r'))
+        if ((ch == '\r') && (tty->termios.c_iflag & ICRNL))
             ch = '\n';
 
         if (icanon) {

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -80,10 +80,10 @@ int main(int argc, char **argv)
     if (tcgetattr(fd, &org) >= 0) {
         new = org;
         new.c_lflag &= ~(ICANON | ISIG | ECHO | ECHOE | ECHONL);
-        new.c_iflag &= ~(ICRNL);
+        new.c_iflag |= ICRNL;
         new.c_cflag |= CS8 | CREAD;
-        new.c_cc[VMIN] = 255;           /* min bytes to read if VTIME = 0*/
-        new.c_cc[VTIME] = 1;            /* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
+        new.c_cc[VMIN] = 255; /* min bytes to read if VTIME = 0*/
+        new.c_cc[VTIME] = 1;  /* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
         tcsetattr(fd, TCSAFLUSH, &new);
     } else errmsg("Can't set termios\n");
     signal(SIGINT, sig_handler);


### PR DESCRIPTION
Sets `sercat` to translate CR -> NL on input data for easier comparison when pasting data, for easier comparison of input streams when testing. `sercat` exits on ^D, so sercat still can't handle binary input data well.

Very slightly speed up kernel processing of non-CR TTY input.