### PR TITLE
[kernel] Cleanup potential kernel startup issues, release more memory

### DIFF
--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -50,10 +50,6 @@ _start:
 
         call    start_kernel    // no return
 
-        .global int3
-int3:   int     $3              // C breakpoint for emu86
-        ret
-
 #if defined(CONFIG_ARCH_SWAN)
 early_putchar:
 1:      in      $0xB3,%al

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -79,18 +79,6 @@ entry.S: syscall.dat mkentry.sh
 strace.o: strace.c
 	$(CC) $(CFLAGS) -fno-optimize-sibling-calls -c -o strace.o strace.c
 
-#
-# Special compilations apparently needed for startup failure using emu86 w/ROM
-# FIXME Apparent stack trashing but not fully verified
-irq.o: irq.c
-	$(CC) $(CFLAGS) -fno-defer-pop -c -o irq.o irq.c
-
-#irq-8259.o: irq-8259.c
-#	$(CC) $(CFLAGS) -fno-defer-pop -c -o irq-8259.o irq-8259.c
-
-#timer-8254.o: timer-8254.c
-#	$(CC) $(CFLAGS) -fno-defer-pop -c -o timer-8254.o timer-8254.c
-
 #########################################################################
 # Standard commands.
 

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -155,6 +155,4 @@ void INITPROC irq_init(void)
 
     enable_timer_tick();        /* reprogram timer for 100 HZ */
 #endif
-
-    init_bh(TIMER_BH, timer_bh);
 }

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -96,6 +96,7 @@ utask:
 #ifdef CHECK_SS
 //
 //      We were in user mode, first confirm
+//      FIXME: won't work - panic requires valid SS and SS == DS!
 //
         mov     %ss,%di
         cmp     TASK_USER_SS(%si),%di // entry SS = current->t_regs.ss?
@@ -377,14 +378,6 @@ tswitch:
         pop     %es
         pop     %bp             // BP of schedule()
         ret
-
-// setsp(void *sp) - set stack pointer
-        .global setsp
-setsp:
-        pop     %bx             // return address
-        pop     %ax
-        mov     %ax,%sp
-        jmp     *%bx
 
 // short *getsp(void) - get stack pointer
         .global getsp

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -143,7 +143,8 @@ static void check_kstack(int n)
     static int max;
 
 #ifdef CHECK_ISTACK
-    check_istack();
+    if (tracing & TRACE_ISTACK)
+	check_istack();
 #endif
     s = syscall_info(current->t_regs.orig_ax);
     if (s == &notimp)

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -144,7 +144,7 @@ static void check_kstack(int n)
 
 #ifdef CHECK_ISTACK
     if (tracing & TRACE_ISTACK)
-	check_istack();
+        check_istack();
 #endif
     s = syscall_info(current->t_regs.orig_ax);
     if (s == &notimp)

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -110,6 +110,19 @@ void do_bottom_half(void);
                         : "memory");        \
         v; })
 
+/* set stack pointer */
+#define setsp(newsp)                    \
+        asm volatile ("mov %%ax,%%sp"   \
+            : /* no output */           \
+            :"a" ((unsigned short)(newsp)) \
+            :"memory")
+
+/* breakpoint interrupt */
+#define int3()                  \
+        asm volatile ("int $3\n"\
+            : /* no output */   \
+            : /* no input */)
+
 #ifdef CONFIG_ARCH_SWAN
 /* acknowledge interrupt */
 #define ack_irq(i)              \

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -172,7 +172,6 @@ extern unsigned int get_ustack(struct task_struct *,int);
 extern void put_ustack(register struct task_struct *,int,int);
 
 extern void tswitch(void);
-extern void setsp(void *);
 extern short *getsp(void);
 extern int run_init_process(const char *cmd);
 extern int run_init_process_sptr(const char *cmd, char *sptr, int slen);

--- a/elks/init/Makefile
+++ b/elks/init/Makefile
@@ -30,7 +30,7 @@ include $(BASEDIR)/Makefile-rules
 all:    main.o
 
 main.o: main.c
-	$(CC) $(CFLAGS) -fno-defer-pop -c -o main.o main.c
+	$(CC) $(CFLAGS) -fno-optimize-sibling-calls -fno-defer-pop -c -o main.o main.c
 
 
 #########################################################################

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -119,7 +119,6 @@ static void FARPROC far_start_kernel(void)
     save_flags(flags);
     clr_irq();                      /* we're running on the kernel interrupt stack! */
     printk("INT %x ", flags);       /* to show interrupt status after setup.S */
