### PR TITLE
[kernel] Reduce kernel .text size for more near code space

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -183,10 +183,10 @@ int tty_open(struct inode *inode, struct file *file)
 
 void tty_release(struct inode *inode, struct file *file)
 {
-    register struct tty *rtty;
+    register struct tty *tty;
 
-    rtty = determine_tty(inode->i_rdev);
-    if (!rtty)
+    tty = determine_tty(inode->i_rdev);
+    if (!tty)
         return;
 
     debug_tty("TTY close pid %P\n");
@@ -196,16 +196,16 @@ void tty_release(struct inode *inode, struct file *file)
         return;
 
     /* don't release pgrp for /dev/tty, only real tty*/
-    if (current->pid == rtty->pgrp) {
+    if (current->pid == tty->pgrp) {
         debug_tty("TTY release pgrp %P\n");
-        if (rtty->termios.c_cflag & HUPCL) {
+        if (tty->termios.c_cflag & HUPCL) {
                 debug_tty("TTY sending SIGHUP pid %P\n");
-                kill_pg(rtty->pgrp, SIGHUP, 1);
+                kill_pg(tty->pgrp, SIGHUP, 1);
         }
-        rtty->pgrp = 0;
+        tty->pgrp = 0;
     }
-    rtty->flags &= ~TTY_OPEN;
-    rtty->ops->release(rtty);
+    tty->flags &= ~TTY_OPEN;
+    tty->ops->release(tty);
 }
 
 /*

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -7,6 +7,7 @@
 #include <linuxmt/signal.h>
 #include <linuxmt/types.h>
 #include <linuxmt/memory.h>
+#include <linuxmt/init.h>
 
 #include <arch/segment.h>
 
@@ -47,7 +48,7 @@ int run_init_process_sptr(const char *cmd, char *sptr, int slen)
  *  so we fork onto our kernel stack.
  */
 
-void kfork_proc(void (*addr)())
+void INITPROC kfork_proc(void (*addr)())
 {
     struct task_struct *t;
 

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -5,6 +5,7 @@
 #include <linuxmt/ntty.h>
 #include <linuxmt/fixedpt.h>
 #include <linuxmt/trace.h>
+#include <linuxmt/init.h>
 #include <arch/io.h>
 #include <arch/irq.h>
 #include <arch/param.h>
@@ -23,7 +24,7 @@ static int spin_on;
 static int delaytick;
 
 #ifdef CONFIG_CPU_USAGE
-static void calc_cpu_usage(void)
+static void FARPROC calc_cpu_usage(void)
 {
     static int count = SAMP_FREQ;
     struct task_struct *p;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -98,7 +98,7 @@ static int nr_free_bh, nr_bh;
 
 #define buf_num(bh)     ((bh) - buffer_heads)   /* buffer number, for debugging */
 
-static void put_last_lru(struct buffer_head *bh)
+static void FARPROC put_last_lru(struct buffer_head *bh)
 {
     ext_buffer_head *ebh = EBH(bh);
 
@@ -323,7 +323,7 @@ void invalidate_buffers(kdev_t dev)
     } while ((bh = ebh->b_prev_lru) != NULL);
 }
 
-static void sync_buffers(kdev_t dev, int wait)
+static void FARPROC sync_buffers(kdev_t dev, int wait)
 {
     struct buffer_head *bh = bh_lru;
     ext_buffer_head *ebh;
@@ -366,7 +366,7 @@ static void sync_buffers(kdev_t dev, int wait)
     debug_blk("SYNC_BUFFERS END %d wrote %d\n", wait, count);
 }
 
-static struct buffer_head *get_free_buffer(void)
+static struct buffer_head * FARPROC get_free_buffer(void)
 {
     struct buffer_head *bh = bh_lru;
     ext_buffer_head *ebh = EBH(bh);
@@ -434,7 +434,7 @@ void bforget(struct buffer_head *bh)
 }
 #endif
 
-static struct buffer_head *find_buffer(kdev_t dev, block32_t block)
+static struct buffer_head * FARPROC find_buffer(kdev_t dev, block32_t block)
 {
     struct buffer_head *bh = bh_llru;
     ext_buffer_head *ebh;

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -40,7 +40,7 @@ static int nr_free_inodes;
 #define SET_COUNT(i)
 #endif
 
-static void remove_inode_free(register struct inode *inode)
+static void FARPROC remove_inode_free(register struct inode *inode)
 {
     register struct inode *ino;
 
@@ -54,7 +54,7 @@ static void remove_inode_free(register struct inode *inode)
         (inode_llru = inode->i_prev)->i_next = NULL;
 }
 
-static void put_last_lru(register struct inode *inode)
+static void FARPROC put_last_lru(register struct inode *inode)
 {
     remove_inode_free(inode);
     inode->i_next = NULL;
@@ -130,7 +130,7 @@ void INITPROC inode_init(void)
  * much better for interrupt latency.
  */
 
-static void wait_on_inode(register struct inode *inode)
+static void FARPROC wait_on_inode(register struct inode *inode)
 {
     while (inode->i_lock) {
         inode->i_count++;
@@ -139,13 +139,13 @@ static void wait_on_inode(register struct inode *inode)
     }
 }
 
-static void lock_inode(register struct inode *inode)
+static void FARPROC lock_inode(register struct inode *inode)
 {
     wait_on_inode(inode);
     inode->i_lock = 1;
 }
 
-static void unlock_inode(register struct inode *inode)
+static void FARPROC unlock_inode(register struct inode *inode)
 {
     inode->i_lock = 0;
     wake_up((struct wait_queue *)inode);
@@ -166,7 +166,7 @@ void invalidate_inodes(kdev_t dev)
     } while ((inode = prev) != NULL);
 }
 
-static void write_inode(register struct inode *inode)
+static void FARPROC write_inode(register struct inode *inode)
 {
     register struct super_block *sb = inode->i_sb;
     if (inode->i_dirt) {
@@ -194,7 +194,7 @@ void sync_inodes(kdev_t dev)
     } while ((inode = inode->i_prev) != NULL);
 }
 
-static struct inode *get_empty_inode(void)
+static struct inode * FARPROC get_empty_inode(void)
 {
     register struct inode *inode;
 
@@ -279,7 +279,7 @@ static void set_ops(register struct inode *inode)
     inode->i_op = inop[(int)tabc[(inode->i_mode & S_IFMT) >> 12]];
 }
 
-static void read_inode(register struct inode *inode)
+static void FARPROC read_inode(register struct inode *inode)
 {
     struct super_block *sb = inode->i_sb;
     register struct super_operations *sop;

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -16,6 +16,7 @@
 #include <linuxmt/fs.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/utime.h>
+#include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 
 #include <arch/segment.h>
@@ -174,7 +175,7 @@ static int do_chown(register struct inode *inode, uid_t user, gid_t group)
 }
 #endif
 
-static int do_chown(register struct inode *inode, uid_t user, gid_t group)
+static int FARPROC do_chown(register struct inode *inode, uid_t user, gid_t group)
 {
     if (IS_RDONLY(inode)) return -EROFS;
 

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -76,7 +76,7 @@ extern void INITPROC tcpdev_init(void);
 extern int INITPROC crtc_probe(unsigned short crtc_base);
 extern void INITPROC crtc_init(int dev);
 
-extern void kfork_proc(void (*addr)());
+extern void INITPROC kfork_proc(void (*addr)());
 extern void arch_setup_user_stack(struct task_struct *, word_t entry, seg_t cseg);
 
 #endif

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -7,9 +7,10 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 
-static void reparent_children(void)
+static void FARPROC reparent_children(void)
 {
     register struct task_struct *p;
 

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -5,6 +5,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/trace.h>
+#include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 
 #include <arch/segment.h>
@@ -13,7 +14,7 @@ int task_slots_unused;
 struct task_struct *next_task_slot;
 pid_t last_pid = 0;
 
-static pid_t get_pid(void)
+static pid_t FARPROC get_pid(void)
 {
     register struct task_struct *p;
 

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -99,7 +99,7 @@ pid_t sys_getpid(int *ppid)
     return twovalues(current->pid, (int *)&current->ppid, ppid);
 }
 
-unsigned short int sys_umask(mode_t mask)
+mode_t sys_umask(mode_t mask)
 {
     mode_t old;
 


### PR DESCRIPTION
Kernel .text size was up to 64608 bytes. This change reduces .text by 1424 bytes, and increases .fartext by 1600 bytes, a net change of +176, but worth it, since the kernel wasn't linking with all three NIC drivers at times.

New .text size 63184 with CONFIG_TRACE linkedin.

Some cleanup in ntty.c and sys.c.