### PR TITLE
[kernel] Implement high priority bottom half interrupt handlers

### DIFF
--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -153,7 +153,6 @@ save_regs:
 #ifdef CONFIG_TRACE
         call    trace_begin
 #endif
-
         pop     %ax             // get syscall function code in AX
         call    syscall
         push    %ax             // syscall return value in ax
@@ -162,10 +161,7 @@ save_regs:
         // strace.c must be compiled with tail optimization off to protect top of stack
         call    trace_end       // syscall return value is top of stack
 #endif
-
-//      Restore registers
-//
-        call    do_signal
+        call    do_signal       // process signals
         cli
         jmp     restore_regs
 //
@@ -220,11 +216,10 @@ updct:
 do_eoi: cmp     $8,%ax          // Send EOI to interrupt controller(s)
         mov     $0x20,%al       // EOI
         jb      a6              // IRQ on low chip
-
+//
 //      Reset secondary 8259 if we have taken an AT rather
 //      than XT irq. We also have to prod the primary controller EOI..
 //
-
         out     %al,$PIC2_CMD   // Ack on secondary controller
         jmp     a5
 a5:     jmp     a6
@@ -251,15 +246,37 @@ was_trap:
 //
 //      Look at running bottom halves or rescheduling
 //
-
+        cmp     $2,intr_count   // Interrupting user or mainline kernel code?
+        ja      restore_regs    // No, interrupting handler code
+        jne     1f              // Yes, interrupting user code
+//
+// Interrupted kernel code (intr_count = 2), only run high-priority BHs
+//
+        testb   $BHM_HIPRI,bh_active    // Any high-priority bottom halfs?
+        jz      restore_regs    // No
+        sti
+        call    do_bottom_half  // Run bottom halves
+        jmp     3f
+//
+// Interrupted user code (intr_count = 1), run all BHs
+//
+1:      cmpw    $0,bh_active    // Any active bottom halfs?
+        je      2f              // No
+        sti
+        call    do_bottom_half  // Run bottom halves
+2:      sti
+        call    schedule        // Task switch
+        call    do_signal       // Check signals
+3:
 #ifdef CHECK_ISTACK
         mov     tracing,%ax
         and     $TRACE_ISTACK,%ax
-        jz      2f
+        jz      4f
         call    check_istack
+4:      cli
 #endif
-2:
 //
+#if 0
         cmpw    $1,intr_count    // Interrupted user mode code?
         jne     restore_regs     // No
 //      cmp     $0,_need_resched // Schedule needed ?
@@ -300,6 +317,7 @@ was_trap:
         call    schedule        // Task switch
         call    do_signal       // Check signals
         cli
+#endif
 //
 //      Restore registers and return
 //

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -275,6 +275,7 @@ was_trap:
         je      3f              // No, return
         sti
         call    do_bottom_half  // Run bottom halves
+        cli
         jmp     3f              // Return
 //
 // Interrupted user code (intr_count = 1), run BHs and reschedule
@@ -286,14 +287,17 @@ was_trap:
 2:      sti                     // Interrupts enabled while reschedule or signal checking
         call    schedule        // Task switch
         call    do_signal       // Check signals
+        cli
 3:
 
 #ifdef CHECK_ISTACK
         mov     tracing,%ax
         and     $TRACE_ISTACK,%ax
         jz      4f
+        sti
         call    check_istack    // Determine max interrupt stack used
-4:      cli
+        cli
+4:
 #endif
 
 //

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -244,8 +244,25 @@ a6:     out     %al,$PIC1_CMD   // Ack on primary controller
 
 was_trap:
 //
-//      Look at running bottom halves or rescheduling
+//      Check if bottom halves can be run or rescheduling can occur
 //
+
+//  At this time after processing the hardware interrupt, the following actions
+//  can be taken, depending on the kernel state described by intr_count:
+//  intr_count = 0  not possible
+//  intr_count = 1  interrupted user code (using process's kernel stack)
+//      Action: Run any bottom halves, schedule and do_signal.
+//  intr_count = 2  interrupted kernel code or idle task (using interrupt stack)
+//      Action: Run high priority bottom halves only, no rescheduling.
+//      Later, bottom halves will be run during the next call to schedule().
+//  intr_count > 2  interrupted handler code (using interrupt stack)
+//      Action: let interrupt stack unwind by returning immediately
+//
+//  Hardware interrupts of kernel or idle code have to use the interrupt stack,
+//  which means that calling schedule() cannot be allowed. This also means that task
+//  rescheduling doesn't happen on return from a timer interrupt from the idle task.
+//  Instead, the idle task is resumed and it calls schedule which calls bottom half.
+
         cmp     $2,intr_count   // Interrupting user or mainline kernel code?
         ja      restore_regs    // No, interrupting handler code
         jne     1f              // Yes, interrupting user code
