### PR TITLE
[cmds] Add ANSI DSR processing for dynamic window size to mined/edit

### DIFF
--- a/elkscmd/misc_utils/mined.h
+++ b/elkscmd/misc_utils/mined.h
@@ -18,7 +18,7 @@
 #undef getchar
 #undef EOF
 extern char *CE, *VS, *SO, *SE, *CL, *AL, *CM;
-#define YMAX		25		/* was 49 */
+#define YMAX		65		/* was 49 */
 #else
 #define YMAX		24		/* Maximum y coordinate starting at 0 */
 /* Escape sequences. */


### PR DESCRIPTION
Fixes #2584.

Due to the design of `edit` (elkscmd/misc_utils/mined), the max number of lines that will work in a window is statically set to 66.