### PR TITLE
[emu86] Update access to EMU86 emulator for kernel symbolic debugging

### DIFF
--- a/libc/include/debug/syms.h
+++ b/libc/include/debug/syms.h
@@ -3,6 +3,7 @@
 #include <sys/cdefs.h>
 #else
 #define noinstrument
+#define __far
 #endif
 
 /* symbol table format


### PR DESCRIPTION
(Duplicated instructions here from https://github.com/ghaerr/emu86/pull/1 for enhanced symbolic kernel instruction tracing using EMU86)

To use, clone and build EMU86 from https://github.com/ghaerr/emu86 using the following instructions:
```
$ cd $TOPDIR
$ cd ..
$ git clone https://github.com/ghaerr/emu86.git
$ cd emu86
$ make
$ cd $TOPDIR
$ cp emu86-rom-full.config .config
$ make clean
$ make
$ ./emu86.sh
```


Adds enhancements to allow the complete emulation of the ELKS kernel from startup through normal operation using the kernel symbol table for easy understanding of instruction sequences. 

The following enhancements are included:
- Symbols displayed from kernel .text and .data segments automatically.
- Instructions displayed by default in AT&T rather than Intel format (see config.mk STYLE=att).
- R command toggles register display between instructions.
- C command displays registers with continuous execution, c command does not.
- Command line option -S for symbol table path.
- Command line option -C for symbol table .text segment address.
- Command line option -D for symbol table .data segment address.
- Adds emu86.sh to automatically run just-compiled version of ELKS kernel from `em86-rom-full.config` configuration file.
- Optional INT 1C BIOS timer callback support added (use CONFIG_TIMER_INT1C=y).
- Emulated INT 8 (IRQ 0) timer changed to fire every 30000 rather than 3000 instructions.
- Optional SDL console available with CONSOLE=sdl in config.mk

To build kernel and test:
```
EMU86=../emu86
$ cd $TOPDIR
$ cp emu86-rom-full.config .config
$ make clean
$ make
$ cd $EMU86
$ ./emu86.sh
info: symtabl text segment  0E062h
info: symtabl data segment  000C0h
info: load address E0000h
info: load file ../elks-gh/elks/arch/i86/boot/Image
info: file size=10CE0h
success: file loaded
info: load address 80000h
info: load file ../elks-gh/image/romfs.bin
info: file size=20189h
success: file loaded
info: symbols file ../elks-gh/elks/arch/i86/boot/system.sym

ELKS Setup INT f000 START
Headless console
32K ext buffers, 8K cache, 1 req hdrs
fd: no get drive fn, ndrives 0
PC/AT class cpu 2, syscaps 30, 512K base ram, 16 tasks, 64 files, 96 inodes
ELKS 0.9.0-dev (59968 text, 0 ftext, 7296 data, 5440 bss, 52798 heap)
Kernel text e062 data c0 end 10c0 top 8000 445+0+0K free
VFS: Mounted root device /dev/rom (0600) romfs filesystem.
Running /etc/rc.sys script
Wed Aug 21 09:47:13 1991

ELKS 0.9.0-dev

[0.18 secs] login: ^C
E062:2D4F  75 03              jnz     schedule+98
>c
E062:2D51  8B 5F 16           mov     0x16(%bx),%bx
E062:2D54  FB                 sti     
E062:2D55  39 F3              cmp     %si,%bx
E062:2D57  74 8E              jz      schedule+2b
E062:2CE7  89 EC              mov     %bp,%sp
E062:2CE9  5D                 pop     %bp
E062:2CEA  5F                 pop     %di
E062:2CEB  5E                 pop     %si
E062:2CEC  C3                 ret     
E062:0172  E8 5D 9C           call    idle_halt
E062:9DD2  F4                 hlt     
E062:9DD3  C3                 ret     
E062:0175  EB D8              jmp     idle_loop+e
E062:014F  8B 1E 3A 2A        mov     idle_task,%bx
E062:0153  81 BF A4 00 76 54  cmpw    $0x5476,0xa4(%bx)
E062:0159  74 14              jz      idle_loop+2e
E062:016F  E8 4A 2B           call    schedule
E062:2CBC  56                 push    %si
E062:2CBD  57                 push    %di
E062:2CBE  55                 push    %bp
E062:2CBF  89 E5              mov     %sp,%bp
^C
...
```
To start the kernel and see each instruction step-by-step from boot, add `-i` to the emu86 command line in emu86.sh.
