### PR TITLE
[NECV25] Support for 2nd console on "Serial 0" for NEC V25 port

### DIFF
--- a/elks/arch/i86/drivers/char/console-serial-necv25.c
+++ b/elks/arch/i86/drivers/char/console-serial-necv25.c
@@ -272,7 +272,7 @@ static void update_port(struct serial_info *port)
 /* Called from main.c */
 void INITPROC console_init(void)
 {
-    struct serial_info *sp = ports;;
+    struct serial_info *sp = ports;
 
     do
     {

--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -108,3 +108,35 @@ asm_fast_irq1_necv25:
     add     $4,%sp      // skip the trampoline DS:*irq
     iret
 #endif
+
+#ifdef CONFIG_FAST_IRQ2_NECV25
+//
+// Entry for console-serial-necv25 top half interrupt handler, called by CALLF within dynamic handler
+//
+    .extern	sercon_fast_irq2_necv25
+    .global asm_fast_irq2_necv25
+asm_fast_irq2_necv25:
+    push    %ax         // save regs, uses 18 bytes of current stack
+    push    %bx
+    push    %cx
+    push    %dx
+    push    %ds
+
+    // Recover kernel data segment
+    // Was pushed by the CALLF of the dynamic handler
+    mov	%sp,%bx
+    mov	%ss:12(%bx),%ds
+
+    call	sercon_fast_irq2_necv25 // call special 2nd part of top half C handler
+                                    // which doesn't use any SS/SP/BP addressing
+
+    .word   0x920f                  // NEC V25 specific FINT (End Of Interrupt) instruction
+
+    pop     %ds			// restore regs
+    pop     %dx
+    pop     %cx
+    pop     %bx
+    pop     %ax
+    add     $4,%sp      // skip the trampoline DS:*irq
+    iret
+#endif

--- a/elks/arch/i86/kernel/irq-necv25.c
+++ b/elks/arch/i86/kernel/irq-necv25.c
@@ -38,6 +38,7 @@ void initialize_irq(void)    // see irq-necv25asm.S
             "movb  $(IRQMSK+IRQPRI6), %%ds:(SEIC0) // SEIC0: Serial error interrupt request control register 0, irq prio 6 \n"\
             "movb  $(IRQMSK+IRQPRID), %%ds:(SRIC0) // SRIC0: Serial reception interrupt request control register 0         \n"\
             "movb  $(IRQMSK+IRQPRID), %%ds:(STIC0) // STIC0: Serial transmission interrupt request control register 0      \n"\
+            "movb  $0x00, %%ds:(TXB0)              // TXB0:  restart transmitter, so that ready waiting funtions           \n"\
             "movb  $(IRQMSK+IRQPRI6), %%ds:(SEIC1) // SEIC1: Serial error interrupt request control register 1, irq prio 6 \n"\
             "movb  $(IRQMSK+IRQPRID), %%ds:(SRIC1) // SRIC1: Serial reception interrupt request control register 1         \n"\
             "movb  $(IRQMSK+IRQPRID), %%ds:(STIC1) // STIC1: Serial transmission interrupt request control register 1      \n"\
@@ -65,8 +66,12 @@ logical_map[] =
 {
     { TIMER_IRQ,    NEC_TMIC2, NEC_INTTU2 }, // Timmer 1 IRQ
     { UART1_IRQ_RX, NEC_SRIC1, NEC_INTSR1 }, // Serial 1 RX IRQ
+#ifdef CONFIG_FAST_IRQ2_NECV25
+    { UART2_IRQ_RX, NEC_SRIC0, NEC_INTSR0 }, // Serial 0 RX IRQ
+#endif
 #ifdef UNUSED
     { UART1_IRQ_TX, NEC_STIC1, NEC_INTST1 }, // Serial 1 TX IRQ
+    { UART2_IRQ_TX, NEC_STIC0, NEC_INTST0 }, // Serial 0 TX IRQ
 #endif
     { NE2K_IRQ,     NEC_EXIC0, NEC_INTP0 }, // NE2000 NIC
 };

--- a/elks/include/arch/necv25.h
+++ b/elks/include/arch/necv25.h
@@ -109,6 +109,10 @@
 #define NEC_INTTU1  0x1d      /* Timer 1 Interrupt */
 #define NEC_INTTU2  0x1e      /* Timer 1 Interrupt */
 
+#define NEC_INTSE0  0x0c      /* SIO0 Error Interrupt */
+#define NEC_INTSR0  0x0d      /* SIO0 RX Interrupt */
+#define NEC_INTST0  0x0e      /* SIO0 TX Interrupt */
+
 #define NEC_INTSE1  0x10      /* SIO1 Error Interrupt */
 #define NEC_INTSR1  0x11      /* SIO1 RX Interrupt */
 #define NEC_INTST1  0x12      /* SIO1 TX Interrupt */
@@ -119,6 +123,8 @@
 
 #define UART1_IRQ_RX  1       /* maps to interrupt NEC_INTSR1 */
 #define UART1_IRQ_TX  2       /* maps to interrupt NEC_INTST1 */
+#define UART2_IRQ_RX  3       /* maps to interrupt NEC_INTSR0 */
+#define UART2_IRQ_TX  4       /* maps to interrupt NEC_INTST0 */
 
 // Interrupt register options
 #define IRQFLAG      0x80     /* interrupt request flag */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -93,7 +93,6 @@
 #endif /* CONFIG_ARCH_8018X */
 
 #ifdef CONFIG_ARCH_NECV25
-#define MAX_SERIAL              2       /* max number of serial tty devices*/
 #define SETUP_VID_COLS          80      /* video # columns */
 #define SETUP_VID_LINES         25      /* video # lines */
 #define SETUP_CPU_TYPE          setupb(0x20)    /* processor type */
@@ -107,7 +106,10 @@
 #define UTS_MACHINE             "NECV25"
 #define CONFIG_NECV25_FCPU      22118400UL /* external CPU crystal clock in Hz 14745600UL or 22118400UL */
 #define CONFIG_DEF_BAUD         B115200
-#define CONFIG_FAST_IRQ1_NECV25        /* Serial 1 */
+#define CONFIG_FAST_IRQ1_NECV25         /* Serial 1 */
+#ifndef CONFIG_HW_SPI                   /* HW SPI uses Serial 0, so no console on this port */
+#define CONFIG_FAST_IRQ2_NECV25         /* Serial 0 as console, if no HW SPI configured */
+#endif
 #endif /* CONFIG_ARCH_NECV25 */
 
 #ifdef CONFIG_ARCH_SWAN

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -23,18 +23,23 @@
 
 /* Predefined maximum number of tty character devices */
 
-#ifdef CONFIG_CONSOLE_DUAL
+#if defined(CONFIG_CONSOLE_DUAL)
 #define MAX_CONSOLES 4
+#elif defined(CONFIG_FAST_IRQ2_NECV25)
+#define MAX_CONSOLES 2
+#elif defined(CONFIG_FAST_IRQ1_NECV25)
+#define MAX_CONSOLES 1
 #else
 #define MAX_CONSOLES 3
 #endif
+
 #define MAX_PTYS     4
 
 #define TTY_MINOR_OFFSET 0
 #define PTY_MINOR_OFFSET 8
 #define RS_MINOR_OFFSET 64
 
-#if defined(CONFIG_CONSOLE_DIRECT) || defined(CONFIG_CONSOLE_BIOS)
+#if defined(CONFIG_CONSOLE_DIRECT) || defined(CONFIG_CONSOLE_BIOS) || defined(CONFIG_ARCH_NECV25)
 #define NR_CONSOLES	MAX_CONSOLES
 #else
 #define NR_CONSOLES	1	/* headless*/


### PR DESCRIPTION
Usually, the internal MCU UART "Serial 0" is configured as a hardware SPI to connect an SD card. If slower software SPI is configured, the now free "Serial 0" is set up as a second serial console.

This is the preparation to work on some xyz-modem app to get files down-/up-loadable via serial port. With only one serial port this is nearly impossible to test.