### PR TITLE
[kernel] Increase size of max UNIX socket name to 20

### DIFF
--- a/elks/include/linuxmt/un.h
+++ b/elks/include/linuxmt/un.h
@@ -1,7 +1,7 @@
 #ifndef __LINUXMT_UN_H
 #define __LINUXMT_UN_H
 
-#define UNIX_PATH_MAX   16          /* keep size of unix_proto_data small, incl/NUL */
+#define UNIX_PATH_MAX   20          /* keep size of unix_proto_data small, incl/NUL */
 
 struct sockaddr_un {
     unsigned short sun_family;		/* AF_UNIX */

--- a/elkscmd/screen/screen.c
+++ b/elkscmd/screen/screen.c
@@ -134,7 +134,7 @@ static char DefaultShell[] = "/bin/sh";
 static char DefaultPath[] = ":/bin:/usr/bin";
 static int TtyMode = 0622;
 static char SockPath[PATH_MAX];
-static char SockDir[] = "screen";
+static char SockDir[] = "scr";
 static char *SockNamePtr, *SockName;
 static int ServerSocket;
 static char *NewEnv[MAXARGS];
@@ -313,7 +313,7 @@ main(int ac, char **av)
     if ((home = getenv("HOME")) == 0)
         Msg(0, "$HOME is undefined.");
 
-    sprintf(SockPath, "%s/%s", home, SockDir);  /* SockDir = "screen" */
+    sprintf(SockPath, "%s/%s", home, SockDir);  /* SockDir = "scr" */
     if (stat(SockPath, &st) == -1) {
         if (errno == ENOENT) {
             if (mkdir(SockPath, 0700) == -1)
@@ -1392,14 +1392,14 @@ MakeServerSocket(void)
     a.sun_family = AF_UNIX;
     strcpy(SockNamePtr, SockName);
     strcpy(a.sun_path, SockPath);
-    if (connect(s, (struct sockaddr *)&a, strlen(SockPath) + 2) != -1) {
+    if (connect(s, (struct sockaddr *)&a, strlen(SockPath) + 1) != -1) {
         p = Filename(SockPath);
         Msg(0, "You have already a screen running on %s.\n\
 If it has been detached, try \"screen -r\".", p);
         /* NOTREACHED */
     }
     unlink(SockPath);
-    if (bind(s, (struct sockaddr *)&a, strlen(SockPath) + 2) == -1)
+    if (bind(s, (struct sockaddr *)&a, strlen(SockPath) + 1) == -1)
         Msg(errno, "bind");
     chown(SockPath, getuid(), getgid());
     if (listen(s, 5) == -1)
@@ -1418,7 +1418,7 @@ MakeClientSocket(int err)
     a.sun_family = AF_UNIX;
     strcpy(SockNamePtr, SockName);
     strcpy(a.sun_path, SockPath);
-    if (connect(s, (struct sockaddr *)&a, strlen(SockPath) + 2) == -1) {
+    if (connect(s, (struct sockaddr *)&a, strlen(SockPath) + 1) == -1) {
         if (err) {
             Msg(errno, "connect: %s", SockPath);
         } else {


### PR DESCRIPTION
Fixes #2541. The max size of a UNIX socket (string) name was previously decreased from 110 bytes to 16, saving lots of usually unused kernel data space, since 16 UNIX sockets are statically allocated. This increases it to 20.

When `screen` starts up, it used to create a UNIX socket with the name /root/screen/tty1.scr, which was failing in `connect`. The name has been shorted to /root/scr/tty1.scr, which fits within the 20 bytes now allowed.