### PR TITLE
[net] Add Interrupt Process and Abort Output telnet protocol handling

### DIFF
--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -105,7 +105,7 @@ int iscmdchar(int c)
         discard = 1;
         return 1;
     }
-    else if (c == CTRL('O')) {
+    if (c == CTRL('O')) {
         sendcmd(IAC_AO);
         discard = 1;
         return 1;

--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -127,6 +127,7 @@ read_keyboard(void)
 
     if (iscmdchar(buffer[0] & 255))
         return;
+    discard = 0;
 
     count = write(tcp_fd, buffer, count);
     if (count < 0) {
@@ -267,8 +268,8 @@ main(int argc, char **argv)
             if (discard) {
                 write(tcp_fd, "\r", 1);
                 write(1, "TO", 2);
+                discard = 0;
             }
-            discard = 0;
             continue;
         }
         if (n < 0) {

--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -263,11 +263,11 @@ main(int argc, char **argv)
         tv.tv_sec = 0;
         tv.tv_usec = 100000L;   /* 100ms */
 
-        n = select(tcp_fd + 1, &fdset, NULL, NULL, &tv);
+        n = select(tcp_fd + 1, &fdset, NULL, NULL, discard? &tv: NULL);
         if (n == 0) {
             if (discard) {
+                debug("TO");
                 write(tcp_fd, "\r", 1);
-                write(1, "TO", 2);
                 discard = 0;
             }
             continue;
@@ -481,10 +481,7 @@ process_opt(char *bp, int count)
         break;
     case IAC_DM:
         debug("got DM\n");
-        if (discard) {
-            write(1, "DM", 2);
-            discard = 0;
-        }
+        discard = 0;
         break;
     case IAC_BRK:
         debug("got BRK\n");

--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -25,7 +25,7 @@
 #define BUFSIZE     1500
 
 #define debug(...)
-//#define debug     printf
+//#define debug     __dprintf
 //#define RAWTELNET             /* test mode for raw telnet without IAC */
 
 /* telnet protocol */
@@ -89,16 +89,16 @@ finish()
     exit(0);
 }
 
-void sendcmd(int cmd)
+static void sendcmd(int cmd)
 {
-    unsigned char reply[3];
+    unsigned char reply[2];
 
     reply[0] = IAC;
     reply[1] = cmd;
     write(tcp_fd, reply, 2);
 }
 
-int iscmdchar(int c)
+static int iscmdchar(int c)
 {
     if (c == CTRL('C')) {
         sendcmd(IAC_IP);
@@ -266,7 +266,7 @@ main(int argc, char **argv)
         n = select(tcp_fd + 1, &fdset, NULL, NULL, discard? &tv: NULL);
         if (n == 0) {
             if (discard) {
-                debug("TO");
+                debug("TO\n");
                 write(tcp_fd, "\r", 1);
                 discard = 0;
             }

--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -261,7 +261,7 @@ main(int argc, char **argv)
         FD_SET(0, &fdset);
         FD_SET(tcp_fd, &fdset);
         tv.tv_sec = 0;
-        tv.tv_usec = 100000L;   /* 100ms */
+        tv.tv_usec = 500000L;   /* 500ms */
 
         n = select(tcp_fd + 1, &fdset, NULL, NULL, discard? &tv: NULL);
         if (n == 0) {

--- a/elkscmd/inet/telopt.c
+++ b/elkscmd/inet/telopt.c
@@ -146,6 +146,8 @@ tel_in(int fdout, int telout, char *buffer, int len)
             case WONT:
             case DO:
             case DONT:
+            case IP:
+            case AO:
                 InState = IN_IAC2;
                 ThisOpt = c;
                 break;
@@ -156,8 +158,6 @@ tel_in(int fdout, int telout, char *buffer, int len)
             case SE:
             case NOP:
             case BREAK:
-            case IP:
-            case AO:
             case AYT:
             case EC:
             case EL:
@@ -186,6 +186,12 @@ tel_in(int fdout, int telout, char *buffer, int len)
                 break;
             case DONT:
                 dodont(c);
+                break;
+            case IP:
+                write(fdout, "\003", 1);
+                break;
+            case AO:
+                /* no action for Abort Output */
                 break;
             }
             break;

--- a/elkscmd/inet/telopt.c
+++ b/elkscmd/inet/telopt.c
@@ -146,13 +146,19 @@ tel_in(int fdout, int telout, char *buffer, int len)
             case WONT:
             case DO:
             case DONT:
-            case IP:
-            case AO:
                 InState = IN_IAC2;
                 ThisOpt = c;
                 break;
             case SB:
                 InState = IN_SB;
+                break;
+            case IP:
+                InState = IN_DATA;
+                write(fdout, "\003", 1);
+                break;
+            case AO:
+                InState = IN_DATA;
+                /* no action for Abort Output */
                 break;
             case EOR:
             case SE:
@@ -186,12 +192,6 @@ tel_in(int fdout, int telout, char *buffer, int len)
                 break;
             case DONT:
                 dodont(c);
-                break;
-            case IP:
-                write(fdout, "\003", 1);
-                break;
-            case AO:
-                /* no action for Abort Output */
                 break;
             }
             break;

--- a/elkscmd/inet/telopt.c
+++ b/elkscmd/inet/telopt.c
@@ -90,7 +90,7 @@ tel_opt(int fdout, int what, int option)
         break;
     }
     if (len > 0)
-        (void)write(fdout, buf, len);
+        write(fdout, buf, len);
 }
 
 static void
@@ -262,16 +262,16 @@ tel_out(int fdout, char *buf, int size)
     while (size > 0) {
         buf = p;
         got_iac = 0;
-        if ((p = (char *)memchr(buf, IAC, size)) != (char *)NULL) {
+        if ((p = memchr(buf, IAC, size)) != NULL) {
             got_iac = 1;
             p++;
         } else
             p = buf + size;
         len = p - buf;
         if (len > 0)
-            (void)write(fdout, buf, len);
+            write(fdout, buf, len);
         if (got_iac)
-            (void)write(fdout, p - 1, 1);
+            write(fdout, p - 1, 1);
         size = size - len;
     }
 }

--- a/elkscmd/inet/telopt.c
+++ b/elkscmd/inet/telopt.c
@@ -34,8 +34,9 @@ static void dowill(int c);
 static void dowont(int c);
 static void dodo(int c);
 static void dodont(int c);
-static void respond(int ack, int option);
 static void respond_really(int ack, int option);
+#define respond(ack, option)    /* reduce code size with null procedure */
+//static void respond(int ack, int option);
 
 void
 tel_init(void)
@@ -154,7 +155,8 @@ tel_in(int fdout, int telout, char *buffer, int len)
                 break;
             case IP:
                 InState = IN_DATA;
-                write(fdout, "\003", 1);
+                *p2++ = '\003';
+                size++;
                 break;
             case AO:
                 InState = IN_DATA;
@@ -316,6 +318,7 @@ dowont(int c)
 static void
 dodo(int c)
 {
+#ifndef respond
     int     ack;
 
     switch (c) {
@@ -323,6 +326,7 @@ dodo(int c)
         ack = WONT;
     }
     respond(ack, c);
+#endif
 }
 
 static void
@@ -336,6 +340,7 @@ dodont(int c)
     respond(WONT, c);
 }
 
+#ifndef respond
 static void
 respond(int ack, int option)
 {
@@ -346,6 +351,7 @@ respond(int ack, int option)
     c[2] = option;
     write(telfdout, c, 3);**/
 }
+#endif
 
 static void
 respond_really(int ack, int option)


### PR DESCRIPTION
Enhances telnet and telnetd to properly handle telnet protocol "Interrupt Process" (^C) and "Abort Output" (^O). Previously, these characters were sent to the remote system. Now, ^C sends telnet IAC IP, which is then converted to ^C by telnetd. ^O sends IAC AO, which currently does nothing in telnetd.

Telnet continues to discard output while ^C or ^O processing is ongoing. Typing any character will reenable output, as will also after a period of network input timeout.

The telnet protocol and how other systems work, particularly GNU inetutils, is discussed in detail in https://github.com/Mellvik/TLVC/pull/215.

@Mellvik, these are my minimal changes based on our long discussion. Everything seems to be working well testing using QEMU and ELKS localhost, and macOS. However, strangely enough, my debug shows that macOS never sends a DM (DataMark) response. Thus, it seems a network timeout is required in order to make this work. I have debug code writing "TO" for timeout and "DM" when DataMark received, and DM is never displayed.