### PR TITLE
[kernel] Move idle task out of task[] array

### DIFF
--- a/elks/Makefile
+++ b/elks/Makefile
@@ -83,7 +83,7 @@ endif
 
 Image: $(TOPDIR)/include/autoconf.h tools
 	$(MAKE) $(ARCHIVES)
-	$(MAKE) init/main.o
+	$(MAKE) -C init main.o
 	$(MAKE) -C $(ARCH_DIR) Image
 
 setup: $(ARCH_DIR)/boot/setup

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -199,7 +199,7 @@ CFLAGS += -Wno-empty-body
 #CFLAGS += -Wstrict-prototypes
 #CFLAGS += -Wconversion
 CFLAGS += -Wextra -Wtype-limits
-#CFLAGS += -fno-defer-pop
+CFLAGS += -fno-defer-pop
 
 LD      = ia16-elf-ld.gold
 LDFLAGS = $(CPU_LD) -s

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -199,6 +199,7 @@ CFLAGS += -Wno-empty-body
 #CFLAGS += -Wstrict-prototypes
 #CFLAGS += -Wconversion
 CFLAGS += -Wextra -Wtype-limits
+#CFLAGS += -fno-defer-pop
 
 LD      = ia16-elf-ld.gold
 LDFLAGS = $(CPU_LD) -s

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -199,7 +199,7 @@ CFLAGS += -Wno-empty-body
 #CFLAGS += -Wstrict-prototypes
 #CFLAGS += -Wconversion
 CFLAGS += -Wextra -Wtype-limits
-CFLAGS += -fno-defer-pop
+#CFLAGS += -fno-defer-pop
 
 LD      = ia16-elf-ld.gold
 LDFLAGS = $(CPU_LD) -s

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -182,6 +182,7 @@ updct:
 #ifndef CONFIG_ARCH_SWAN
         sti                     // Reenable interrupts
 #endif
+
         mov     %sp,%bx         // Get pointer to pt_regs
         cbw
         push    %ax             // IRQ for later
@@ -470,5 +471,5 @@ ssmsg:  .ascii "INVALID SS\0"
         .bss
         .p2align 1
 endistack:
-        .skip ISTACK_BYTES,0    // interrupt stack
+        .skip INTRSTACK_BYTES,0 // interrupt stack
 istack:

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -182,7 +182,6 @@ updct:
 #ifndef CONFIG_ARCH_SWAN
         sti                     // Reenable interrupts
 #endif
-
         mov     %sp,%bx         // Get pointer to pt_regs
         cbw
         push    %ax             // IRQ for later

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -77,7 +77,7 @@ void kfork_proc(void (*addr)())
 
     t = find_empty_process();
 
-    /* t_regs values are invalid for idle task or handlers interrupting idle task */
+    /* t_regs values are nonexistent for idle task or handlers interrupting idle task */
     t->t_regs.ds = t->t_regs.es = t->t_regs.ss = kernel_ds;
     arch_build_stack(t, addr);
 }

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -77,10 +77,9 @@ void kfork_proc(void (*addr)())
 
     t = find_empty_process();
 
-    /* All other t_regs values invalid for idle task or handlers interrupting idle task */
+    /* t_regs values are invalid for idle task or handlers interrupting idle task */
     t->t_regs.ds = t->t_regs.es = t->t_regs.ss = kernel_ds;
-    if (addr)
-        arch_build_stack(t, addr);
+    arch_build_stack(t, addr);
 }
 
 /*

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -102,11 +102,11 @@ static void check_kstack(int n)
     static int maxistack;
 
     /* calc interrupt stack usage */
