### PR TITLE
[ekermit] Set -DNO_SCAN

### DIFF
--- a/elkscmd/ekermit/Makefile
+++ b/elkscmd/ekermit/Makefile
@@ -4,7 +4,7 @@ include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 
-LOCALFLAGS = -DNO_LP -DELKS
+LOCALFLAGS = -DNO_LP -DNO_SCAN -DELKS
 LOCALFLAGS += -Wno-unused-variable -Wno-unused-but-set-variable -Wno-pointer-sign
 #LOCALFLAGS += -DNODEBUG
 

--- a/elkscmd/ekermit/elksio.c
+++ b/elkscmd/ekermit/elksio.c
@@ -464,7 +464,7 @@ openfile(struct k_data * k, UCHAR * s, int mode) {
 */
 #ifdef F_SCAN
 #define SCANBUF 1024
-#define SCANSIZ 32767
+#define SCANSIZ (32767 - SCANBUF)
 #endif /* F_SCAN */
 
 ULONG


### PR DESCRIPTION
Hello @ghaerr 

This is the PR to add -DNO_SCAN to disable F_SCAN as we talked on
https://github.com/ghaerr/elks/pull/2564#issuecomment-3720009614
It reduces code size about 200Bytes.

The text mode still can be used with -T option in the command line.
I have confirmed a text file LF(ELKS) -> CR+LF(Windows).

Thank you. 