### PR TITLE
[cmds] Increase ANSI DSR delay for possibly network delays

### DIFF
--- a/elkscmd/elvis/curses.c
+++ b/elkscmd/elvis/curses.c
@@ -486,14 +486,15 @@ static int getCursorPosition(int ifd, int ofd, int *rows, int *cols)
 	char buf[32];
 	struct termios org, vmin;
 
-	/* change to raw mode to wait 200ms instead of 1 character for DSR response*/
+	/* change to raw mode to wait 500ms instead of 1 character for DSR response*/
 	if (tcgetattr(ifd, &org) < 0)
 		return -1;
 	vmin = org;
 	vmin.c_iflag &= (IXON|IXOFF|IXANY|ISTRIP|IGNBRK);
 	vmin.c_oflag &= ~OPOST;
 	vmin.c_lflag &= ISIG;
-	vmin.c_cc[VMIN] = 0; vmin.c_cc[VTIME] = 2; /* 0 bytes, 200ms timer */
+	vmin.c_cc[VMIN] = 0;  /* 0 bytes */
+	vmin.c_cc[VTIME] = 5; /* 500ms timer for possible network delays */
 	if (tcsetattr(ifd, TCSAFLUSH, &vmin) < 0)
 		return -1;
 

--- a/libc/misc/linenoise.c
+++ b/libc/misc/linenoise.c
@@ -461,10 +461,10 @@ static int getCursorPosition(int ifd, int ofd) {
     char buf[32];
     struct termios org, vmin;
 
-    /* change raw mode to wait 200ms instead of 1 character for DSR response*/
+    /* change raw mode to wait 500ms instead of 1 character for DSR response*/
     tcgetattr(ifd,&org);
     vmin = org;
-    vmin.c_cc[VMIN] = 0; vmin.c_cc[VTIME] = 2; /* 0 bytes, 200ms timer */
+    vmin.c_cc[VMIN] = 0; vmin.c_cc[VTIME] = 5; /* 0 bytes, 500ms timer */
     tcsetattr(ifd,TCSAFLUSH,&vmin);
 
     /* Report cursor location */


### PR DESCRIPTION
From discussion in https://github.com/Mellvik/TLVC/issues/218#issuecomment-3745169023 and fix in https://github.com/Mellvik/TLVC/pull/220. Since 500ms was reported as stable and the values could be additive, this version uses 500ms rather than 800ms delay, and also fixes linenoise. Thanks @Mellvik!