@@ -256,9 +273,10 @@ was_trap:
         jz      restore_regs    // No
         sti
         call    do_bottom_half  // Run bottom halves
-        jmp     3f
+        jmp     3f              // Return from interrupt
 //
-// Interrupted user code (intr_count = 1), run all BHs
+// Interrupted user code (intr_count = 1), run all BHs, reschedule,
+// then return to user space
 //
 1:      cmpw    $0,bh_active    // Any active bottom halfs?
         je      2f              // No
@@ -268,6 +286,9 @@ was_trap:
         call    schedule        // Task switch
         call    do_signal       // Check signals
 3:
+//
+// Check interrupt stack and return from interrupt
+//
 #ifdef CHECK_ISTACK
         mov     tracing,%ax
         and     $TRACE_ISTACK,%ax
@@ -284,26 +305,6 @@ was_trap:
 
 //
 // This path will return directly to user space
-//
-
-//
-// Check for any active bottom-half handlers and if we're able to run them now.
-//  Bottom half handlers can run now only if this interrupt is from user mode,
-//  otherwise handlers will be run during next call to schedule().
-//  Interrupts from the idle task have to return now since they're running on
-//  the interrupt stack and can't be switched. On return the idle task will call
-//  schedule() in its main loop, which then runs the bottom half handlers.
-//
-//  At this time, intr_count values mean:
-//  intr_count==0   not possible
-//  intr_count==1   interrupted user code (using process's kernel stack)
-//  intr_count==2   interrupted kernel code or idle task (using interrupt stack)
-//  intr_count>2    interrupted handler code (using interrupt stack)
-//  The idle task always runs at intr_count==1, since it is actually kernel code.
-//  This means that interrupts of idle task or kernel run on the interrupt stack
-//  and thus calling schedule() cannot be allowed. This also means that
-//  task rescheduling doesn't happen on return from a timer interrupt from the idle task.
-//  Instead, the idle task is resumed and it calls schedule which calls bottom half.
 //
         cmpw    $0,bh_active    // Any active bottom halfs?
         je      1f              // No

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -13,7 +13,7 @@
 //
 //      IRQ and IRQ return paths for Linux 8086
 //
-// The execution thread will not return from the function call.
+// The execution thread will not return from the interrupt vector trampoline.
 // Instead, the address pushed in the stack will be used to get
 // the interrupt number.
 
@@ -143,10 +143,11 @@ save_regs:
 //
         movb    (%di),%al
         cmpb    $IDX_SYSCALL,%al
-        jne     updct
-//
-//      ----------PROCESS SYSCALL----------
-//
+        jne     doirq
+/*
+!
+!       ----------PROCESS SYSCALL----------
+*/
         sti
         call    check_ustack    // Check user mode stack
 
@@ -173,7 +174,7 @@ save_regs:
 !
 !       ----------PROCESS INTERRUPT----------
 */
-updct:
+doirq:
 //
 //      Call the C code
 //
@@ -260,10 +261,10 @@ was_trap:
 //
 //  Hardware interrupts of kernel or idle code have to use the interrupt stack,
 //  which means that calling schedule() cannot be allowed. After possibly running
-//  BHs on the interrupt stack, we will return and the stack switched back to
-//  the kernel user process or idle task stack. Interrupted kernel code will be
-//  resumed with no reschedling, and in the case of idle task interruption,
-//  rescheduling will occur by the idle task when resumed.
+//  BHs on the kernel's user process or interrupt stack, we will return to user mode,
+//  or switch back to the interrupted kernel user process or idle task stack.
+//  Interrupted kernel code will be resumed with no reschedling, and in the case
+//  of idle task interruption, rescheduling will occur by the idle task when resumed.
 
         cmp     $2,intr_count   // Interrupting user or non-handler kernel code?
         ja      restore_regs    // No, interrupting handler code

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -256,12 +256,12 @@ was_trap:
 //      Action: Run high priority bottom halves only, no rescheduling.
 //      Later, bottom halves will be run during the next call to schedule().
 //  intr_count > 2  interrupted handler code (using interrupt stack)
-//      Action: let interrupt stack unwind by returning immediately
+//      Action: let interrupt stack unwind by returning immediately.
 //
 //  Hardware interrupts of kernel or idle code have to use the interrupt stack,
 //  which means that calling schedule() cannot be allowed. This also means that task
 //  rescheduling doesn't happen on return from a timer interrupt from the idle task.
