### PR TITLE
[kernel] Rearrange task structure to save kernel code space

### DIFF
--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -118,16 +118,12 @@ static int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg
         retword = (unsigned)&_heap_all;
         break;
     case MEM_GETJIFFADDR:
+    case MEM_GETUPTIME:
         retword = (unsigned)&jiffies;
         break;
     case MEM_GETSEGALL:
         retword = (unsigned)&_seg_all;
         break;
-    case MEM_GETUPTIME:
-#ifdef CONFIG_CPU_USAGE
-        retword = (unsigned)&uptime;
-        break;
-#endif
         /* fall thru */
     default:
         return -EINVAL;

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -21,15 +21,12 @@ volatile jiff_t jiffies;
 static int spin_on;
 
 #ifdef CONFIG_CPU_USAGE
-jiff_t uptime;
-
 static void calc_cpu_usage(void)
 {
     static int count = SAMP_FREQ;
     struct task_struct *p;
 
     current->ticks++;
-    uptime++;
     if (--count <= 0) {
         count = SAMP_FREQ;
         //unsigned int total = 0;

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -31,15 +31,10 @@ struct signal_struct {
 #define SEG_CODE        0
 #define SEG_DATA        1
 
+/* ordering this struct saves kernel code space using byte offsets for freq accesses */
 struct task_struct {
-
-/* Executive stuff */
-    struct xregs                t_xregs;    /* CS and kernel SP */
-    segoff_t                    t_enddata;  /* start of heap = end of data+bss */
-    segoff_t                    t_endbrk;   /* current break (end of heap) */
-    segoff_t                    t_begstack; /* start SP, argc/argv strings above */
-    segoff_t                    t_endseg;   /* end of data seg (data+bss+heap+stack) */
-    segoff_t                    t_minstack; /* min stack size */
+    unsigned char               state;
+    unsigned char               ticks;          /* CONFIG_CPU_USAGE counts 2 secs */
 
 /* Kernel info */
     pid_t                       pid;
@@ -54,27 +49,32 @@ struct task_struct {
     gid_t                       sgid;
 
 /* Scheduling + status variables */
-    unsigned char               state;
-    struct wait_queue           child_wait;
-    jiff_t                      timeout;        /* for select() */
-    struct wait_queue           *waitpt;        /* Wait pointer */
-    struct wait_queue           *poll[MAX_POLLFD]; /* polled queues */
     struct task_struct          *next_run;
     struct task_struct          *prev_run;
-    struct file_struct          files;          /* File system structure */
-    struct fs_struct            fs;             /* File roots */
-    struct segment              *mm[MAX_SEGS];  /* App code/data segments */
-    struct tty                  *tty;
     struct task_struct          *p_parent;
-    int                         exit_status;    /* process exit status*/
     struct inode                *t_inode;
+    struct tty                  *tty;
     sigset_t                    signal;         /* Signal status */
-    struct signal_struct        sig;            /* Signal block */
+    jiff_t                      timeout;        /* for select() */
+    int                         exit_status;    /* Stopped or exit status */
+    struct fs_struct            fs;             /* File roots */
+    struct wait_queue           *waitpt;        /* Wait pointer */
+    struct wait_queue           *poll[MAX_POLLFD]; /* select() poll queues */
+    struct segment              *mm[MAX_SEGS];  /* App code/data segments */
+    struct file_struct          files;          /* Open files */
+    struct signal_struct        sig;            /* Signal actions */
+    struct wait_queue           child_wait;     /* Wait for stopped/zombie status */
 
-#ifdef CONFIG_CPU_USAGE
+/* Executive stuff */
+    struct xregs                t_xregs;        /* User CS and kernel SP */
+    segoff_t                    t_enddata;      /* start of heap = end of data+bss */
+    segoff_t                    t_endbrk;       /* current break (end of heap) */
+    segoff_t                    t_begstack;     /* start SP, argc/argv strings above */
+    segoff_t                    t_endseg;       /* end of dataseg (data+bss+heap+stack) */
+    segoff_t                    t_minstack;     /* min stack size */
+
+/* Other */
     unsigned long               average;        /* fixed point CPU % usage */
-    unsigned char               ticks;          /* # jiffies / 2 seconds */
-#endif
 
 #ifdef CONFIG_SUPPLEMENTARY_GROUPS
 #define NGROUPS     13

--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -36,6 +36,4 @@ void spin_timer(int);
 void enable_timer_tick(void);
 void disable_timer_tick(void);
 
-extern jiff_t uptime;       /* uptime for CONFIG_CPU_USAGE */
-
 #endif

--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -36,8 +36,6 @@ void spin_timer(int);
 void enable_timer_tick(void);
 void disable_timer_tick(void);
 
-#ifdef CONFIG_CPU_USAGE
-extern jiff_t uptime;
-#endif
+extern jiff_t uptime;       /* uptime for CONFIG_CPU_USAGE */
 
 #endif

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -53,14 +53,10 @@ struct task_struct *find_empty_process(void)
     *t = *current;
     t->state = TASK_UNINTERRUPTIBLE;
     t->pid = get_pid();
-#ifdef CONFIG_CPU_USAGE
-    t->ticks = 0;
+    t->ticks = 0;                   /* for CONFIG_CPU_USAGE */
     t->average = 0;
-#endif
-#ifdef CHECK_KSTACK
-    t->kstack_max = 0;
+    t->kstack_max = 0;              /* for CHECK_KSTACK */
     t->kstack_prevmax = 0;
-#endif
     t->kstack_magic = KSTACK_MAGIC;
     t->next_run = t->prev_run = NULL;
     return t;


### PR DESCRIPTION
Rearranging the task structure members allows the task structure itself to be shortened by a couple bytes each due to better structure packing, and moving frequently accessed members to the top allowed for the compiler to emit ~100 bytes less code accessing these members by using byte rather than word offsets in the instructions.

Removed the CONFIG_CPU_USAGE ifdef in the task structure and most other code, except for the actual cpu calculations in timer.c, and display in ps.c. It was then found that the kernel `uptime` variable wasn't required, and `jiffies` was used instead, since their values are always identical. This slightly sped up the timer overhead. Overall system uptime can be displayed using `ps -u` or `uptime`.