### PR TITLE
[net,kernel] Remove 50ms timeout in telnetd, cleanup tty_write

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -296,8 +296,7 @@ size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
     while (i < len) {
         s = chq_wait_wr(&tty->outq, (file->f_flags & O_NONBLOCK) | i);
         if (s < 0) {
-            /* FIXME EAGAIN not returned, cycle required on telnet nonblocking terminal */
-            if (s == -EINTR || s == -EAGAIN) {
+            if (i != 0 && s == -EAGAIN) {
                 tty->ops->write(tty);
                 wake_up(&tty->outq.wait);
                 schedule();

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -289,29 +289,28 @@ static void tty_echo(register struct tty *tty, unsigned char ch)
 size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
 {
     register struct tty *tty = determine_tty(inode->i_rdev);
-    size_t i;
-    int s;
+    size_t count = 0;
+    int ret;
 
-    i = 0;
-    while (i < len) {
-        s = chq_wait_wr(&tty->outq, (file->f_flags & O_NONBLOCK) | i);
-        if (s < 0) {
-            if (i != 0 && s == -EAGAIN) {
+    while (count < len) {
+        ret = chq_wait_wr(&tty->outq, (file->f_flags & O_NONBLOCK) | count);
+        if (ret < 0) {
+            if (count != 0 && ret == -EAGAIN) {
                 tty->ops->write(tty);
                 wake_up(&tty->outq.wait);
                 schedule();
                 continue;
             }
-            if (i == 0)
-                i = s;
+            if (count == 0)
+                count = ret;
             break;
         }
         chq_addch_nowakeup(&tty->outq, get_user_char(data++));
-        i++;
+        count++;
     }
     tty->ops->write(tty);
     wake_up(&tty->outq.wait);
-    return i;
+    return count;
 }
 
 size_t tty_read(struct inode *inode, struct file *file, char *data, size_t len)

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -115,7 +115,6 @@ size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len
 	while (count < len) {
 		ret = chq_wait_wr (&tty->inq, (file->f_flags & O_NONBLOCK) | count);
 		if (ret < 0) {
-			//if (ret == -EINTR) continue;
 			if (count == 0) count = ret;
 			break;
 		}

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -115,7 +115,8 @@ size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len
 	while (count < len) {
 		ret = chq_wait_wr (&tty->inq, (file->f_flags & O_NONBLOCK) | count);
 		if (ret < 0) {
-			if (count == 0) count = ret;
+			if (count == 0)
+				count = ret;
 			break;
 		}
 
@@ -126,7 +127,6 @@ size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len
 	}
 	if (count > 0)
 		wake_up(&tty->inq.wait);
-
 	return count;
 }
 

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -44,6 +44,8 @@ int chq_wait_wr(register struct ch_queue *q, int nonblock)
 	else {
 	    interruptible_sleep_on(&q->wait);
 	    if (q->len == q->size)
+		return -EAGAIN;
+	    if (current->signal)
 		return -EINTR;
 	}
     }

--- a/elkscmd/inet/telnetd.c
+++ b/elkscmd/inet/telnetd.c
@@ -116,12 +116,9 @@ client_loop(int fdsock, int fdterm)
     int     count_fd = (fdsock > fdterm) ? (fdsock + 1) : (fdterm + 1);
     fd_set  fds_read;
     fd_set  fds_write;
-    struct timeval timeint;
 
     telnet_init(fdsock);
 
-    timeint.tv_sec = 0;
-    timeint.tv_usec = 50000L;   /* slow 50ms timeout to fix select hang bug in #1048 */
     while (1) {
         FD_ZERO(&fds_read);
         FD_ZERO(&fds_write);
@@ -134,7 +131,7 @@ client_loop(int fdsock, int fdterm)
         if (count_out)
             FD_SET(fdsock, &fds_write);
 
-        count = select(count_fd, &fds_read, &fds_write, NULL, &timeint);
+        count = select(count_fd, &fds_read, &fds_write, NULL, NULL);
         if (count < 0) {
             perror("telnetd select");
             break;


### PR DESCRIPTION
This PR removes the unnecessary 50ms timeout in `telnetd`, originally added in #1073 as a workaround for hanging in select until a character was typed #1048, years ago. The TTY driver was found to be the actual culprit, and the real hang bug fixed in #1709, under the pretense of speeding up TTY I/O on slow systems.

Now discussed and found unfixed in TLVC in https://github.com/Mellvik/TLVC/issues/219#issuecomment-3759515722, the kernel fix had never been applied from ELKS. This PR adds a 'proper' fix to finalize all the above, which cleans up the TTY driver when O_NONBLOCK is set and removes some improper comments from #1021 where dropped PTY data was fixed.

Now, the `chq_wait_wr` routine property returns -EAGAIN when the queue is full, and -EINTR only on a signal. Thus, only
-EAGAIN needs to be checked to continue waiting for the queue to empty and a sleep is never performed without first calling wakeup, as before. The TTY version of tty_write renames some variables to more closely resemble its close cousin tty_write in the PTY driver, for clarity.

Tested on QEMU using telnet to localhost and remote. Hopefully this cleanup and small enhancement for O_NONBLOCK is the end of many years of hang issues when the PTY driver is involved.

