### PR TITLE
[cmds] Add ekermit to distribution images

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -209,6 +209,7 @@ inet/sample_index.html ::var/www/index.html :net
 #inet/urlget :::ftpget          :net
 #inet/urlget :::ftpput          :net
 #inet/urlget :::httpget         :net
+ekermit/ekermit                 :other                          :1440c
 inet/tinyirc/tinyirc            :other                          :1440c
 bc/bc                           :other                          :1440c
 sys_utils/test_unreal           :test                           :1440c

--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -25,6 +25,7 @@ IA16DIRS =       \
 	debug       \
 	disk_utils  \
 	fsck_dos    \
+	ekermit	    \
 	elvis	    \
 	file_utils  \
 	gui         \

--- a/elkscmd/ekermit/Makefile
+++ b/elkscmd/ekermit/Makefile
@@ -5,7 +5,8 @@ include $(BASEDIR)/Makefile-rules
 ###############################################################################
 
 LOCALFLAGS = -DNO_LP -DELKS
-#LOCALFLAGS = -DNO_LP -DELKS -DNODEBUG
+LOCALFLAGS += -Wno-unused-variable -Wno-unused-but-set-variable -Wno-pointer-sign
+#LOCALFLAGS += -DNODEBUG
 
 ###############################################################################
 

--- a/elkscmd/ekermit/kermit.h
+++ b/elkscmd/ekermit/kermit.h
@@ -285,8 +285,8 @@
 #define K_SEND      6			/* Begin Send sequence */
 
 /* Kermit module return codes */
-
 #define X_ERROR    -1                   /* Fatal error */
+#undef X_OK                             /* WARNING: incompatible with unistd.h */
 #define X_OK        0                   /* OK, no action needed */
 #define X_FILE      1                   /* Filename received */
 #define X_DATA      2                   /* File data received */

--- a/elkscmd/ekermit/main.c
+++ b/elkscmd/ekermit/main.c
@@ -209,7 +209,7 @@ doarg(char c) {				/* Command-line option parser */
 		  fatal("File '",s,"' not accessible");
 		nfils++;
 	    }
-	    xargc++, *xargv--;		/* Adjust argv/argc */
+	    xargc++, xargv--;		/* Adjust argv/argc */
 	    if (nfils < 1)
 	      fatal("Missing filename for -s",(char *)0,(char *)0);
 	    action = A_SEND;
