### PR TITLE
[ash] Add fg command for simple job control to ash

### DIFF
--- a/elkscmd/ash/builtins.table
+++ b/elkscmd/ash/builtins.table
@@ -61,7 +61,7 @@ execcmd 	exec
 exitcmd 	exit
 exportcmd	export readonly
 exprcmd 	expr test [
-fgcmd -j	fg
+fgcmd		fg
 getoptscmd	getopts
 hashcmd 	hash
 jobidcmd -j	jobid


### PR DESCRIPTION
Adds `fg` command to ash for simple job control. Use in conjunction with ^Z (terminal stop) and `jobs` command to restart stopped jobs into foreground.

ELKS `ash` doesn't implement full job control. In particular, job control doesn't work well or at all with programs that are stopped while waiting for input, due to problems related to simultaneous reading of stdin by the shell and child programs. This implementation of `fg` essentially just reads the list of stopped jobs and executes a `kill -CONT <pid>`. Use `jobs` to list all stopped or background jobs.

@Mellvik This is the fg command enhancement you requested (the previously described ash enhancements must also be included).

Screenshot showing sample `out` program (output's X's) being run and stopped twice, then restarted using fg:
<img width="832" height="540" alt="Screenshot 2026-01-12 at 4 01 47 PM" src="https://github.com/user-attachments/assets/47247af7-a586-4514-9464-3bafc9491503" />
