### PR TITLE
[net] Cleanup arp, netstat, httpd source. Reduce executable and memory sizes also

### DIFF
--- a/elkscmd/inet/httpd/Makefile
+++ b/elkscmd/inet/httpd/Makefile
@@ -5,7 +5,7 @@ include $(BASEDIR)/Makefile-rules
 ###############################################################################
 
 LOCALFLAGS=-I$(ELKSCMD_DIR)
-LDFLAGS += -maout-heap=1024 -maout-stack=1024
+LDFLAGS += -maout-heap=256 -maout-stack=2048
 
 ###############################################################################
 

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -36,10 +36,10 @@
 #include <arpa/inet.h>
 #include <sys/wait.h>
 
-#define DEF_PORT		80
-#define DEF_CONTENT	"text/html"
+#define DEF_PORT        80
+#define DEF_CONTENT "text/html"
 
-#define WS(c)	( ((c) == ' ') || ((c) == '\t') || ((c) == '\r') || ((c) == '\n') )
+#define WS(c)   ( ((c) == ' ') || ((c) == '\t') || ((c) == '\r') || ((c) == '\n') )
 
 int listen_sock;
 char buf[1536];
@@ -50,163 +50,163 @@ char* get_mime_type(char *name)
 
     dot = strrchr( name, '.' );
     if ( dot == (char*) 0 )
-	return "text/plain";
+    return "text/plain";
     if ( strcmp( dot, ".html" ) == 0 || strcmp( dot, ".htm" ) == 0 )
-	return "text/html";
+    return "text/html";
     if ( strcmp( dot, ".jpg" ) == 0 || strcmp( dot, ".jpeg" ) == 0 )
-	return "image/jpeg";
+    return "image/jpeg";
     if ( strcmp( dot, ".gif" ) == 0 )
-	return "image/gif";
+    return "image/gif";
     if ( strcmp( dot, ".png" ) == 0 )
-	return "image/png";
+    return "image/png";
     if ( strcmp( dot, ".css" ) == 0 )
-	return "text/css";
+    return "text/css";
     if ( strcmp( dot, ".vrml" ) == 0 || strcmp( dot, ".wrl" ) == 0 )
-	return "model/vrml";
+    return "model/vrml";
     if ( strcmp( dot, ".midi" ) == 0 || strcmp( dot, ".mid" ) == 0 )
