### PR TITLE
[net] Ensure ISIG off and OPOST and ONLCR on in telnet

### DIFF
--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -220,12 +220,11 @@ main(int argc, char **argv)
 
     struct termios termios;
     tcgetattr(0, &termios);
+    termios.c_oflag |= (OPOST | ONLCR);
+    termios.c_lflag &= ~ISIG;       /* ISIG off to disable ^N/^O/^P */
 #ifdef RAWTELNET
     termios.c_iflag &= ~(ICRNL | IGNCR | INLCR | IXON | IXOFF);
-    termios.c_oflag &= ~(OPOST);
-    termios.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG);
-#else
-    termios.c_lflag &= ~ISIG;   /* ISIG off to disable ^N/^O/^P */
+    termios.c_lflag &= ~(ECHO | ECHONL | ICANON)
 #endif
     tcsetattr(0, TCSANOW, &termios);
     nonblock = 1;


### PR DESCRIPTION
This is mostly an additional cleanup PR, as ISIG/^O was already handled in #2543. 

Now, ISIG is also disabled in WILL ECHO, as well as forcing OPOST and OCRNL on, which renders extra CRs embedded in various writes to be removed.

Also fixes potential use of uninitialized term_env variable and cleans up debug messages.