### PR TITLE
[ekermit] Reduce SCANSIZ since count is 16bits int

### DIFF
--- a/elkscmd/ekermit/elksio.c
+++ b/elkscmd/ekermit/elksio.c
@@ -464,7 +464,7 @@ openfile(struct k_data * k, UCHAR * s, int mode) {
 */
 #ifdef F_SCAN
 #define SCANBUF 1024
-#define SCANSIZ 49152
+#define SCANSIZ 32767
 #endif /* F_SCAN */
 
 ULONG


### PR DESCRIPTION
Hello @ghaerr 

There was a warning
elksio.c: In function ‘fileinfo’:
elksio.c:513:19: warning: comparison is always true due to limited range of data type [-Wtype-limits]
      while (count < SCANSIZ && !isbinary) { /* Scan this much */

because count is 16bits int in our system.

I have reduced SCANSIZ to eliminate this warning.

Thank you.