-//  Instead, the idle task is resumed and it calls schedule which calls bottom half.
+//  When the idle task is resumed it calls schedule which runs any bottom halves.
 
         cmp     $2,intr_count   // Interrupting user or mainline kernel code?
         ja      restore_regs    // No, interrupting handler code

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -153,6 +153,7 @@ save_regs:
 #ifdef CONFIG_TRACE
         call    trace_begin
 #endif
+
         pop     %ax             // get syscall function code in AX
         call    syscall
         push    %ax             // syscall return value in ax
@@ -251,74 +252,50 @@ was_trap:
 //  can be taken, depending on the kernel state described by intr_count:
 //  intr_count = 0  not possible
 //  intr_count = 1  interrupted user code (using process's kernel stack)
-//      Action: Run any bottom halves, schedule and do_signal.
+//      Action: Run bottom halves, schedule and do_signal.
 //  intr_count = 2  interrupted kernel code or idle task (using interrupt stack)
-//      Action: Run high priority bottom halves only, no rescheduling.
-//      Later, bottom halves will be run during the next call to schedule().
+//      Action: Run bottom halves, no rescheduling.
 //  intr_count > 2  interrupted handler code (using interrupt stack)
 //      Action: let interrupt stack unwind by returning immediately.
 //
 //  Hardware interrupts of kernel or idle code have to use the interrupt stack,
-//  which means that calling schedule() cannot be allowed. This also means that task
-//  rescheduling doesn't happen on return from a timer interrupt from the idle task.
-//  When the idle task is resumed it calls schedule which runs any bottom halves.
+//  which means that calling schedule() cannot be allowed. After possibly running
+//  BHs on the interrupt stack, we will return and the stack switched back to
+//  the kernel user process or idle task stack. Interrupted kernel code will be
+//  resumed with no reschedling, and in the case of idle task interruption,
+//  rescheduling will occur by the idle task when resumed.
 
-        cmp     $2,intr_count   // Interrupting user or mainline kernel code?
+        cmp     $2,intr_count   // Interrupting user or non-handler kernel code?
         ja      restore_regs    // No, interrupting handler code
         jne     1f              // Yes, interrupting user code
 //
-// Interrupted kernel code (intr_count = 2), only run high-priority BHs
+// Interrupted kernel or idle task code (intr_count = 2), run BHs and return
 //
-        testb   $BHM_HIPRI,bh_active    // Any high-priority bottom halfs?
-        jz      restore_regs    // No
+        cmpw    $0,bh_active    // Any active bottom halfs?
+        je      3f              // No, return
         sti
         call    do_bottom_half  // Run bottom halves
-        jmp     3f              // Return from interrupt
+        jmp     3f              // Return
 //
-// Interrupted user code (intr_count = 1), run all BHs, reschedule,
-// then return to user space
+// Interrupted user code (intr_count = 1), run BHs and reschedule
 //
 1:      cmpw    $0,bh_active    // Any active bottom halfs?
         je      2f              // No
         sti
         call    do_bottom_half  // Run bottom halves
-2:      sti
+2:      sti                     // Interrupts enabled while reschedule or signal checking
         call    schedule        // Task switch
         call    do_signal       // Check signals
 3:
-//
-// Check interrupt stack and return from interrupt
-//
+
 #ifdef CHECK_ISTACK
         mov     tracing,%ax
         and     $TRACE_ISTACK,%ax
         jz      4f
-        call    check_istack
+        call    check_istack    // Determine max interrupt stack used
 4:      cli
 #endif
-//
-#if 0
-        cmpw    $1,intr_count    // Interrupted user mode code?
-        jne     restore_regs     // No
-//      cmp     $0,_need_resched // Schedule needed ?
-//      je      restore_regs     // No
 
-//
-// This path will return directly to user space
-//
-        cmpw    $0,bh_active    // Any active bottom halfs?
-        je      1f              // No
-        //incw    intr_count    // Don't rerun bottom half if interrupted
-        sti                     // Interrupts enabled but handlers not reentrant
-        call    do_bottom_half
-        //cli
-        //decw    intr_count
-1:
-        sti                     // Interrupts enabled while reschedule or signal checking
-        call    schedule        // Task switch
-        call    do_signal       // Check signals
-        cli
-#endif
 //
 //      Restore registers and return
 //

--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -18,8 +18,8 @@
  * from being re-entered, so they don't need to be reentrant.
  *
  * High priority BH handlers run directly after the hardware interrupt stack
