### PR TITLE
[cmds] Add elks-viewer image viewers as external application

### DIFF
--- a/buildext.sh
+++ b/buildext.sh
@@ -19,6 +19,7 @@
 #       c86_elkscmd     C86             Some elkscmd/ programs compiled by C86
 #       doom            OpenWatcom      Doom for ELKS
 #       ngircd_elks     OpenWatcom      IRC daemon for ELKS
+#       elks_viewer     OpenWatcom      Image viewers (BMP, PPM, JPG) for ELKS
 #
 # Some projects may require prerequisites.
 # To only build the C86 toolchain, use './buildext.sh owc_libc c86_toolchain'
@@ -197,6 +198,20 @@ elkirc()
     echo "elkirc build complete"
 }
 
+elks_viewer()
+{
+    echo "Building elks-viewer..."
+    cd $TOPDIR/extapps
+    if [ ! -d elks-viewer ] ; then
+        git clone https://github.com/rafael2k/elks-viewer
+    fi
+    cd elks-viewer
+    git pull
+    make -f Makefile.owc clean
+    make -f Makefile.owc
+    echo "elks-viewer build complete"
+}
+
 # build all extapps repos
 make_all()
 {
@@ -210,6 +225,7 @@ make_all()
         c86_elkscmd
         doom
         ngircd_elks
+        elks_viewer
     fi
 }
 

--- a/elkscmd/ExtApplications
+++ b/elkscmd/ExtApplications
@@ -51,6 +51,10 @@ ngircd-elks/ngircd.os2                              :ngircd
 ngircd-elks/ngircd.conf ::etc/ngircd.conf           :ngircd
 elkirc/elkirc                                       :elkirc             :2880k
 elkirc/man/elkirc.1 ::lib/man1/elkirc.1             :elkirc             :2880k
+# elks-viewer image viewers
+elks-viewer/jpgview                                 :elksviewer         :2880k
+elks-viewer/ppmview                                 :elksviewer         :2880k
+elks-viewer/bmpview                                 :elksviewer         :2880k
 # sample ELKS OWC/C86 files
 ../elkscmd/basic/basic.os2                          :owc                :2880k
 ../elkscmd/fsck_dos/fsck-dos.os2                    :owc                :2880k


### PR DESCRIPTION
Add support for building elks-viewer (BMP, PPM, JPG image viewers) as an external application using OpenWatcom C compiler. Source repository: https://github.com/rafael2k/elks-viewer

Could you please check if I got the idea right?

ps: I'm still compiling latest ELKS (many months without compiling it!) - so code still untested!
ps2: I don't quite remember if there was any missing feature when compiling with C86, this is why I submitted the MR using OWC