### PR TITLE
[kernel,boot] Add istack option to measure timer_bh delays and calculate max interrupt stack size

### DIFF
--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -42,16 +42,18 @@
 !       related nonsense. This way we need only one dedicated int stack
 !
 */
-        .extern schedule
         .extern do_signal
         .extern do_IRQ
         .extern syscall
-        .extern stack_check
         .extern trace_begin
         .extern trace_end
-        .extern panic
+        .extern tracing
+        .extern check_ustack
+        .extern check_istack
         .extern bh_active
         .extern do_bottom_half
+        .extern schedule
+        .extern panic
 
         .global _irqit
 _irqit:
@@ -146,7 +148,7 @@ save_regs:
 //      ----------PROCESS SYSCALL----------
 //
         sti
-        call    stack_check     // Check user mode stack
+        call    check_ustack    // Check user mode stack
 
 #ifdef CONFIG_TRACE
         call    trace_begin
@@ -161,7 +163,6 @@ save_regs:
         call    trace_end       // syscall return value is top of stack
 #endif
 
-//
 //      Restore registers
 //
         call    do_signal
@@ -195,17 +196,16 @@ updct:
         pop     %ax             // Saved IRQ
         cli                     // Disable interrupts to avoid reentering ISR
 
+//
+//      Determine if hardware or software (trap) interrupt
+//
 #if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98)
-//
-//      Determine if trap or interrupt
-//
         cmp     $16,%ax
         jge     was_trap        // Traps need no reset
 
 #if defined(CONFIG_BLK_DEV_BFD) && !defined(CONFIG_ARCH_PC98)
         or      %ax,%ax         // Is int #0?
         jnz     do_eoi
-
 //
 //      Call original BIOS IRQ 0 (timer) ~55ms for floppy motor control
 //
@@ -217,44 +217,29 @@ updct:
         jmp     was_trap        // EOI already sent by bios int
 #endif
 
-//
-//      Send EOI to interrupt controller
-//
-do_eoi:
-        cmp     $8,%ax
+do_eoi: cmp     $8,%ax          // Send EOI to interrupt controller(s)
         mov     $0x20,%al       // EOI
         jb      a6              // IRQ on low chip
-/*
-!
-!       Reset secondary 8259 if we have taken an AT rather
-!       than XT irq. We also have to prod the primay
-!       controller EOI..
-!
-*/
+
+//      Reset secondary 8259 if we have taken an AT rather
+//      than XT irq. We also have to prod the primary controller EOI..
+//
+
         out     %al,$PIC2_CMD   // Ack on secondary controller
         jmp     a5
 a5:     jmp     a6
 a6:     out     %al,$PIC1_CMD   // Ack on primary controller
 
 #elif defined(CONFIG_ARCH_8018X)
-//
-//      Determine if trap or interrupt
-//
-        cmp     $16,%ax
+        cmp     $16,%ax         // Determine if trap or interrupt
         jge     was_trap        // Traps need no reset
-
         mov $0x8000, %ax        // set the NSPEC bit on the
         mov $0xff02, %dx        // EOI register so the ICU
         out %ax, %dx            // acks the highest priority interrupt
 
 #elif defined(CONFIG_ARCH_NECV25)
-//
-//      Determine if trap or interrupt
-//
-   
-        cmp     $16,%ax
+        cmp     $16,%ax         // Determine if trap or interrupt
         jge     was_trap        // Traps need no reset
-
         .word   0x920f          // NEC V25 specific FINT (End Of Interrupt) instruction
 
 #elif defined(CONFIG_ARCH_SOLO86)
@@ -262,12 +247,18 @@ a6:     out     %al,$PIC1_CMD   // Ack on primary controller
         out %al, %dx
 #endif
 
-//
-//      And a trap does no hardware work
-//
 was_trap:
 //
 //      Look at running bottom halves or rescheduling
+//
+
+#ifdef CHECK_ISTACK
+        mov     tracing,%ax
+        and     $TRACE_ISTACK,%ax
+        jz      2f
+        call    check_istack
+#endif
+2:
 //
         cmpw    $1,intr_count    // Interrupted user mode code?
         jne     restore_regs     // No
@@ -304,8 +295,8 @@ was_trap:
         call    do_bottom_half
         //cli
         //decw    intr_count
-
-1:      sti                     // Interrupts enabled while reschedule or signal checking
+1:
+        sti                     // Interrupts enabled while reschedule or signal checking
         call    schedule        // Task switch
         call    do_signal       // Check signals
         cli

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -43,30 +43,6 @@ int run_init_process_sptr(const char *cmd, char *sptr, int slen)
 }
 
 /*
- * Check that SP is within proper range, called before every syscall.
- */
-void stack_check(void)
-{
-    segoff_t sp = current->t_regs.sp;
-    segoff_t brk = current->t_endbrk;
-    segoff_t stacklow = current->t_begstack - current->t_minstack;
-
-    if (sp < brk) {
-        printk("(%P)STACK OVERFLOW by %u\n", brk - sp);
-        printk("curbreak %u, SP %u\n", current->t_endbrk, current->t_regs.sp);
-        do_exit(SIGSEGV);
-    }
-    if (sp < stacklow) {
-        /* notification only, allow process to continue */
-        printk("(%P)STACK USING %u UNUSED HEAP\n", stacklow - sp);
-    }
-    if (sp > current->t_begstack) {
-        printk("(%P)STACK UNDERFLOW\n");
-        do_exit(SIGSEGV);
-    }
-}
-
-/*
  *  Make task t fork into kernel space. We are in kernel mode
  *  so we fork onto our kernel stack.
  */

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -18,7 +18,7 @@
 
 #define INTRSTACK_BYTES 512     /* Size of interrupt stack */
 
