### PR TITLE
[ekermit] Fix to accept /dev/ttyUSB device for hostek

### DIFF
--- a/elkscmd/ekermit/README.md
+++ b/elkscmd/ekermit/README.md
@@ -24,6 +24,8 @@ then
 
 The default serial device is /dev/ttyS0.
 
+The filename cannot include PATH for now.
+
 If opening the device failed and the current ttyname is the serial device,  
 then STDIN_FILENO is used instead.
 

--- a/elkscmd/ekermit/main.c
+++ b/elkscmd/ekermit/main.c
@@ -198,7 +198,7 @@ doarg(char c) {				/* Command-line option parser */
 		if (**xargv == '-')
 		  break;
 #ifdef ELKS
-		if (strncasecmp(s, "/dev/ttyS", 9) == 0)	/* Stop if device name is found */
+		if (strncasecmp(s, "/dev/tty", 8) == 0)	/* Stop if device name is found */
 		  break;
 #endif
 		errno = 0;


### PR DESCRIPTION
Hello @ghaerr ,

I needed another change to accept /dev/ttyUSB device for hostek.

I still have trouble with ckermit but,
now I could send/receive files with this hostek on Debian.

Also it seems that filename cannot include PATH for now
I made a note on Readme.
(Not sure why yet, but it does not work if there is PATH)

Thank you.