-	return "audio/midi";
+    return "audio/midi";
     return "text/plain";
 }
 
 void send_header(int fd, char *ct)
 {
-	buf[0] = 0;
-	sprintf(buf, "HTTP/1.0 200 OK\r\nServer: nanoHTTPd/0.1\r\nDate: Thu Apr 26 15:37:46 GMT 2001\r\nContent-Type: %s\r\n",ct);
-	write(fd, buf, strlen(buf));
+    buf[0] = 0;
+    sprintf(buf, "HTTP/1.0 200 OK\r\nServer: nanoHTTPd/0.1\r\nDate: Thu Apr 26 15:37:46 GMT 2001\r\nContent-Type: %s\r\n",ct);
+    write(fd, buf, strlen(buf));
 }
 
 void send_error(int fd, int errnum, char *str)
 {
-	sprintf(buf,"HTTP/1.0 %d %s\r\nContent-type: %s\r\n", errnum, str, DEF_CONTENT);
-	write(fd, buf, strlen(buf));
-	sprintf(buf,"Connection: close\r\nDate: Thu Apr 26 15:37:46 GMT 2001\r\n\r\n%s\r\n",str);
-	write(fd, buf, strlen(buf));
+    sprintf(buf,"HTTP/1.0 %d %s\r\nContent-type: %s\r\n", errnum, str, DEF_CONTENT);
+    write(fd, buf, strlen(buf));
+    sprintf(buf,"Connection: close\r\nDate: Thu Apr 26 15:37:46 GMT 2001\r\n\r\n%s\r\n",str);
+    write(fd, buf, strlen(buf));
 }
 
 void process_request(int fd)
 {
-	int fin, ret;
-	off_t size;
-	char *c, *file, fullpath[PATH_MAX];
-	struct stat st;
-	
-	ret = read(fd, buf, sizeof(buf));
-	
-	c = buf;
-	while (*c && !WS(*c) && c < (buf + sizeof(buf))){
-		c++;
-	}
-	*c = 0;
-	
-	if (strcasecmp(buf, "get")){
-		send_error(fd, 404, "Method not supported");
-		return;		
-	}
-	
-	file = ++c;
-	while (*c && !WS(*c) && c < (buf + sizeof(buf))){
-		c++;
-	}
-	*c = 0;
+    int fin, ret;
+    off_t size;
+    char *c, *file, fullpath[PATH_MAX];
+    struct stat st;
+    
+    ret = read(fd, buf, sizeof(buf));
+    
+    c = buf;
+    while (*c && !WS(*c) && c < (buf + sizeof(buf))){
+        c++;
+    }
+    *c = 0;
+    
+    if (strcasecmp(buf, "get")){
+        send_error(fd, 404, "Method not supported");
+        return;     
+    }
+    
+    file = ++c;
+    while (*c && !WS(*c) && c < (buf + sizeof(buf))){
+        c++;
+    }
+    *c = 0;
 
-	/* TODO : Use strncat when security is the only problem of this server! */
-	strcpy(fullpath, _PATH_DOCBASE);
-	strcat(fullpath, file);
-	
-	if (!stat(fullpath, &st) && (st.st_mode & S_IFMT) == S_IFDIR) {
-		if (file[strlen(fullpath) - 1] != '/'){
-			strcat(fullpath, "/");
-		}
-		strcat(fullpath, "index.html");
-	}
-	
-	fin = open(fullpath, O_RDONLY);
-	if (fin < 0){
-		send_error(fd, 404, "Document (probably) not found");
-		return;
-	}
-	size = lseek(fin, (off_t)0, SEEK_END);
-	lseek(fin, (off_t)0, SEEK_SET);
-	send_header(fd, get_mime_type(fullpath));
-	sprintf(buf,"Content-Length: %ld\r\n\r\n", size);
-	write(fd, buf, strlen(buf));
-	
-	do {
-		ret = read(fin, buf, sizeof(buf));
-		if (ret > 0)
-			ret = write(fd, buf, ret);
-	} while (ret == sizeof(buf));
-	
-	close(fin);
-	
+    /* TODO : Use strncat when security is the only problem of this server! */
+    strcpy(fullpath, _PATH_DOCBASE);
+    strcat(fullpath, file);
+    
+    if (!stat(fullpath, &st) && (st.st_mode & S_IFMT) == S_IFDIR) {
+        if (file[strlen(fullpath) - 1] != '/'){
+            strcat(fullpath, "/");
+        }
+        strcat(fullpath, "index.html");
+    }
+    
+    fin = open(fullpath, O_RDONLY);
+    if (fin < 0){
+        send_error(fd, 404, "Document (probably) not found");
+        return;
+    }
+    size = lseek(fin, (off_t)0, SEEK_END);
+    lseek(fin, (off_t)0, SEEK_SET);
+    send_header(fd, get_mime_type(fullpath));
+    sprintf(buf,"Content-Length: %ld\r\n\r\n", size);
+    write(fd, buf, strlen(buf));
+    
+    do {
+        ret = read(fin, buf, sizeof(buf));
+        if (ret > 0)
+            ret = write(fd, buf, ret);
+    } while (ret == sizeof(buf));
+    
+    close(fin);
+    
 }
 
 int main(int argc, char **argv)
 {
-	int ret, conn_sock;
-	struct sockaddr_in localadr;
+    int ret, conn_sock;
+    struct sockaddr_in localadr;
 
-	if ((listen_sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		perror("httpd");
-		return -1;
-	}
+    if ((listen_sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        perror("httpd");
+        return -1;
+    }
 
-	/* set local port reuse, allows server to be restarted in less than 10 secs */
-	ret = 1;
-	if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(int)) < 0)
-		perror("SO_REUSEADDR");
+    /* set local port reuse, allows server to be restarted in less than 10 secs */
+    ret = 1;
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(int)) < 0)
+        perror("SO_REUSEADDR");
 