-#define IDLESTACK_BYTES 128     /* Size of idle task stack */
+#define IDLESTACK_BYTES 160     /* Size of idle task stack */
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -18,7 +18,7 @@
 
 #define INTRSTACK_BYTES 512     /* Size of interrupt stack */
 
-#define IDLESTACK_BYTES 160     /* Size of idle task stack */
+#define IDLESTACK_BYTES 160     /* Size of idle task stack (min 128) */
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -177,7 +177,6 @@ extern short *getsp(void);
 extern int run_init_process(const char *cmd);
 extern int run_init_process_sptr(const char *cmd, char *sptr, int slen);
 extern void ret_from_syscall(void);
-extern void check_stack(void);
 
 void select_wait(struct wait_queue *);
 int select_poll(struct task_struct *, struct wait_queue *);

--- a/elks/include/linuxmt/trace.h
+++ b/elks/include/linuxmt/trace.h
@@ -13,9 +13,13 @@
  * When CONFIG_TRACE is enabled, the following can be used in /bootopts:
  *  strace  - enable system call tracing
  *  kstack  - display max kernel stack usage per process
+ *  istack  - display max interrup stack usage and timer_bh execution delays
  */
 
 #ifdef CONFIG_TRACE
+
+/* calculate interrupt stack usage and timer_bh delays after hardware interrupts */
+#define CHECK_ISTACK
 
 /* calculate max kernel stack usage per system call, notify when near overflow */
 #define CHECK_KSTACK
@@ -51,13 +55,15 @@
 /* internal flags for kernel */
 #define TRACE_STRACE    0x01    /* system call tracing enabled */
 #define TRACE_KSTACK    0x02    /* calculate kernel stack used per syscall/process */
+#define TRACE_ISTACK    0x04    /* calculate interrupt stack use each hw interrupt */
 
 #ifndef __ASSEMBLER__
 extern int tracing;
 
 void trace_begin(void);
 void trace_end(unsigned int retval);
-void check_tstack(void);
+void check_ustack(void);
+void check_istack(void);
 #endif
 
 #endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -561,6 +561,10 @@ static int INITPROC parse_options(void)
             tracing |= TRACE_KSTACK;
             continue;
         }
+        if (!strcmp(line,"istack")) {
+            tracing |= TRACE_ISTACK;
+            continue;
+        }
         if (!strncmp(line,"init=",5)) {
             line += 5;
             init_command = argv_init[1] = line;

--- a/elks/kernel/syscall.c
+++ b/elks/kernel/syscall.c
@@ -1,6 +1,0 @@
-#include <linuxmt/errno.h>
-
-int syscall(void)
-{
-    return -ENOSYS;
-}

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -27,6 +27,7 @@ xms=on
 #n	# no rc.sys
 #init=/bin/sash
 #kstack
+#istack
 #strace
 #FTRACE=1
 #net=ne0

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -27,10 +27,10 @@ xms=on
 #n	# no rc.sys
 #init=/bin/sash
 #kstack
-#istack
 #strace
 #FTRACE=1
 #net=ne0
 #debug=1
+#istack
 #console=ttyS0,19200 3
 #MOUSE_PORT=/dev/ttyS1


### PR DESCRIPTION
Adds code to determine whether the timer_bh (bottom half timer) routine was ever delayed, such that another hardware timer interrupt occurred prior to it being scheduled to run. 

Much to my surprise, it was found that timer_bh execution is sometimes delayed 20-80 ms (i.e. 2-8 timer ticks)!! The reason for this is explained below, but a longer explanation, along with solutions and possible ramifications, will be the subject of an issue to be opened separately.

The new code determines whether the timer_bh routine has been delayed longer than one tick, and displays "TIMER_BH DELAY \<n>" showing the number of ticks delay.

The bottom half handlers all run on the interrupt stack, but are currently allowed to run *only* when the kernel wasn't already running. That is, they run only when the hardware interrupted a user task, never currently when the hardware interrupted the kernel. 

With the timer_bh delay code activated and high system load a TIMER_BH DELAY message or two is displayed. This will be investigated further.

An `istack` option (tracing |= TRACE_ISTACK) was added to /bootopts, allowing the new delay code to be turned on only when wanted (providing CHECK_ISTACK is defined), otherwise the system operates normally.

The idle task stack size was increased from 128 bo 160 bytes to avoid some idle stack overflow messages seen with the increased usage of printk running when idle.

Also includes more source code cleanup and rearrangement in irqtab.S and strace.c, with no changes to system operation.