### PR TITLE
[kernel] Eliminate startup temp stack

### DIFF
--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -46,7 +46,7 @@ _start:
 
         mov     %ds,%ax
         mov     %ax,%ss         // SS=ES=DS
-        mov     $tstack,%sp     // can't use kernel interrupt stack, must have temp stack
+        mov     $istack,%sp
 
         call    start_kernel    // no return
 
@@ -112,7 +112,7 @@ early_putchar:
         .global _endbss
         .extern kernel_cs
         .extern kernel_ds
-        .extern tstack
+        .extern istack
 
 _endtext:
         .word   0

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -453,9 +453,7 @@ int_vector_set:
         .data
         .global intr_count
         .global endistack
-        .global endtstack
         .global istack
-        .global tstack
         .extern current
         .extern previous
 
@@ -474,7 +472,3 @@ ssmsg:  .ascii "INVALID SS\0"
 endistack:
         .skip ISTACK_BYTES,0    // interrupt stack
 istack:
-
-endtstack:
-        .skip TSTACK_BYTES,0    // startup temp stack
-tstack:

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -183,19 +183,4 @@ void trace_end(unsigned int retval)
         check_kstack(n);
 }
 
-#if UNUSED
-void check_tstack(void)
-{
-    int i;
-
-    /* calc temp stack usage */
-    for (i=0; i<TSTACK_BYTES/2; i++) {
-        if (endtstack[i] != 0)
-            break;
-    }
-    i = (TSTACK_BYTES/2 - i) << 1;
-    printk("tstack usage %d\n", i);
-}
-#endif
-
 #endif /* CONFIG_TRACE */

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -6,7 +6,6 @@
 extern seg_t kernel_cs, kernel_ds;
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
 extern short endistack[], istack[];
-extern short endtstack[], tstack[];
 extern unsigned int heapsize;
 
 #endif

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -17,7 +17,6 @@
 #endif
 
 #define ISTACK_BYTES    512     /* Size of interrupt stack */
-#define TSTACK_BYTES    128     /* Size of temp startup stack */
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 


### PR DESCRIPTION
Eliminates the temporary 'tstack' stack previously used only at very early kernel startup. The system can now startup using the interrupt stack until sched_init executed, after which the kernel stack is set to the idle process stack, and then the rest of kernel_init is executed. Interrupts are guaranteed disabled until the stack is switched, so the temp stack is no longer required.

This saves 128 bytes in the kernel data segment, and is an incremental improvement to a future attempt at decreasing the size of the idle stack.