### PR TITLE
[CI] Build Nano-X with Github Continuous Integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,15 +122,6 @@ jobs:
           name: fd2880-fat.img
           path: image/fd2880-fat.img
 
-      - name: upload1232
-        uses: actions/upload-artifact@v4
-        with:
-          name: fd1232.img
-          path: image/fd1232.img
-
-      - name: buildnx
-        run: ./buildnx.sh
-
       - name: upload14
         uses: actions/upload-artifact@v4
         with:
@@ -154,3 +145,9 @@ jobs:
         with:
           name: hd64mbr-minix.img
           path: image/hd64mbr-minix.img
+
+      - name: upload18
+        uses: actions/upload-artifact@v4
+        with:
+          name: fd1232.img
+          path: image/fd1232.img

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,6 +122,15 @@ jobs:
           name: fd2880-fat.img
           path: image/fd2880-fat.img
 
+      - name: upload1232
+        uses: actions/upload-artifact@v4
+        with:
+          name: fd1232.img
+          path: image/fd1232.img
+
+      - name: buildnx
+        run: ./buildnx.sh
+
       - name: upload14
         uses: actions/upload-artifact@v4
         with:
@@ -145,9 +154,3 @@ jobs:
         with:
           name: hd64mbr-minix.img
           path: image/hd64mbr-minix.img
-
-      - name: upload18
-        uses: actions/upload-artifact@v4
-        with:
-          name: fd1232.img
-          path: image/fd1232.img

--- a/build.sh
+++ b/build.sh
@@ -66,10 +66,18 @@ make -j1 all || clean_exit 5
 # Possibly build all images
 
 if [ "$2" = "allimages" ]; then
-	echo "Building all images..."
+	echo "Building FD images..."
 	cd image
-	make -j1 images || clean_exit 6
+	make -j1 images-minix images-fat || clean_exit 6
 	cd ..
+
+	# Build Nano-X for HD images only
+	./buildnx.sh || clean_exit 62
+	echo "Building HD images..."
+	cd image
+	make -j1 images-hd || clean_exit 62
+	cd ..
+	./cleannx.sh || clean_exit 63
 fi
 
 # Build 8018X kernel and image

--- a/buildnx.sh
+++ b/buildnx.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# buildnx.sh - build Nano-X in external/microwindows
+# This build script is called in main.yml by GitHub Continuous Integration
+
+set -e
+
+SCRIPTDIR="$(dirname "$0")"
+
+clean_exit () {
+	E="$1"
+	test -z $1 && E=0
+	if [ $E -eq 0 ]
+		then echo "Build script has completed successfully."
+		else echo "Build script has terminated with error $E"
+	fi
+	exit $E
+}
+
+# Environment setup
+
+. "$SCRIPTDIR/env.sh"
+[ $? -ne 0 ] && clean_exit 1
+
+# Clone and build Nano-X for ELKS
+
+echo "Building Nano-X..."
+mkdir -p external
+cd external
+rm -rf microwindows
+git clone https://github.com/ghaerr/microwindows.git
+cd microwindows/src
+make -f Makefile.elks clean
+make -f Makefile.elks
+
+# Success
+
+echo "Nano-X binaries are in $TOPDIR/elkscmd/rootfs_template/bin folder"
+clean_exit 0

--- a/cleannx.sh
+++ b/cleannx.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# cleannx.sh - clean Nano-X binaries from distribution
+#
+set -e
+
+if [ -z "$TOPDIR" ]
+  then
+    echo "ELKS TOPDIR= environment variable not set, run . env.sh"
+    exit
+fi
+
+DEST=$TOPDIR/elkscmd/rootfs_template
+rm -f $DEST/bin/nano-x
+rm -f $DEST/bin/nx*
+rm -f $DEST/lib/nx*
+rm -f $DEST/root/*.jpg

--- a/image/Makefile
+++ b/image/Makefile
@@ -42,13 +42,13 @@ compress:
 	cd $(TOPDIR)/target/bin; elks-compress *
 
 .NOTPARALLEL: images images-minix images-fat images-hd
-images: images-minix images-hd images-fat
+images: images-minix images-fat images-hd
 
 images-minix: fd360-minix fd720-minix fd1200-minix fd1440-minix fd2880-minix
 
-images-fat: fd360-fat fd720-fat fd1200-fat fd1440-fat fd2880-fat hd32-fat hd32mbr-fat
+images-fat: fd360-fat fd720-fat fd1200-fat fd1440-fat fd2880-fat
 
-images-hd: hd32-minix hd32mbr-minix hd64-minix hd64mbr-minix
+images-hd: hd32-minix hd32mbr-minix hd64-minix hd64mbr-minix hd32-fat hd32mbr-fat
 
 fd360-minix:
 	echo CONFIG_APPS_360K=y		> Config


### PR DESCRIPTION
This PR allows automatic generation of ELKS HDD image with Nano X applications integrated. Nano-X is now built from an external repository on every PR.

Replaces @toncho11's original request in #2562 and adds the ELKS build of Nano-X from [The Nano-X Window System](https://github.com/ghaerr/microwindows) to the 32M and 64M HD MINIX and FAT images. 

Nano-X is not included on any of the FD images (including 2880k floppy recently, unfortunately) as the distribution is too large. I would like to get the 2880k floppy distribution down a few hundred blocks so that Nano-X can be included, but have not yet had the time to figure out what to remove.

@toncho11, let me know how this works for you, thanks!