- * is fully unwound, while normal priority BH handlers run after the kernel
- * has completed its previously interrupted code.
+ * is fully unwound, while other handlers are delayed until the next call to
+ * schedule(), or before turning to user mode if user code was interrupted.
  *
  * Since BH handlers run in an interrupt context, they can't sleep, can't access user
  * space, and can't reschedule.

--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -17,6 +17,10 @@
  * A BH handler may be interrupted by any top-half interrupt, but are protected
  * from being re-entered, so they don't need to be reentrant.
  *
+ * High priority BH handlers run directly after the hardware interrupt stack
+ * is fully unwound, while normal priority BH handlers run after the kernel
+ * has completed its previously interrupted code.
+ *
  * Since BH handlers run in an interrupt context, they can't sleep, can't access user
  * space, and can't reschedule.
  *

--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -33,7 +33,7 @@ void do_bottom_half(void)
     unsigned int active;
     unsigned int mask, left;
     void (**bh)(void);
-    static int in_bottom_half;
+    static char in_bottom_half;
 
     if (++in_bottom_half != 1) {    /* protect BHs from reentry */
         //printk("REENTRANT BH\n");

--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -39,11 +39,12 @@ void do_bottom_half(void)
         printk("I");                /* called from idle task */
     else printk("K");               /* called after syscall or user mode interrupt */
     printk("{B%d}", intr_count);
+    if (intr_count != 2) printk("{B%d}", intr_count);
 #endif
 
     bh = bh_base;
     active = bh_active;
-    for (mask = 1, left = ~0; left & active; bh++, mask += mask, left += left) {
+    for (mask = 1, left = ~0; left & active; bh++, mask <<= 1, left <<= 1) {
         if (mask & active) {
             bh_active &= ~mask;
             if (*bh)

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -85,6 +85,9 @@ void timer_bh(void)
     }
 #endif
 
+    /*  Test timer_bh delay message and BH reentrancy when running loop program */
+    //for (volatile long i=0; i<30000L; i++);
+
 #if (defined(CONFIG_CHAR_DEV_RS) &&                               \
         (defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3))) \
     || defined(CONFIG_FAST_IRQ1_NECV25)

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -8,9 +8,6 @@
 #define IDX_NMI         18
 #define NR_IRQS         19      /* = # IRQs plus special indexes above */
 
-/* mask of handlers to run even when kernel is interrupted (high priority) */
-#define BHM_HIPRI       0x01    /* NETWORK_BH */
-
 #define INT_GENERIC  0  // use the generic interrupt handler (aka '_irqit')
 #define INT_SPECIFIC 1  // use a specific interrupt handler
 
@@ -43,9 +40,9 @@ int irq_vector(int irq);
 /* softirq.c */
 /* BH handlers, run in increasing numeric order */
 enum {
-//  NETWORK_BH = 0,         /* high priority */
-    TIMER_BH = 1,           /* lo priority */
-    SERIAL_BH,
+    NETWORK_BH = 0,
+    TIMER_BH = 1,
+    SERIAL_BH,          /* unused, handled by timer_bh */
     MAX_SOFTIRQ
 };
 extern unsigned int bh_active;

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -8,11 +8,11 @@
 #define IDX_NMI         18
 #define NR_IRQS         19      /* = # IRQs plus special indexes above */
 
+/* mask of handlers to run even when kernel is interrupted (high priority) */
+#define BHM_HIPRI       0x01    /* NETWORK_BH */
+
 #define INT_GENERIC  0  // use the generic interrupt handler (aka '_irqit')
 #define INT_SPECIFIC 1  // use a specific interrupt handler
-
-/* mask of handlers to run even when kernel is interrupted (high priority) */
-#define BHM_HIPRI   0x01    /* NETWORK_BH */
 
 #ifndef __ASSEMBLER__
 #include <linuxmt/types.h>

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -11,6 +11,9 @@
 #define INT_GENERIC  0  // use the generic interrupt handler (aka '_irqit')
 #define INT_SPECIFIC 1  // use a specific interrupt handler
 
+/* mask of handlers to run even when kernel is interrupted (high priority) */
+#define BHM_HIPRI   0x01    /* NETWORK_BH */
+
 #ifndef __ASSEMBLER__
 #include <linuxmt/types.h>
 
@@ -38,15 +41,17 @@ int remap_irq(int);
 int irq_vector(int irq);
 
 /* softirq.c */
+/* BH handlers, run in increasing numeric order */
 enum {
-    TIMER_BH = 0,
+//  NETWORK_BH = 0,         /* high priority */
+    TIMER_BH = 1,           /* lo priority */
     SERIAL_BH,
     MAX_SOFTIRQ
 };
 extern unsigned int bh_active;
 extern void (*bh_base[MAX_SOFTIRQ])(void);
 #define init_bh(nr, routine)    { bh_base[nr] = routine; }
-#define mark_bh(nr)             { bh_active |= 1 << nr;  }
+#define mark_bh(nr)             { bh_active |= 1 << (nr);  }
 void do_bottom_half(void);
 
 #endif /* __ASSEMBLER__ */

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -85,12 +85,6 @@ void schedule(void)
     }
 #endif
 
