### PR TITLE
[libc] Cleanup tcdrain, tcsendbreak, getpass library internals

### DIFF
--- a/libc/termios/Makefile
+++ b/libc/termios/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/libc/$(COMPILER).inc
 #DEFINES += -DL_tcdrain -DL_tcflow -DL_tcgetpgrp -DL_cfmakeraw
 
 # TCSBRK is unimplemented except for with elksemu
-DEFINES += -DL_tcsendbreak
+DEFINES += -DL_tcsendbreak -DL_tcflush
 
 OBJS = \
 	cfgetispeed.o \

--- a/libc/termios/tcflush.c
+++ b/libc/termios/tcflush.c
@@ -1,3 +1,4 @@
+#ifdef L_tcflush
 #include <sys/ioctl.h>
 #include <termios.h>
 
@@ -7,3 +8,4 @@ tcflush(int fd, int queue_selector)
 {
 	return ioctl(fd, TCFLSH, queue_selector);
 }
+#endif

--- a/libc/termios/tcsendbreak.c
+++ b/libc/termios/tcsendbreak.c
@@ -7,20 +7,7 @@
 int
 tcsendbreak(int fd, int duration)
 {
-	/*
-	 * The break lasts 0.25 to 0.5 seconds if DURATION is zero, and an
-	 * implementation-defined period if DURATION is nonzero. We define a
-	 * positive DURATION to be number of milliseconds to break.
-	 */
-	if (duration <= 0)
-		return ioctl(fd, TCSBRK, 0);
-
-	/*
-	 * ioctl can't send a break of any other duration for us. This could be
-	 * changed to use trickery (e.g. lower speed and send a '\0') to send
-	 * the break, but for now just return an error.
-	 */
-	errno = EINVAL;
-	return -1;
+    /* The break lasts 0.25 to 0.5 seconds and duration is ignored */
+    return ioctl(fd, TCSBRK, 0);
 }
 #endif


### PR DESCRIPTION
Note that neither tcflush, tcdrain nor tcsendbreak are actually implemented as kernel ioctls (yet).