### PR TITLE
[kernel] Allow writes to /dev/console by all groups/users

### DIFF
--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -59,7 +59,7 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "tty4",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 3)         },
     { "ttyS0",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 64)        },
     { "ttyS1",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 65)        },
-    { "console",S_IFCHR | 0600, MKDEV(TTY_MAJOR, 254)       },
+    { "console",S_IFCHR | 0622, MKDEV(TTY_MAJOR, 254)       },
     { "tty",	S_IFCHR | 0666, MKDEV(TTY_MAJOR, 255)       },
     { "ttyp0",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 8)         },
     { "ttyp1",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 9)         },

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -15,7 +15,7 @@ devices:
 
 ##############################################################################
 # Create frequently accessed /dev files first
-	$(MKDEV) /dev/console	c 4 254 1 1 0600
+	$(MKDEV) /dev/console	c 4 254 1 1 0622
 	$(MKDEV) /dev/tty1      c 4 0
 	$(MKDEV) /dev/ttyS0     c 4 64
 	$(MKDEV) /dev/fd0       b 3 32
@@ -126,7 +126,7 @@ devices:
 # /dev/tty is minor 255, /dev/console minor 254
 
 	$(MKDEV) /dev/tty       c 4 255 1 1 0666
-#	$(MKDEV) /dev/console	c 4 254 1 1 0600
+#	$(MKDEV) /dev/console	c 4 254 1 1 0622
 
 # Serial ports, as detected by the ROM BIOS.
 


### PR DESCRIPTION
Discovered in https://github.com/ghaerr/elks/pull/2560#issuecomment-3740250583 where debug output from \_\_dprintf failed due to not being able to open /dev/console when not running as root user. /dev/console is now created with mode 0622.

@tyama501, this should fix the problem you're seeing on building C86 examples as non-root user.