-	/* set small listen buffer to save ktcp memory */
-	ret = SO_LISTEN_BUFSIZ;
-	if (setsockopt(listen_sock, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
-		perror("SO_RCVBUF");
+    /* set small listen buffer to save ktcp memory */
+    ret = SO_LISTEN_BUFSIZ;
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
+        perror("SO_RCVBUF");
 
-	localadr.sin_family = AF_INET;
-	localadr.sin_port = htons(DEF_PORT);
-	localadr.sin_addr.s_addr = INADDR_ANY;
+    localadr.sin_family = AF_INET;
+    localadr.sin_port = htons(DEF_PORT);
+    localadr.sin_addr.s_addr = INADDR_ANY;
 
-	if (bind(listen_sock, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in)) < 0) {
-		fprintf(stderr, "httpd: bind error (may already be running)\n");
-		return 1;
-	}
-	if (listen(listen_sock, 5) < 0) {
-		perror("listen");
-		return 1;
-	}
+    if (bind(listen_sock, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in)) < 0) {
+        fprintf(stderr, "httpd: bind error (may already be running)\n");
+        return 1;
+    }
+    if (listen(listen_sock, 5) < 0) {
+        perror("listen");
+        return 1;
+    }
 
-	/* become daemon, debug output on 1 and 2*/
-	if ((ret = fork()) == -1) {
-		perror("httpd");
-		return 1;
-	}
-	if (ret) exit(0);
-	ret = open("/dev/null", O_RDWR); /* our log file! */
-	dup2(ret, 0);
-	dup2(ret, 1);
-	dup2(ret, 2);
-	if (ret > 2)
-		close(ret);
-	setsid();
+    /* become daemon, debug output on 1 and 2*/
+    if ((ret = fork()) == -1) {
+        perror("httpd");
+        return 1;
+    }
+    if (ret) exit(0);
+    ret = open("/dev/null", O_RDWR); /* our log file! */
+    dup2(ret, 0);
+    dup2(ret, 1);
+    dup2(ret, 2);
+    if (ret > 2)
+        close(ret);
+    setsid();
 
-	while (1) {
-		conn_sock = accept(listen_sock, NULL, NULL);
-		
-		if (conn_sock < 0) {
-			if (errno == ENOTSOCK)
-				exit(1);
-			continue;
-		}
+    while (1) {
+        conn_sock = accept(listen_sock, NULL, NULL);
+        
+        if (conn_sock < 0) {
+            if (errno == ENOTSOCK)
+                exit(1);
+            continue;
+        }
 
-		if ((ret = fork()) == -1)
-			perror("httpd");
-		else if (ret == 0) {
-			close(listen_sock);
-			process_request(conn_sock);
-			close(conn_sock);
-			exit(0);
-		} else {
-			close(conn_sock);
-			waitpid(ret, NULL, 0);
-		}
-	}
+        if ((ret = fork()) == -1)
+            perror("httpd");
+        else if (ret == 0) {
+            close(listen_sock);
+            process_request(conn_sock);
+            close(conn_sock);
+            exit(0);
+        } else {
+            close(conn_sock);
+            waitpid(ret, NULL, 0);
+        }
+    }
 }

--- a/elkscmd/inet/nettools/arp.c
+++ b/elkscmd/inet/nettools/arp.c
@@ -19,6 +19,8 @@
 #include <ktcp/arp.h>
 #include <arpa/inet.h>
 
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
+
 struct arp_cache arp_cache[ARP_CACHE_MAX];
 
 char *mac_ntoa(eth_addr_t eth_addr)
@@ -37,7 +39,7 @@ int main(int ac, char **av)
     struct sockaddr_in localadr, remaddr;
 
     if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-        perror("arp");
+        errmsg("arp: Network is down\n");
         return 1;
     }
 
@@ -45,7 +47,7 @@ int main(int ac, char **av)
     localadr.sin_port = PORT_ANY;
     localadr.sin_addr.s_addr = INADDR_ANY;  
     if (bind(s, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in)) < 0) {
-        perror("bind");
+        errmsg("arp: bind failure\n");
         return 1;
     }
 
@@ -53,7 +55,7 @@ int main(int ac, char **av)
     remaddr.sin_port = htons(NETCONF_PORT);
     remaddr.sin_addr.s_addr = 0;
     if (connect(s, (struct sockaddr *)&remaddr, sizeof(struct sockaddr_in)) < 0) {
-        perror("connect");
+        errmsg("arp: Can't connect to ktcp\n");
         return 1;
     }
 
@@ -61,7 +63,7 @@ int main(int ac, char **av)
     write(s, &sr, sizeof(sr));
     ret = read(s, arp_cache, ARP_CACHE_MAX*sizeof(struct arp_cache));
     if (ret != ARP_CACHE_MAX*sizeof(struct arp_cache)) {
-        perror("read");
+        errmsg("arp: Can't read ARP cache\n");
         return 1;
     }
 