-    for (i=0; i<ISTACK_BYTES/2; i++) {
+    for (i=0; i<INTRSTACK_BYTES/2; i++) {
         if (endistack[i] != 0)
             break;
     }
-    i = (ISTACK_BYTES/2 - i) << 1;
+    i = (INTRSTACK_BYTES/2 - i) << 1;
     if (i > maxistack) {
         maxistack = i;
         printk("ISTACK NEW MAX %d\n", maxistack);

--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -48,7 +48,7 @@ void * heap_alloc (word_t size, byte_t tag);
 void heap_free (void * data);
 
 void heap_add (void * data, word_t size);
-void heap_init ();
-void heap_iterate (void (* cb) (heap_s * h));
+void heap_init (void);
+void heap_display (void);
 
 #endif

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -16,7 +16,9 @@
 #endif
 #endif
 
-#define ISTACK_BYTES    512     /* Size of interrupt stack */
+#define INTRSTACK_BYTES 512     /* Size of interrupt stack */
+
+#define IDLESTACK_BYTES 128     /* Size of idle task stack */
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -113,7 +113,7 @@ extern struct task_struct *next_task_slot;
 extern int max_tasks;
 extern int task_slots_unused;
 
-#define IDLESTACK_BYTES     128
+/* size of task struct up to stack area */
 #define TASK_KSTACK         (offsetof(struct task_struct, t_kstack))
 
 extern volatile jiff_t jiffies; /* ticks updated by the timer interrupt*/

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -109,6 +109,7 @@ struct task_struct {
 extern struct task_struct *task;
 extern struct task_struct *current;
 extern struct task_struct *next_task_slot;
+extern struct task_struct idle_task;
 extern int max_tasks;
 extern int task_slots_unused;
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -52,11 +52,11 @@ struct task_struct {
     struct task_struct          *next_run;
     struct task_struct          *prev_run;
     struct task_struct          *p_parent;
-    struct inode                *t_inode;
     struct tty                  *tty;
     sigset_t                    signal;         /* Signal status */
     jiff_t                      timeout;        /* for select() */
     int                         exit_status;    /* Stopped or exit status */
+    struct inode                *t_inode;
     struct fs_struct            fs;             /* File roots */
     struct wait_queue           *waitpt;        /* Wait pointer */
     struct wait_queue           *poll[MAX_POLLFD]; /* select() poll queues */
@@ -107,11 +107,14 @@ struct task_struct {
 //#define DEPRECATED    __attribute__ ((deprecated))
 
 extern struct task_struct *task;
+extern struct task_struct *idle_task;
 extern struct task_struct *current;
 extern struct task_struct *next_task_slot;
-extern struct task_struct idle_task;
 extern int max_tasks;
 extern int task_slots_unused;
+
+#define IDLESTACK_BYTES     128
+#define TASK_KSTACK         (offsetof(struct task_struct, t_kstack))
 
 extern volatile jiff_t jiffies; /* ticks updated by the timer interrupt*/
 extern pid_t last_pid;

--- a/elks/include/linuxmt/string.h
+++ b/elks/include/linuxmt/string.h
@@ -35,6 +35,7 @@ extern char *strstr(char *,char *);
 extern void *memscan(void *,int,size_t);
 extern long simple_strtol(const char *,int);
 extern int atoi(const char *);
+extern void hexdump(void *off, unsigned int seg, int count, int summary);
 
 /*
  * Include machine specific routines

--- a/elks/include/linuxmt/string.h
+++ b/elks/include/linuxmt/string.h
@@ -35,7 +35,7 @@ extern char *strstr(char *,char *);
 extern void *memscan(void *,int,size_t);
 extern long simple_strtol(const char *,int);
 extern int atoi(const char *);
-extern void hexdump(void *off, unsigned int seg, int count, int summary);
+extern void hexdump(void *off, unsigned int seg, int count, int flags);
 
 /*
  * Include machine specific routines

--- a/elks/init/Makefile
+++ b/elks/init/Makefile
@@ -25,4 +25,13 @@ NOINDENT	= main.c
 include $(BASEDIR)/Makefile-rules
 
 #########################################################################
+# Commands:
+
+all:    main.o
+
+main.o: main.c
+	$(CC) $(CFLAGS) -fno-defer-pop -c -o main.o main.c
+
+
+#########################################################################
 ### Dependencies:

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -141,7 +141,7 @@ void start_kernel(void)
      * since it overflows into relatively unused areas of the idle task's task_struct.
      */
     setsp(&idle_task->t_kstack[IDLESTACK_BYTES/2]); /* change to small idle task stack */
-    //hexdump(idle_task->t_kstack, kernel_ds, IDLESTACK_BYTES, 1);
+    hexdump(idle_task->t_kstack, kernel_ds, IDLESTACK_BYTES, 1);
 
     /*
      * In the call to schedule below, the init_task function will run, which

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -17,7 +17,6 @@
 #include <linuxmt/prectimer.h>
 #include <linuxmt/debug.h>
 #include <arch/segment.h>
-#include <arch/asm-offsets.h>
 #include <arch/ports.h>
 #include <arch/irq.h>
 #include <arch/io.h>
@@ -141,7 +140,7 @@ void start_kernel(void)
      * since it overflows into relatively unused areas of the idle task's task_struct.
      */
     setsp(&idle_task->t_kstack[IDLESTACK_BYTES/2]); /* change to small idle task stack */
-    hexdump(idle_task->t_kstack, kernel_ds, IDLESTACK_BYTES, 1);
+    //hexdump(idle_task->t_kstack, kernel_ds, IDLESTACK_BYTES, 1);
 
     /*
      * In the call to schedule below, the init_task function will run, which

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -97,10 +97,10 @@ static void init_task(void);
 
 /*
  * This function is called using the interrupt stack as a temporary stack.
- * The stack is then switched to an unused kernel task struct stack while
- * performing the majority of kernel initialization. After that, the stack
- * is switched again to the tiny idle task struct and then becomes the idle
- * task. Must be compiled using -fno-defer-pop, as otherwise stack pointer
+ * The stack is then switched to an unused task struct's kernel stack area while
+ * performing the majority of kernel initialization. After that, the stack is
+ * switched again to the tiny idle task struct stack area and then becomes the
+ * idle task. Must be compiled using -fno-defer-pop, as otherwise stack pointer
  * cleanup is delayed after function calls, which interferes with SP resets.
  */
 void start_kernel(void)
@@ -132,7 +132,7 @@ void start_kernel(void)
     /*
      * Set SP to the idle task struct. We then become the idle task and are only
      * switched to when the last runnable user mode process sleeps from its
-     * kernel stack and/or schedule() is called.
+     * kernel stack and schedule() is called.
      * As a result, the idle task always runs with intr_count 1, which guarantees
      * interrupt register saves will be on the interrupt stack, not the idle stack.
      *
@@ -146,8 +146,8 @@ void start_kernel(void)
     /*
      * In the call to schedule below, the init_task function will run, which
      * completes kernel initialization by mounting the root filesystem, then
-     * loads an executable and executes ret_from_syscall, and the system
-     * enters user mode until the next clock tick or system call.
+     * loads an executable and executes ret_from_syscall, and the system returns
+     * from the kernel and enters user mode until the next clock tick or system call.
      */
     while (1) {
 #ifdef CHECK_KSTACK

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -38,7 +38,6 @@ static pid_t get_pid(void)
 struct task_struct *find_empty_process(void)
 {
     register struct task_struct *t;
-    int n;
 
     if (task_slots_unused <= 1) {
         printk("Only %d task slots\n", task_slots_unused);
@@ -52,9 +51,9 @@ struct task_struct *find_empty_process(void)
     }
     next_task_slot = t;
     task_slots_unused--;
-    n = (current == idle_task)?
-        (TASK_KSTACK+IDLESTACK_BYTES): sizeof(struct task_struct);
-    memcpy(t, current, n);
+    memcpy(t, current,
+        (current == idle_task)? (TASK_KSTACK+IDLESTACK_BYTES)
+                              : sizeof(struct task_struct));
     t->state = TASK_UNINTERRUPTIBLE;
     t->pid = get_pid();
     t->ticks = 0;                   /* for CONFIG_CPU_USAGE */

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -10,7 +10,7 @@
 
 int task_slots_unused;
 struct task_struct *next_task_slot;
-pid_t last_pid = -1;
+pid_t last_pid = 0;
 
 static pid_t get_pid(void)
 {
@@ -46,7 +46,7 @@ struct task_struct *find_empty_process(void)
     t = next_task_slot;
     while (t->state != TASK_UNUSED) {
         if (++t >= &task[max_tasks])
-            t = &task[1];
+            t = &task[0];
     }
     next_task_slot = t;
     task_slots_unused--;

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -1,6 +1,7 @@
 #include <linuxmt/config.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/kernel.h>
+#include <linuxmt/string.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/trace.h>
@@ -37,6 +38,7 @@ static pid_t get_pid(void)
 struct task_struct *find_empty_process(void)
 {
     register struct task_struct *t;
+    int n;
 
     if (task_slots_unused <= 1) {
         printk("Only %d task slots\n", task_slots_unused);
@@ -50,7 +52,9 @@ struct task_struct *find_empty_process(void)
     }
     next_task_slot = t;
     task_slots_unused--;
-    *t = *current;
+    n = (current == idle_task)?
+        (TASK_KSTACK+IDLESTACK_BYTES): sizeof(struct task_struct);
+    memcpy(t, current, n);
     t->state = TASK_UNINTERRUPTIBLE;
     t->pid = get_pid();
     t->ticks = 0;                   /* for CONFIG_CPU_USAGE */

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -51,7 +51,7 @@ struct task_struct *find_empty_process(void)
     }
     next_task_slot = t;
     task_slots_unused--;
-    memcpy(t, current,
+    memcpy(t, current,              /* duplicate current task data into new one */
         (current == idle_task)? (TASK_KSTACK+IDLESTACK_BYTES)
                               : sizeof(struct task_struct));
     t->state = TASK_UNINTERRUPTIBLE;

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -23,6 +23,12 @@ int max_tasks = MAX_TASKS;
 
 void add_to_runqueue(register struct task_struct *p)
 {
+#if UNUSED
+    if (p->next_run || p->prev_run)
+        panic("task already add_to_runq\n");
+    if (!idle_task->prev_run || !idle_task->next_run)
+        panic("idle add_to_runq");
+#endif
     (p->prev_run = idle_task->prev_run)->next_run = p;
     p->next_run = idle_task;
     idle_task->prev_run = p;
@@ -30,7 +36,7 @@ void add_to_runqueue(register struct task_struct *p)
 
 static void del_from_runqueue(register struct task_struct *p)
 {
-#ifdef CHECK_SCHED
+#if UNUSED
     if (!p->next_run || !p->prev_run)
         panic("delrunq %d,%d", p->pid, p->state);   /* task not on run queue */
     if (p == idle_task)
@@ -200,7 +206,7 @@ void INITPROC sched_init(void)
     t->state = TASK_RUNNING;
     t->kstack_magic = KSTACK_MAGIC;
     t->next_run = t->prev_run = t;
-    memset(t->t_kstack, 0xff, IDLESTACK_BYTES);
+    //memset(t->t_kstack, 0xff, IDLESTACK_BYTES);   /* for debugging idle stack size */
 
     current = t;
     next_task_slot = task;

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -67,7 +67,7 @@ void schedule(void)
     struct task_struct *prev;
     struct task_struct *next;
     jiff_t timeout = 0UL;
-    struct timer_list timer;    // 16
+    struct timer_list timer;
 
     prev = current;
 

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -80,7 +80,7 @@ void wait_clear(struct wait_queue *p)
 static void __sleep_on(register struct wait_queue *p, int state)
 {
 #ifdef CHECK_SCHED
-    if (current == &idle_task) panic("idle task sleep_on %x", p);
+    if (current == idle_task) panic("idle task sleep_on %x", p);
 #endif
     debug_sched("sleep: %P waitq %04x\n", p);
     current->state = state;

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -80,7 +80,7 @@ void wait_clear(struct wait_queue *p)
 static void __sleep_on(register struct wait_queue *p, int state)
 {
 #ifdef CHECK_SCHED
-    if (current == &task[0]) panic("idle task sleep_on %x", p);
+    if (current == &idle_task) panic("idle task sleep_on %x", p);
 #endif
     debug_sched("sleep: %P waitq %04x\n", p);
     current->state = state;

--- a/elks/lib/Makefile
+++ b/elks/lib/Makefile
@@ -35,7 +35,7 @@ include $(BASEDIR)/Makefile-rules
 #########################################################################
 # Objects to compile.
 
-OBJS  = chqueue.o string.o list.o heap.o
+OBJS  = chqueue.o string.o list.o heap.o hexdump.o
 
 #########################################################################
 # Commands:

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -102,7 +102,6 @@ void heap_free (void * data)
 {
 	heap_s * h = ((heap_s *) (data)) - 1;  // back to header
 
-
 	// Free block will be inserted to free list:
 	//   - tail if merged to previous or next free block
 	//   - head if still alone to increase 'exact hit'

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -4,6 +4,7 @@
 #include <linuxmt/kernel.h>
 #include <linuxmt/heap.h>
 #include <linuxmt/string.h>
+#include <linuxmt/debug.h>
 
 // Minimal block size to hold heap header
 // plus enough space in body to be useful
@@ -101,6 +102,7 @@ void heap_free (void * data)
 {
 	heap_s * h = ((heap_s *) (data)) - 1;  // back to header
 
+
 	// Free block will be inserted to free list:
 	//   - tail if merged to previous or next free block
 	//   - head if still alone to increase 'exact hit'
@@ -159,25 +161,26 @@ void heap_add (void * data, word_t size)
 
 // Initialize heap
 
-void heap_init ()
+void heap_init (void)
 {
+	//debug_setcallback(2, heap_display);
 	list_init (&_heap_all);
 	list_init (&_heap_free);
 }
 
-#if UNUSED
-static void heap_cb (heap_s * h)
+#if DEBUG
+static void heap_line (heap_s *h)
 {
-        printk ("heap:%Xh:%u:%hxh\n",h, h->size, h->tag);
+    printk("heap %04x size %5u tag %02x\n", h, h->size, h->tag);
 }
 
-void heap_iterate (void (* cb) (heap_s *))
+void heap_display (void)
 {
 	list_s * n = _heap_all.next;
 
 	while (n != &_heap_all) {
 		heap_s * h = structof (n, heap_s, all);
-		(*cb) (h);
+		heap_line (h);
 		n = h->all.next;
 	}
 }

--- a/elks/lib/hexdump.c
+++ b/elks/lib/hexdump.c
@@ -1,0 +1,79 @@
+/* hex dump library routine */
+#include <linuxmt/kernel.h>
+#include <linuxmt/string.h>
+
+#define isprint(c) ((c) > ' ' && (c) <= '~')
+static int lastnum[16] = {-1};
+static long lastaddr = -1;
+
+static void printline(unsigned int offset, unsigned int seg, int *num, char *chr,
+    int count, int flags)
+{
+    long address = ((unsigned long)seg << 4) + offset;
+    int j;
+
+    if (lastaddr >= 0) {
+        for (j = 0; j < count; j++)
+            if (num[j] != lastnum[j])
+                break;
+        if (j == 16 && (flags & 1)) {
+            if (lastaddr + 16 == address)
+                printk("*\n");
+            return;
+        }
+    }
+
+    lastaddr = address;
+    if (flags & 2)
+        printk("%06lx:", address);
+    else printk("%04x:%04x", seg, offset);
+    for (j = 0; j < count; j++) {
+        if (j == 8)
+            printk(" ");
+        if (num[j] >= 0)
+            printk(" %02x", num[j]);
+        else
+            printk("   ");
+        lastnum[j] = num[j];
+        num[j] = -1;
+    }
+
+    for (j=count; j < 16; j++) {
+        if (j == 8)
+            printk(" ");
+        printk("   ");
+    }
+
+    printk("  ");
+    for (j = 0; j < count; j++)
+        printk("%c", chr[j]);
+    printk("\n");
+}
+
+void hexdump(void *off, unsigned int seg, int count, int flags)
+{
+    unsigned char __far *addr;
+    unsigned int offset = (unsigned)off;
+    static char buf[20];
+    static int num[16];
+
+    addr = (unsigned char __far *)(((unsigned long)seg << 16) | (unsigned int)off);
+    lastnum[0] = -1;
+    lastaddr = -1;
+    for (; count > 0; count -= 16, offset += 16) {
+        int j, ch;
+
+        memset(buf, 0, 16);
+        for (j = 0; j < 16; j++)
+            num[j] = -1;
+        for (j = 0; j < 16; j++) {
+            ch = *addr++;
+            num[j] = ch;
+            if (isprint(ch) && ch < 0x80)
+                buf[j] = ch;
+            else
+                buf[j] = '.';
+        }
+        printline(offset, seg, num, buf, count > 16? 16: count, flags);
+    }
+}

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -192,13 +192,11 @@ int main(int argc, char **argv)
     printf("  PID");
     if (f_listall) printf("  PPID");
     printf("   GRP  TTY USER STAT ");
-#ifdef CONFIG_CPU_USAGE
-    printf("CPU");
-#endif
+    printf(f_listall? "TSK": "CPU");
     printf(" ");
     if (f_listall) printf("CSEG DSEG ");
     printf(" HEAP  FREE   SIZE COMMAND\n");
-    for (j = 1; j < maxtasks; j++) {
+    for (j = 0; j < maxtasks; j++) {
         if (!memread(fd, off + j*sizeof(struct task_struct), ds, &task_table, sizeof(task_table))) {
             printf("no memread\n");
             return 1;
@@ -228,16 +226,16 @@ int main(int argc, char **argv)
         printf(" %5d %4s %-8s%c ",
                 task_table.pgrp,
                 tty_name(fd, (unsigned int)task_table.tty, ds),
-                (pwent ? pwent->pw_name : "unknown"),
-                c);
+                (pwent ? pwent->pw_name : "unknown"), c);
 
-#ifdef CONFIG_CPU_USAGE
-        {
+        if (f_listall)
+            printf("%3d ", j);
+        else {
             /* Round up, then divide by 2 for %. Change if SAMP_FREQ not 2 */
             unsigned long cpu_percent = (task_table.average + FIXED_HALF) >> 1;
             printf("%3d", FIXED_INT(cpu_percent));
         }
-#endif
+
         /* CSEG*/
         cseg = (word_t)task_table.mm[SEG_CODE];
         if (f_listall) printf(" %4x ",


### PR DESCRIPTION
This PR implements a somewhat major improvement of gaining an additional process for user use, by moving the kernel idle task out of the task array, and not using more kernel memory. There are now by default a full 16 processes, rather than the previous 15 + 1 (idle task).

This is the final of several incremental improvements started in #2529 and #2530.

The `ps -l` option was changed to show the internal task number in the CPU column for better system inspection.

Here's a screenshot showing all 16 processes in use:
<img width="832" height="540" alt="max tasks" src="https://github.com/user-attachments/assets/400bceae-c93e-4d30-ba8d-7ca18f5de551" />

A new hexdump() library routine was added to display any memory, which was written in order to debug this enhancement, as was an improved `heap_display` internal kernel function that can be wired to ^P if desired.

An explanation of how exactly this works is quite long, but lengthy comments were added to main.c to explain in much more detail how the system starts up. The idle task is now allocated with a much smaller stack (128 bytes) than a normal task structure (640-740 bytes). This, along with the elimination of the 128 byte temp startup stack effectively allows another usable task for "free" without consuming any additional kernel heap space.

After the "tiny" idle task structure was implemented and almost working, a ridiculously long deep dive occurred as the result of the requirements to reset the kernel startup stack in start_kernel several times. Very long story short, and after way too many hexdump()s looked at, it was finally found that the ia16-elf-gcc compiler defaults to not adjusting the stack pointer after each function call - instead the stack is adjusted upwards somewhat randomly long after a function call has returned. This ended up causing the required stack resets in start_kernel to not operate correctly, and a previously unknown `-fno-defer-pop` gcc option was discovered, which is now used to compile main.c.

The default use of `-fdefer-pop` in the kernel with `-Os` optimization ends up saving ~976 bytes of code space, but ends up using excessive stack, since many function calls and their arguments may not be popped until the enclosing function exits. This very likely is resulting in excessive requirements for each of the 16 kernel stack areas. Compiling the entire kernel with `-fno-defer-pop` adds 976 bytes to the .text segment, and the kernel fails to link with all ETH drivers compiled in. The excessive stack usage and getting the kernel size reduced will be investigated more fully in the future.

Since the idle task now runs on a 128 bytes stack, the true kernel stack usage of functions as seemingly bane as `printk` came to light - a single printk can easily use more than 128 bytes stack, especially when used by any function called from the idle task. For now, an "IDLE STACK OFLOW" message is displayed in these cases. The good news is that idle stack overflow isn't as bad as it sounds, as the stack overflow effectively just writes further into mostly unused task structure variables (the kernel stack is placed at the end of each task structure, where the user registers are also saved on a hardware interrupt from user mode).





