### PR TITLE
[net] Fix telnet incoming DM handling

### DIFF
--- a/elkscmd/inet/telnet.c
+++ b/elkscmd/inet/telnet.c
@@ -148,8 +148,6 @@ read_network(void)
         printf("\nConnection closed\n");
         finish();
     }
-    if (discard)
-        return;
 
 #ifdef RAWTELNET
     write(1, buffer, count);
@@ -158,11 +156,11 @@ read_network(void)
     do {
         iacptr = memchr(bp, IAC, count);
         if (!iacptr) {
-            write(1, bp, count);
+            if (!discard) write(1, bp, count);
             return;
         }
         if (iacptr && iacptr > bp) {
-            write(1, bp, iacptr - bp);
+            if (!discard) write(1, bp, iacptr - bp);
             count -= (iacptr - bp);
             bp = iacptr;
             continue;


### PR DESCRIPTION
Fixes telnet requirement to discard received data after ^C or ^O until DM received, with DM handling having been untested from previous PR comment https://github.com/ghaerr/elks/pull/2566#issuecomment-3734874243.

Coding error found during discussion in https://github.com/Mellvik/TLVC/pull/217#discussion_r2679830328. Thanks @Mellvik for testing my macOS telnetd.

Testing now shows ^C handling with discarding working well with ELKS telnetd and macOS telnetd using DM instead of timeout, with no lost data and shell prompt displayed after discarding stopped. 

^O discards output, also without sending ENTER after DM. On very long listings, ^O discards output for several seconds, then ^O is displayed, and if a character is typed, output resumes as expected, with ^O^R displayed after several more seconds. This is likely expected behavior of the remote shell. I will be leaving this as is until more information is found regarding IAC AO operations(s).