-    if (bh_active) {
-        intr_count++;
-        do_bottom_half();
-        intr_count--;
-    }
-
     /* We have to let a task exit! */
     if (prev->state == TASK_EXITING)
         return;

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -85,8 +85,11 @@ void schedule(void)
     }
 #endif
 
-    if (bh_active)
+    if (bh_active) {
+        intr_count++;
         do_bottom_half();
+        intr_count--;
+    }
 
     /* We have to let a task exit! */
     if (prev->state == TASK_EXITING)

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -31,6 +31,6 @@ xms=on
 #FTRACE=1
 #net=ne0
 #debug=1
-#istack
-#console=ttyS0,19200 3
+istack
+console=ttyS0,19200 3
 #MOUSE_PORT=/dev/ttyS1

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -31,6 +31,6 @@ xms=on
 #FTRACE=1
 #net=ne0
 #debug=1
-istack
-console=ttyS0,19200 3
+#istack
+#console=ttyS0,19200 3
 #MOUSE_PORT=/dev/ttyS1


### PR DESCRIPTION
This PR implements the concept of "high priority" bottom half (BH) interrupt handlers as a potential solution for certain device drivers which may need their bottom half handlers to execute as soon as possible after their top half interrupt completes. [EDIT: A solution was found where all BH handlers execute as high priority, thus the strike-outs below.]

~Currently,~ "normal" BH handlers ~may be~ are no longer delayed. ~due to the design decision of running them only when no other kernel code was previously executing, which essentially allows almost any code to be called from the bottom handler (except schedule() and sleep_on/do_wait etc of course), and guarantees that any interrupted kernel code completes before BH execution.~

The current method of selecting when bottom half handlers can run is quite conservative, and purposely doesn't introduce changed code paths for more complex scenarios. This was done to ensure that system stability remains very high. Speeding up the current delay for normal BH handlers ~can likely be~ is now accomplished.  ~but must be done with the ability to also test during more complex application and driver involvement.~

When the system is busy executing other processes, it was found in https://github.com/ghaerr/elks/pull/2533 that bottom half delays of 20-80ms (2-8 timer ticks) were sometimes occurring, until the system was relatively idle. For the timer_bh bottom half, this isn't  too big a deal, since jiffies are incremented in the top half. But for network packet transmit/receive, this could result in much decreased networking speed.

Without more experimentation, it is hard to tell exactly how quickly a bottom half handler for various device drivers must be called, and thus a higher-priority implementation was designed. ~to allow either to be used very easily. In irq.h, the following code is used to define the execution order of bottom half routines~
```
/* BH handlers, run in increasing numeric order */
enum {
//  NETWORK_BH = 0,         /* high priority */
    TIMER_BH = 1,           /* lower priority */
    SERIAL_BH,
    MAX_SOFTIRQ
};
```
The enumerated routines will be run in increasing numeric order. ~A BHM_HIPRI mask is used to designate which of the lowest-numbered routines have high priority, and these will now be executed as soon as possible (when marked) after the top half interrupt exits, while the remaining routines may be delayed as usual.~

~The unused NETWORK_BH is number 0, which designates it to be the first routine to run, and its mask value (1 << 0) is set in BHM_HIPRI to designate it as a high priority handler. The TIMER_BH runs next (when marked, of course) and is normal priority. (To add yet another high priority handler designate it as number 1, and set BHM_HIPRI to 3. The remaining handlers would then be numbered from 2 upwards).~

Currently, no NIC drivers use BH handlers, and the timer BH is the only handler that ever runs. For reasons of keeping extreme stability in the kernel, the mechanism of exactly how/when the bottom half handlers run has not been changed, and won't likely be until more experimentation can occur with converted device drivers. The overall overhead of implementing high priority handlers is only 3 instructions/interrupt, so this won't affect much. The now-default fast serial drivers don't take this code path at all, so will have no effect on serial input speed.

Discussion on strategies for writing top/bottom half NIC interrupt handlers is occurring in https://github.com/Mellvik/TLVC/issues/212.



