### PR TITLE
[net] Don't discard output when ^C typed, use ^C^O instead

### DIFF
--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -20,13 +20,13 @@
 /* /dev/ptyp0 master (PTY) open */
 int pty_open(struct inode *inode, struct file *file)
 {
-    register struct tty *otty;
+    register struct tty *tty;
 
-    if (!(otty = determine_tty(inode->i_rdev))) {
+    if (!(tty = determine_tty(inode->i_rdev))) {
 	debug("pty open fail NODEV\n");
 	return -ENODEV;
     }
-    if (otty->flags & TTY_OPEN) {
+    if (tty->flags & TTY_OPEN) {
 	debug("pty open fail BUSY\n");
 	return -EBUSY;
     }
@@ -36,11 +36,11 @@ int pty_open(struct inode *inode, struct file *file)
 /* /dev/ptyp0 master close */
 void pty_release(struct inode *inode, struct file *file)
 {
-    register struct tty *otty;
+    register struct tty *tty;
 
     debug("pty release\n");
-    if ((otty = determine_tty(inode->i_rdev)))
-	kill_pg(otty->pgrp, SIGHUP, 1);
+    if ((tty = determine_tty(inode->i_rdev)))
+	kill_pg(tty->pgrp, SIGHUP, 1);
 }
 
 /* /dev/ptyp0 master select */
@@ -94,7 +94,7 @@ size_t pty_read (struct inode *inode, struct file *file, char *data, size_t len)
 			break;
 		}
 
-		put_user_char (tty_outproc (tty), (void *)(data++));
+		put_user_char (tty_outproc (tty), data++);
 		count++;
 	}
 

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -23,6 +23,7 @@
 #include <linuxmt/in.h>
 #include <linuxmt/tcpdev.h>
 #include <linuxmt/debug.h>
+#include <arch/irq.h>
 
 #include "af_inet.h"
 
@@ -369,7 +370,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
             if (ret == -ERESTARTSYS) {
                 /* delay process 100ms*/
                 current->state = TASK_INTERRUPTIBLE;
-                current->timeout = jiffies + (HZ / 10); /* 1/10 sec = 100ms*/
+                current->timeout = jiffies() + (HZ / 10); /* 1/10 sec = 100ms*/
                 schedule();
             } else
                 return ret;

--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -8,7 +8,6 @@
  */
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <termios.h>
 #include <signal.h>
@@ -101,9 +100,12 @@ read_keyboard(void)
         fprintf(stderr, "\nSession terminated\n");
         finish();
     }
+#if DISABLED
     if (buffer[0] == CTRL('C'))
         discard = 1;
-    else if (buffer[0] == CTRL('O')) {
+    else
+#endif
+    if (buffer[0] == CTRL('O')) {
         discard ^= 1;
         return;
     }
@@ -224,7 +226,7 @@ main(int argc, char **argv)
     termios.c_lflag &= ~ISIG;       /* ISIG off to disable ^N/^O/^P */
 #ifdef RAWTELNET
     termios.c_iflag &= ~(ICRNL | IGNCR | INLCR | IXON | IXOFF);
-    termios.c_lflag &= ~(ECHO | ECHONL | ICANON)
+    termios.c_lflag &= ~(ECHO | ECHONL | ICANON);
 #endif
     tcsetattr(0, TCSANOW, &termios);
     nonblock = 1;
@@ -239,7 +241,7 @@ main(int argc, char **argv)
         FD_SET(0, &fdset);
         FD_SET(tcp_fd, &fdset);
         tv.tv_sec = 0;
-        tv.tv_usec = 100000L;
+        tv.tv_usec = 100000L;   /* 100ms */
 
         n = select(tcp_fd + 1, &fdset, NULL, NULL, &tv);
         if (n == 0) {


### PR DESCRIPTION
In `telnet`, typing ^C sends ^C but no longer discards output (see below). Use ^C^O to terminate the active program and start discarding output. Originally discussed in https://github.com/Mellvik/TLVC/pull/215.

While debugging https://github.com/ghaerr/microwindows/pull/160 which invovled running `sl`, it was noticed that `sl` displays output continuously, but also ignores ^C/SIGINT. When a user types ^C to terminate sl, on a shell nothing happens (the `sl` train keeps moving), but from within a telnet session, the system appears to hang (because of telnet discarding sl's streaming output). It was thus decided that the two-character sequence ^C^O should be used for very fast remote hosts rather than discarding output when programs might ignore SIGINT.

Various other small source cleanups and a volatile jiffies variable access fixed in network inet_write().