--- a/elkscmd/inet/nettools/arp.c
+++ b/elkscmd/inet/nettools/arp.c
@@ -37,38 +37,38 @@ int main(int ac, char **av)
     struct sockaddr_in localadr, remaddr;
 
     if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-	perror("arp");
-	return 1;
+        perror("arp");
+        return 1;
     }
 
     localadr.sin_family = AF_INET;
     localadr.sin_port = PORT_ANY;
     localadr.sin_addr.s_addr = INADDR_ANY;  
     if (bind(s, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in)) < 0) {
-	perror("bind");
-	return 1;
+        perror("bind");
+        return 1;
     }
 
     remaddr.sin_family = AF_INET;
     remaddr.sin_port = htons(NETCONF_PORT);
     remaddr.sin_addr.s_addr = 0;
     if (connect(s, (struct sockaddr *)&remaddr, sizeof(struct sockaddr_in)) < 0) {
-	perror("connect");
-	return 1;
+        perror("connect");
+        return 1;
     }
 
     sr.type = NS_ARP;
-    write(s, &sr, sizeof(sr));	
+    write(s, &sr, sizeof(sr));
     ret = read(s, arp_cache, ARP_CACHE_MAX*sizeof(struct arp_cache));
     if (ret != ARP_CACHE_MAX*sizeof(struct arp_cache)) {
-	perror("read");
-	return 1;
+        perror("read");
+        return 1;
     }
 
     for(i=0; i<ARP_CACHE_MAX; i++) {
-	if (arp_cache[i].ip_addr)
-		printf("%-15s %s\n", in_ntoa(arp_cache[i].ip_addr),
-			mac_ntoa(arp_cache[i].eth_addr));
+        if (arp_cache[i].ip_addr)
+                printf("%-15s %s\n", in_ntoa(arp_cache[i].ip_addr),
+                        mac_ntoa(arp_cache[i].eth_addr));
     }
     return 1;
 }

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -29,23 +29,23 @@
 #include <ktcp/netconf.h>
 
 char *tcp_states[11] = {
-	"CLOSED",
-	"LISTEN",
-	"SYN_SENT",
-	"SYN_RECEIVED",
-	"ESTABLISHED",
-	"FIN_WAIT_1",
-	"FIN_WAIT_2",
-	"CLOSE_WAIT",
-	"CLOSING",
-	"LAST_ACK",
-	"TIME_WAIT"	
+    "CLOSED",
+    "LISTEN",
+    "SYN_SENT",
+    "SYN_RECEIVED",
+    "ESTABLISHED",
+    "FIN_WAIT_1",
+    "FIN_WAIT_2",
+    "CLOSE_WAIT",
+    "CLOSING",
+    "LAST_ACK",
+    "TIME_WAIT"
 };
 
 timeq_t timer_get_time(void)
 {
-    struct timezone	tz;
-    struct timeval 	tv;
+    struct timezone tz;
+    struct timeval tv;
 
     gettimeofday(&tv, &tz);
 
@@ -65,30 +65,30 @@ int main(int ac, char **av)
     __u8 *addrbytes;
     char buf[100];
     char addr[16];
-	    
+
     if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-	perror("netstat");
-	return 1;
+        perror("netstat");
+        return 1;
     }
 
     localadr.sin_family = AF_INET;
     localadr.sin_port = PORT_ANY;
     localadr.sin_addr.s_addr = INADDR_ANY;  
     if (bind(s, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in)) < 0) {
-	perror("bind");
-	return 1;
+        perror("bind");
+        return 1;
     }
 
     remaddr.sin_family = AF_INET;
     remaddr.sin_port = htons(NETCONF_PORT);
     remaddr.sin_addr.s_addr = 0;
     if (connect(s, (struct sockaddr *)&remaddr, sizeof(struct sockaddr_in)) < 0) {
-	perror("connect");
-	return 1;
+        perror("connect");
+        return 1;
     }
 
     sr.type = NS_GENERAL;
-    write(s, &sr, sizeof(sr));	
+    write(s, &sr, sizeof(sr));
     read(s, buf, sizeof(buf));
     gstats = (struct general_stats_s *)buf;
     retrans_mem = gstats->retrans_memory;