-    printk("SP %x ", getsp());
     printk("START\n");
 
     early_kernel_init();            /* read bootopts using kernel interrupt stack */
@@ -156,8 +155,6 @@ static void FARPROC far_start_kernel(void)
 /* the idle task loop, no return */
 static void idle_loop(void)
 {
-    debug("IDLE LOOP\n");
-
     /*
      * Set SP to the small stack in the special idle task struct.
      * We then become the idle task and are only switched to when the last runnable
@@ -166,6 +163,7 @@ static void idle_loop(void)
      * interrupt register saves will be on the interrupt stack, not the idle stack.
      */
     setsp(&idle_task->t_kstack[IDLESTACK_BYTES/2]);
+    debug("IDLE LOOP\n");
     //hexdump(idle_task->t_kstack, kernel_ds, IDLESTACK_BYTES, 1);
 
     /*

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -15,6 +15,7 @@
 #include <linuxmt/devnum.h>
 #include <linuxmt/heap.h>
 #include <linuxmt/prectimer.h>
+#include <linuxmt/timer.h>
 #include <linuxmt/debug.h>
 #include <arch/segment.h>
 #include <arch/ports.h>
@@ -90,10 +91,12 @@ static void INITPROC finalize_options(void);
 static char * INITPROC option(char *s);
 #endif /* CONFIG_BOOTOPTS */
 
+static void FARPROC far_start_kernel(void);
 static void INITPROC early_kernel_init(void);
 static void INITPROC kernel_init(void);
 static void INITPROC kernel_banner(seg_t init, seg_t extra);
 static void init_task(void);
+static void idle_loop(void);
 
 /*
  * This function is called using the interrupt stack as a temporary stack.
@@ -102,51 +105,67 @@ static void init_task(void);
  * switched again to the tiny idle task struct stack area and then becomes the
  * idle task. Must be compiled using -fno-defer-pop, as otherwise stack pointer
  * cleanup is delayed after function calls, which interferes with SP resets.
+ * No return is allowed since SP is switched, and the memory used by far_start_kernel
+ * is released after kernel initialization is complete.
  */
 void start_kernel(void)
 {
-    flag_t flags;                   /* check interrupts - should already be disabled! */
+    far_start_kernel();             /* start executing in reusable memory */
+}
+
+static void FARPROC far_start_kernel(void)
+{
+    flag_t flags;                   /* get CPU flag word */
     save_flags(flags);
-    if (flags & 0x0200)
-        printk("INT ON ");          /* warning message for bad setup.S code */
-    clr_irq();
-
+    clr_irq();                      /* we're running on the kernel interrupt stack! */
+    printk("INT %x ", flags);       /* to show interrupt status after setup.S */
+    printk("SP %x ", getsp());
     printk("START\n");
-    early_kernel_init();            /* read bootopts using kernel temp stack */
 
-    /*
-     * Allocate the task array + smaller task struct for the idle task.
-     * The idle task struct has a smaller stack in t_kstack[] and no t_regs.
-     * This works because the idle task always runs at intr_count 1, so
-     * interrupts will always save registers onto istack, and never
-     * to the t_regs struct at the end of a normal task struct.
-     */
-    task = heap_alloc(max_tasks * sizeof(struct task_struct) +
-        TASK_KSTACK + IDLESTACK_BYTES, HEAP_TAG_TASK|HEAP_TAG_CLEAR);
-    if (!task) panic("No task mem");
-    idle_task = (struct task_struct *)
-        ((char *)task + max_tasks * sizeof(struct task_struct));
+    early_kernel_init();            /* read bootopts using kernel interrupt stack */
+
+     /*
+      * Allocate the task array + smaller task struct for the idle task.
+      * The idle task struct has a smaller stack in t_kstack[] and no t_regs.
+      * This works because the idle task always runs at intr_count 1, so
+      * interrupts will always save registers onto istack, and never
+      * to the t_regs struct at the end of a normal task struct.
+      */
+     task = heap_alloc(max_tasks * sizeof(struct task_struct) +
+         TASK_KSTACK + IDLESTACK_BYTES, HEAP_TAG_TASK|HEAP_TAG_CLEAR);
+     if (!task) panic("No task mem");
+     idle_task = (struct task_struct *)
+         ((char *)task + max_tasks * sizeof(struct task_struct));
+    setsp(&(task+1)->t_regs.ax);    /* change to a large temp stack (unused task #1) */
+    debug("SP SWITCH\n");
+
+    printk("endbss %x task %x idle_task %x idle_stack %x\n",
+        _endbss, task, idle_task, &idle_task->t_kstack[IDLESTACK_BYTES/2]);
 
     sched_init();                   /* init the idle and other task structs */
-    setsp(&(task+1)->t_regs.ax);    /* change to a large temp stack (unused task #1) */
     kernel_init();                  /* continue kernel init running on large stack */
 
     /* allocate task struct #0/pid 1 and setup init_task() to run on next reschedule */
     kfork_proc(init_task);
     wake_up_process(&task[0]);
 
+    init_bh(TIMER_BH, timer_bh);    /* finally enable timer bottom halves */
+    idle_loop();                    /* no return */
+}
+
+/* the idle task loop, no return */
+static void idle_loop(void)
+{
+    debug("IDLE LOOP\n");
+
     /*
-     * Set SP to the idle task struct. We then become the idle task and are only
-     * switched to when the last runnable user mode process sleeps from its
-     * kernel stack and schedule() is called.
+     * Set SP to the small stack in the special idle task struct.
+     * We then become the idle task and are only switched to when the last runnable
+     * user mode process sleeps from its kernel stack and schedule() is called.
      * As a result, the idle task always runs with intr_count 1, which guarantees
      * interrupt register saves will be on the interrupt stack, not the idle stack.
-     *
-     * NOTE: Any calls to printk afer the small idle stack is set below can cause idle
-     * stack overflow. The good news is that the overflow shouldn't cause much harm
-     * since it overflows into relatively unused areas of the idle task's task_struct.
      */
-    setsp(&idle_task->t_kstack[IDLESTACK_BYTES/2]); /* change to small idle task stack */
+    setsp(&idle_task->t_kstack[IDLESTACK_BYTES/2]);
     //hexdump(idle_task->t_kstack, kernel_ds, IDLESTACK_BYTES, 1);
 
     /*
@@ -215,6 +234,7 @@ static void INITPROC kernel_init(void)
 #endif
     irq_init();                     /* installs timer and div fault handlers */
 
+    debug("INT ENB\n");
     set_irq();                      /* interrupts enabled early for jiffie timers */
 
 #ifdef CONFIG_CHAR_DEV_RS

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -139,7 +139,7 @@ static void FARPROC far_start_kernel(void)
     setsp(&(task+1)->t_regs.ax);    /* change to a large temp stack (unused task #1) */
     debug("SP SWITCH\n");
 
-    printk("endbss %x task %x idle_task %x idle_stack %x\n",
+    debug("endbss %x task %x idle_task %x idle_stack %x\n",
         _endbss, task, idle_task, &idle_task->t_kstack[IDLESTACK_BYTES/2]);
 
     sched_init();                   /* init the idle and other task structs */

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -52,9 +52,8 @@ struct task_struct *find_empty_process(void)
     }
     next_task_slot = t;
     task_slots_unused--;
-    memcpy(t, current,              /* duplicate current task data into new one */
-        (current == idle_task)? (TASK_KSTACK+IDLESTACK_BYTES)
-                              : sizeof(struct task_struct));
+    if (current != idle_task)       /* duplicate current task data into new one */
+        memcpy(t, current, sizeof(struct task_struct));
     t->state = TASK_UNINTERRUPTIBLE;
     t->pid = get_pid();
     t->ticks = 0;                   /* for CONFIG_CPU_USAGE */

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -48,6 +48,7 @@
 #include <stdarg.h>
 
 #define CONFIG_PREC_TIMER   1   /* =1 to include %k precision timer printk format */
+#define STATIC static           /* avoid stack overflow from printk on idle stack */
 
 dev_t dev_console;
 
@@ -123,11 +124,12 @@ static unsigned long conv_ptick(unsigned long v, int *pDecimal, int *pSuffix)
 static void numout(unsigned long v, int width, unsigned int base, int type,
     int Zero, int alt)
 {
-    int n, i;
-    unsigned int c;
+    int i;
     char *p;
-    int Sign, Suffix, Decimal;
-    char buf[12];                       /* small stack: good up to max long octal v */
+    STATIC int n;
+    STATIC unsigned int c;
+    STATIC int Sign, Suffix, Decimal;
+    STATIC char buf[12];                    /* small stack: good up to max long octal v */
 
     Decimal = -1;
     Sign = Suffix = 0;
@@ -188,9 +190,10 @@ static void numout(unsigned long v, int width, unsigned int base, int type,
 
 static void vprintk(const char *fmt, va_list p)
 {
-    int c, n, width, zero, alt, ptrfmt;
-    unsigned long v;
-    char *str;
+    int c, n;
+    STATIC int width, zero, alt, ptrfmt;
+    STATIC unsigned long v;
+    STATIC char *str;
 
     while ((c = *fmt++)) {
         if (c != '%')

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -201,9 +201,9 @@ void INITPROC sched_init(void)
  */
     t = idle_task;
     t->state = TASK_RUNNING;
-    t->kstack_magic = KSTACK_MAGIC;
     t->next_run = t->prev_run = t;
     //memset(t->t_kstack, 0xff, IDLESTACK_BYTES);   /* for debugging idle stack size */
+    t->kstack_magic = KSTACK_MAGIC;
 
     current = t;
     next_task_slot = task;

--- a/elkscmd/rootfs_template/etc/passwd
+++ b/elkscmd/rootfs_template/etc/passwd
@@ -7,7 +7,7 @@ shutdown::6:0:shutdown:/bin:/bin/shutdown
 poweroff::7:0:poweroff:/bin:/bin/poweroff
 reboot::8:0:poweroff:/bin:/bin/reboot
 meminfo::9:0:meminfo:/root:/bin/meminfo
-ps::10:0:meminfo:/root:/bin/meminfo
+ps::10:0:meminfo:/root:/bin/ps
 tty::11:0:tty:/home:/bin/tty
 ftp:*:14:50:FTP User:/home/ftp:/bin/sh
 nobody:*:99:99:Nobody:/tmp:

--- a/elkscmd/rootfs_template/etc/passwd
+++ b/elkscmd/rootfs_template/etc/passwd
@@ -7,7 +7,8 @@ shutdown::6:0:shutdown:/bin:/bin/shutdown
 poweroff::7:0:poweroff:/bin:/bin/poweroff
 reboot::8:0:poweroff:/bin:/bin/reboot
 meminfo::9:0:meminfo:/root:/bin/meminfo
-tty::10:0:tty:/home:/bin/tty
+ps::10:0:meminfo:/root:/bin/meminfo
+tty::11:0:tty:/home:/bin/tty
 ftp:*:14:50:FTP User:/home/ftp:/bin/sh
 nobody:*:99:99:Nobody:/tmp:
 user1::101:101:User 1:/home:/bin/sh


### PR DESCRIPTION
During testing of the CONFIG_TIMER_INT1C in #2553 using emu86, a number of problematic situations were found that caused kernel startup to fail and noted. The reasons for these issues were finally found, and are fixed in this PR.

The following enhancements and fixes are included:
- The previous `setsp` function call was problematic since it changes SP, but the compiler was emitting ADD $2,SP instructions after the function call to clean up the stack, causing endless hard-to-find problems. An ASM macro is now used.
- `int3` is now also a macro, useful for tracing in emu86.
- The majority of the kernel startup in kernel_start was moved to far_kernel_start which is now released as available free memory after kernel startup.
- Chlynging the stack pointer midway through kernel initialization proved problematic, since there's no way to inform the compiler of such nefarious activities. Now, the startup interrupt stack is switched to an unused task stack just after the task arrays are allocated, and then only switched to the idle stack immediately before the idle task runs, in another function. This gets around ongoing issues compiler-generated optimized code doing something one wouldn't think of.
- At startup, the cpu FLAGS register is displayed, showing potential propblems with setup.S code inadvertantly enabling interrupts. It seems interrupts may still be inadvertently enabled during certain CPU processer identification code execution. Interrupts are now explicitly disabled immediately after the FLAG word display since startup is using the kernel interrupt stack.
- It was found that printk is using a large amount of stack, which could (and sometimes did) cause stack overflow on the 160-byte idle task or (larger) 512-byte interrupt stack. This is now fixed through the use of static variables in printk routines, making its use much cleaner for debugging issues that might have involved the stack without knowing it.
- The funny business of having to have irq.c compiled using -fno-defer-pop is now removed, since the ultimate issue was related to kernel stack startup issues discussed above.
- The IRQ 0 timer interrupt bottom half routine timer_bh is now only enabled late in kernel initialization, since the timer bottom half could otherwise interfere with kernel startup by assuming the system is fully operational when run. It is now enabled immediately before the idle task main loop.
- `ps` is added as a valid login, for quick system testing and observation without logging in.

Tested on QEMU and EMU86 under normal and INT 1C configurations.