### PR TITLE
[kernel] Remove t_xregs struct in task struct

### DIFF
--- a/elks/arch/i86/kernel/asm-offsets.c
+++ b/elks/arch/i86/kernel/asm-offsets.c
@@ -6,7 +6,7 @@ extern int TASK_USER_BX, TASK_USER_SI, TASK_USER_DI;
 
 void asm_offsets(void)
 {
-    TASK_KRNL_SP = offsetof(struct task_struct, t_xregs.ksp);
+    TASK_KRNL_SP = offsetof(struct task_struct, t_ksp);
     TASK_USER_DS = offsetof(struct task_struct, t_regs.ds);
     TASK_USER_AX = offsetof(struct task_struct, t_regs.ax);
     TASK_USER_SS = offsetof(struct task_struct, t_regs.ss);

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -539,7 +539,6 @@ static void FARPROC finalize_exec(struct inode *inode, segment_s *seg_code,
         currentp->mm[SEG_DATA] = seg_data;
     }
 
-    currentp->t_xregs.cs = seg_code->base;
     currentp->t_regs.ss = currentp->t_regs.es = currentp->t_regs.ds = seg_data->base;
     currentp->t_regs.sp = currentp->t_begstack;
 
@@ -592,7 +591,7 @@ static void FARPROC finalize_exec(struct inode *inode, segment_s *seg_code,
      * Arrange for our return from sys_execve onto the new
      * user stack and to CS:entry of the user process.
      */
-    arch_setup_user_stack(currentp, entry);
+    arch_setup_user_stack(currentp, entry, seg_code->base);
 }
 
 #ifdef CONFIG_EXEC_OS2

--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -33,11 +33,6 @@ struct pt_regs {
     __u16       ax, bx, cx, dx, di, si, orig_ax, es, ds, sp, ss;
 };
 
-struct xregs {
-    __u16       cs;     /* code segment to use in arch_setup_user_stack()*/
-    __u16       ksp;    /* saved kernel SP used by twsitch()*/
-};
-
 /* ordering of saved registers on user stack after interrupt entry*/
 struct uregs {
     __u16       bp, ip, cs, f;

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -77,6 +77,6 @@ extern int INITPROC crtc_probe(unsigned short crtc_base);
 extern void INITPROC crtc_init(int dev);
 
 extern void kfork_proc(void (*addr)());
-extern void arch_setup_user_stack(struct task_struct *, word_t entry);
+extern void arch_setup_user_stack(struct task_struct *, word_t entry, seg_t cseg);
 
 #endif

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -66,7 +66,7 @@ struct task_struct {
     struct wait_queue           child_wait;     /* Wait for stopped/zombie status */
 
 /* Executive stuff */
-    struct xregs                t_xregs;        /* User CS and kernel SP */
+    segoff_t                    t_ksp;          /* kernel SP used by tswitch */
     segoff_t                    t_enddata;      /* start of heap = end of data+bss */
     segoff_t                    t_endbrk;       /* current break (end of heap) */
     segoff_t                    t_begstack;     /* start SP, argc/argv strings above */


### PR DESCRIPTION
Simplifies low-level task creation, as t_xregs.cs was not required to be kept in the task structure.

Changes are part of an incremental approach to eliminating the large unneeded kernel stack (640-740 bytesfor the idle task, which will leave room for either more kernel heap or another task structure available for user processes.