@@ -114,24 +114,24 @@ int main(int ac, char **av)
     printf(" No        State    RTT lport        raddress  rport\n");
     printf("-----------------------------------------------------\n");
     sr.type = NS_CB;
-    for (i = 0 ;; i++){
-		sr.extra = i;
-		write(s, &sr, sizeof(sr));	
-		read(s, buf, sizeof(buf));
-		cbstats = (struct cb_stats_s *)buf;
-		if (cbstats->valid == 0)break;
-		addrbytes = (__u8 *)&cbstats->remaddr;
-		sprintf(addr,"%d.%d.%d.%d",addrbytes[0],addrbytes[1],addrbytes[2],addrbytes[3]);
-		printf("%3d %12s %4dms", i+1, tcp_states[cbstats->state], cbstats->rtt);
-		printf(" %5u %15s  %5u", cbstats->localport, addr, cbstats->remport);
-		if (cbstats->state > TS_ESTABLISHED) {
-			/* time is in 1/16 second clicks*/
-			int secs = (unsigned)(cbstats->time_wait_exp - (long)timer_get_time());
-			unsigned int tenthsecs = ((secs + 8) & 15) >> 1;
-			secs >>= 4;
-			printf(" (%d.%d secs)", secs, tenthsecs);
-		}
-		printf("\n");
+    for (i = 0;; i++) {
+        sr.extra = i;
+        write(s, &sr, sizeof(sr));
+        read(s, buf, sizeof(buf));
+        cbstats = (struct cb_stats_s *)buf;
+        if (cbstats->valid == 0)break;
+        addrbytes = (__u8 *)&cbstats->remaddr;
+        sprintf(addr,"%d.%d.%d.%d",addrbytes[0],addrbytes[1],addrbytes[2],addrbytes[3]);
+        printf("%3d %12s %4dms", i+1, tcp_states[cbstats->state], cbstats->rtt);
+        printf(" %5u %15s  %5u", cbstats->localport, addr, cbstats->remport);
+        if (cbstats->state > TS_ESTABLISHED) {
+                /* time is in 1/16 second clicks*/
+                int secs = (unsigned)(cbstats->time_wait_exp - (long)timer_get_time());
+                unsigned int tenthsecs = ((secs + 8) & 15) >> 1;
+                secs >>= 4;
+                printf(" (%d.%d secs)", secs, tenthsecs);
+        }
+        printf("\n");
     }
     return 0;
 }

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -17,7 +17,6 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
-
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -27,6 +26,8 @@
 #include <arpa/inet.h>
 #include <ktcp/tcp.h>
 #include <ktcp/netconf.h>
+
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
 
 char *tcp_states[11] = {
     "CLOSED",
@@ -67,7 +68,7 @@ int main(int ac, char **av)
     char addr[16];
 
     if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-        perror("netstat");
+        errmsg("netstat: Network is down\n");
         return 1;
     }
 
@@ -75,7 +76,7 @@ int main(int ac, char **av)
     localadr.sin_port = PORT_ANY;
     localadr.sin_addr.s_addr = INADDR_ANY;  
     if (bind(s, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in)) < 0) {
-        perror("bind");
+        errmsg("netstat bind failure\n");
         return 1;
     }
 
@@ -83,7 +84,7 @@ int main(int ac, char **av)
     remaddr.sin_port = htons(NETCONF_PORT);
     remaddr.sin_addr.s_addr = 0;
     if (connect(s, (struct sockaddr *)&remaddr, sizeof(struct sockaddr_in)) < 0) {
-        perror("connect");
+        errmsg("netstat: Can't connect to ktcp\n");
         return 1;
     }
 

--- a/elkscmd/inet/telnetd/Makefile
+++ b/elkscmd/inet/telnetd/Makefile
@@ -10,7 +10,7 @@ include $(BASEDIR)/Makefile-rules
 
 SRCS = telnetd.c telnet.c
 OBJS = $(SRCS:.c=.o) 
-LDFLAGS += -maout-heap=1024 -maout-stack=1024
+LDFLAGS += -maout-heap=256 -maout-stack=1024
 
 all:	telnetd
 


### PR DESCRIPTION
Reduce resident memory used by httpd and telnetd daemons.
Fixes httpd operation when out of processes.
Emit better errror messages in arp, netstat and httpd; eliminate perror to decrease executable size.
Reformats source code for arp.c, netstat.c, httpd.c. Commits were made directly after reformatting to enable more easily seeing other enhancements.