@@ -224,7 +224,7 @@ doarg(char c) {				/* Command-line option parser */
 #endif /* DEBUG */
 	    if (*(xp+1))
 	      fatal("Invalid argument bundling",(char *)0,(char *)0);
-	    *xargv++, xargc--;
+	    xargv++, xargc--;
 	    if ((xargc < 1) || (**xargv == '-'))
 	      fatal("Missing option argument",(char *)0,(char *)0);
 	    s = *xargv;
@@ -275,7 +275,7 @@ doarg(char c) {				/* Command-line option parser */
 	  case 'p':			/* Parity */
 	    if (*(xp+1))
 	      fatal("Invalid argument bundling",(char *)0,(char *)0);
-	    *xargv++, xargc--;
+	    xargv++, xargc--;
 	    if ((xargc < 1) || (**xargv == '-'))
 	      fatal("Missing parity",(char *)0,(char *)0);
 	    switch(x = **xargv) {
@@ -305,7 +305,7 @@ doarg(char c) {				/* Command-line option parser */
     return(action);
 }
 
-void
+int
 main(int argc, char ** argv) {
     int status, rx_len, i, x;
     char c;

--- a/elkscmd/ekermit/unixio.c
+++ b/elkscmd/ekermit/unixio.c
@@ -44,9 +44,6 @@
 #include <errno.h>
 #ifndef O_WRONLY
 #include <sys/file.h>
-#ifdef X_OK
-#undef X_OK
-#endif /* X_OK */
 #endif /* O_WRONLY */
 
 #include "cdefs.h"


### PR DESCRIPTION
Continuation of original contribution in #2554.

Builds `ekermit` and adds to compressed 1440k and larger images.

The original contribution displayed a large number of compiler warnings. This PR cleans some of the easier messages up, and includes a LOCALFLAGS modification to silence others. In general, it would be nice to fix the remaining issues so that the ELKS build produces less warnings, something we've worked hard on reducing for years.

@tyama501, thank you for the contribution. I'm unable to test, so I didn't try to fix further errors which might affect usability.
The current warning list is:
```
ia16-elf-gcc -mcmodel=small -melks-libc -mtune=i8086 -Wall -Os -mno-segment-relocation-stuff -fno-inline -fno-builtin-printf -fno-builtin-fprintf -Wextra -Wtype-limits -Wno-unused-parameter -Wno-sign-compare -Wno-empty-body -Wno-implicit-int -Wno-parentheses -DNO_LP -DELKS -Wno-unused-variable -Wno-unused-but-set-variable -Wno-pointer-sign -I/Users/greg/net/elks-gh/include -I/Users/greg/net/elks-gh/libc/include -I/Users/greg/net/elks-gh/elks/include -c -o main.o main.c
main.c: In function ‘main’:
main.c:388:14: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
     k.dbf    = db ? dodebug : 0; /* for debugging */
              ^
ia16-elf-gcc -mcmodel=small -melks-libc -mtune=i8086 -Wall -Os -mno-segment-relocation-stuff -fno-inline -fno-builtin-printf -fno-builtin-fprintf -Wextra -Wtype-limits -Wno-unused-parameter -Wno-sign-compare -Wno-empty-body -Wno-implicit-int -Wno-parentheses -DNO_LP -DELKS -Wno-unused-variable -Wno-unused-but-set-variable -Wno-pointer-sign -I/Users/greg/net/elks-gh/include -I/Users/greg/net/elks-gh/libc/include -I/Users/greg/net/elks-gh/elks/include -c -o kermit.o kermit.c
kermit.c: In function ‘spar’:
kermit.c:1099:26: warning: ‘y’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             x = xunchar(s[y+1]);
                          ^
kermit.c: In function ‘rpar’:
kermit.c:1168:9: warning: ‘b’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  k->bct = b;
  ~~~~~~~^~~
kermit.c: In function ‘decode’:
kermit.c:1236:10: warning: ‘p’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       *p = '\0';   /* terminate the string */
       ~~~^~~~~~
kermit.c: In function ‘gattr’:
kermit.c:1340:15: warning: ‘fsizek’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     } else if (fsizek > -1L) {
               ^
kermit.c:1338:8: warning: ‘fsize’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (fsize > -1L) {   /* Remember the file size */
        ^
kermit.c: In function ‘kermit’:
kermit.c:732:14: warning: ‘s’ may be used uninitialized in this function [-Wmaybe-uninitialized]
           rc = ack(k, k->r_seq, s);
           ~~~^~~~~~~~~~~~~~~~~~~~~
ia16-elf-gcc -mcmodel=small -melks-libc -mtune=i8086 -Wall -Os -mno-segment-relocation-stuff -fno-inline -fno-builtin-printf -fno-builtin-fprintf -Wextra -Wtype-limits -Wno-unused-parameter -Wno-sign-compare -Wno-empty-body -Wno-implicit-int -Wno-parentheses -DNO_LP -DELKS -Wno-unused-variable -Wno-unused-but-set-variable -Wno-pointer-sign -I/Users/greg/net/elks-gh/include -I/Users/greg/net/elks-gh/libc/include -I/Users/greg/net/elks-gh/elks/include -c -o elksio.o elksio.c
elksio.c: In function ‘fileinfo’:
elksio.c:513:19: warning: comparison is always true due to limited range of data type [-Wtype-limits]
      while (count < SCANSIZ && !isbinary) { /* Scan this much */
                   ^
In file included from elksio.c:59:0:
elksio.c: In function ‘readfile’:
debug.h:34:56: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
 #define debug(a,b,c,d) dodebug(a,(UCHAR *)b,(UCHAR *)c,(long)(d))
                                                        ^
elksio.c:581:5: note: in expansion of macro ‘debug’
     debug(DB_LOG,"readfile exit zinptr",0,k->zinptr);
     ^~~~~
ia16-elf-gcc -o ekermit -mcmodel=small -melks-libc -mtune=i8086 -Wall -Os -mno-segment-relocation-stuff -fno-inline -fno-builtin-printf -fno-builtin-fprintf main.o kermit.o elksio.o 
```
In some cases, the "maybe uninitialized" warnings can be removed by setting the variable to 0 on declaration, but one must be somewhat careful, as this could also be a warning of bad programming. I realize that e-kermit is ancient and it may be lots of work to fix all these. If so, that's ok, but thought to mention it.

