### PR TITLE
[tools] elf2elks - allow removal of unused code sections with static bss data

### DIFF
--- a/elks/tools/elf2elks/elf2elks.c
+++ b/elks/tools/elf2elks/elf2elks.c
@@ -429,10 +429,15 @@ input_for_header (void)
 	    set_scn (&ftext, &ftext_sh, scn, shdr, "far text", sidx);
 	  else if (strcmp (name, ".data") == 0)
 	    set_scn (&data, &data_sh, scn, shdr, "data", sidx);
+	/*
+ 	 * Removing this error case allows compilation using -ffunction-sections
+ 	 * and linking with -Wl,--gc-sections to remove unused code sections,
+ 	 * even though some may have static bss data within them.
+ 	 */
+#if 0
 	  else if (shdr->sh_size != 0 && (shdr->sh_flags & SHF_ALLOC) != 0)
-	    error ("stray SHT_PROGBITS SHF_ALLOC section %#zx `%s'", sidx,
-								     name);
-
+	    error ("stray SHT_PROGBITS SHF_ALLOC section %#zx `%s'", sidx, name);
+#endif
 	  break;
 
 	case SHT_NOBITS:


### PR DESCRIPTION
Removing this error check from `elf2elks` will allow compilation of Nano-X applications using `-ffunction-sections` and 
`-Wl,--gc-sections` to eliminate unused functions and reduce binary size significantly.