### PR TITLE
[kernel] Add preliminary support for PS/2 mouse driver /dev/psaux

### DIFF
--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -128,6 +128,10 @@ ifdef CONFIG_CHAR_DEV_RS
 	endif
 endif
 
+ifdef CONFIG_ARCH_IBMPC
+  OBJS += mouse-ps2.o
+endif
+
 ifdef CONFIG_CHAR_DEV_CGATEXT
 	OBJS += cgatext.o
 endif

--- a/elks/arch/i86/drivers/char/console.h
+++ b/elks/arch/i86/drivers/char/console.h
@@ -2,7 +2,6 @@
 
 void Console_conin(unsigned char Key);
 void Console_conout(dev_t dev, int Ch);
-extern struct tty ttys[];
 
 void kbd_init(void);
 extern char kbd_name[];

--- a/elks/arch/i86/drivers/char/mouse-ps2.c
+++ b/elks/arch/i86/drivers/char/mouse-ps2.c
@@ -1,0 +1,120 @@
+/*
+ * Minimal PS/2 mouse driver for ELKS
+ *
+ * 23 Jan 2026 Original version by @toncho11, adapted by Greg Haerr
+ */
+
+#include <linuxmt/config.h>
+#include <linuxmt/wait.h>
+#include <linuxmt/chqueue.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/ntty.h>
+#include <arch/io.h>
+#include <arch/irq.h>
+
+#ifdef CONFIG_MOUSE_PS2
+
+#define IRQ_MOUSE       12      /* mouse interrupt, may conflict with networking */
+
+/* i8042 ports */
+#define I8042_DATA      0x60
+#define I8042_STATUS    0x64
+#define I8042_CMD       0x64
+
+/* status bits */
+#define ST_OBF          0x01
+#define ST_AUXDATA      0x20
+
+/* Minimal mouse enable (no reset, BIOS-friendly) */
+static void ps2_mouse_enable(void)
+{
+    /* FIXME controller ready (status bit 1) should be read before each write!! */
+    /* Enable AUX (mouse) device */
+    outb(0xA8, I8042_CMD);
+
+    /* FIXME unclear whether the following enables IRQ 12 */
+    /* Enable data reporting */
+    outb(0xD4, I8042_CMD);   /* next byte to mouse */
+    outb(0xF4, I8042_DATA);  /* enable streaming */
+
+    /* FIXME this could cause OS hang if no PS/2 controller present */
+    /* Eat ACK (0xFA) */
+    while (!(inb(I8042_STATUS) & ST_OBF))
+        ;
+    inb(I8042_DATA);
+}
+
+/* IRQ handler */
+static void ps2_irq(int irq, struct pt_regs *regs)
+{
+    struct ch_queue *q = &ttys[NR_CONSOLES + NR_PTYS + NR_SERIAL].inq;
+    unsigned char c;
+
+    /* Read all available mouse bytes */
+    while ((inb(I8042_STATUS) & (ST_OBF | ST_AUXDATA)) == (ST_OBF | ST_AUXDATA)) {
+        c = inb(I8042_DATA);
+        chq_addch_nowakeup(q, c);
+    }
+
+    if (q->len)
+        wake_up(&q->wait);
+}
+
+static int ps2_open(struct tty *tty)
+{
+    int err;
+
+    if (tty->usecount)      /* exclusive use only */
+        return -EBUSY;
+
+    err = request_irq(IRQ_MOUSE, ps2_irq, INT_GENERIC);
+    if (err)
+        return err;
+
+    err = tty_allocq(tty, MOUSEINQ_SIZE, 0);  /* input only */
+    if (err) {
+        free_irq(IRQ_MOUSE);
+        return err;
+    }
+
+    tty->usecount = 1;
+    ps2_mouse_enable();     /* minimal init */
+
+    return 0;
+}
+
+static void ps2_release(struct tty *tty)
+{
+    if (--tty->usecount == 0) {
+        /* FIXME needs code to disable i8042 interrupts here!! */
+        free_irq(IRQ_MOUSE);
+        tty_freeq(tty);
+    }
+}
+
+static int ps2_write(struct tty *tty)
+{
+    return 0;   /* mouse is read-only */
+}
+
+static int ps2_ioctl(struct tty *tty, int cmd, char *arg)
+{
+    switch (cmd) {
+    case TCSETS:
+    case TCSETSW:
+    case TCSETSF:
+        return 0;
+    }
+    return -EINVAL;
+}
+
+struct tty_ops ps2_mouse_ops = {
+    ps2_open,
+    ps2_release,
+    ps2_write,
+    NULL,
+    ps2_ioctl,
+    NULL
+};
+#endif

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -470,6 +470,7 @@ extern struct tty_ops rs_ops;           /* CONFIG_CHAR_DEV_RS*/
 extern struct tty_ops ttyp_ops;         /* CONFIG_PSEUDO_TTY*/
 extern struct tty_ops i8018xcon_ops;    /* CONFIG_CONSOLE_8018X*/
 extern struct tty_ops necv25con_ops;    /* CONFIG_CONSOLE_NECV25*/
+extern struct tty_ops ps2_mouse_ops;    /* CONFIG_MOUSE_PS2*/
 
 void INITPROC tty_init(void)
 {
@@ -513,6 +514,11 @@ void INITPROC tty_init(void)
         ttyp->ops = &ttyp_ops;
         (ttyp++)->minor = i;            /* ttyp0 = PTY slave PTY_MINOR_OFFSET */
     }
+#endif
+
+#ifdef CONFIG_MOUSE_PS2
+        ttyp->ops = &ps2_mouse_ops;
+        (ttyp++)->minor = MOUSE_MINOR_OFFSET;   /* psaux = PS/2 mouse */
 #endif
 
     register_chrdev(TTY_MAJOR, "tty", &tty_fops);

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -83,8 +83,6 @@ static unsigned int divisors[] = {
     0                           /*  0 = B230400 */
 };
 
-extern struct tty ttys[];
-
 /* Flow control buffer markers */
 #define RS_IALLMOSTFULL         (3 * INQ_SIZE / 4)
 #define RS_IALLMOSTEMPTY        (    INQ_SIZE / 4)

--- a/elks/arch/i86/drivers/char/serial-pc98.c
+++ b/elks/arch/i86/drivers/char/serial-pc98.c
@@ -89,8 +89,6 @@ static unsigned int divisors_8MHz[] = {
     0				/*  0 = B230400 */
 };
 
-extern struct tty ttys[];
-
 static int rs_init_done = 0;
 
 /* printk console out */

--- a/elks/arch/i86/drivers/char/serial-swan.c
+++ b/elks/arch/i86/drivers/char/serial-swan.c
@@ -18,7 +18,6 @@
 #include <arch/swan.h>
 
 static struct tty *tty;
-extern struct tty ttys[];
 
 /* printk console out */
 void rs_conout(dev_t dev, int c)

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -57,6 +57,7 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "tty2",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 1)         },
     { "tty3",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 2)         },
     { "tty4",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 3)         },
+    { "psaux",  S_IFCHR | 0666, MKDEV(TTY_MAJOR, 32)        },
     { "ttyS0",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 64)        },
     { "ttyS1",	S_IFCHR | 0644, MKDEV(TTY_MAJOR, 65)        },
     { "console",S_IFCHR | 0622, MKDEV(TTY_MAJOR, 254)       },

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -40,6 +40,9 @@
 #define CONFIG_FAST_IRQ4                        /* com1 */
 #define CONFIG_FAST_IRQ3                        /* com2 */
 
+/* temp always enable experimental PS/2 mouse driver for IBM PC */
+#define CONFIG_MOUSE_PS2        1
+
 /* The following can be set for minimal systems or for QEMU emulation testing:
  * 10 buffers (@20 = 200), 2 ttyq (@80 = 160), 4k L1 cache, 512 heap free,
  * 10 tasks (@876 = 8760), 64 inodes (@80 = 5120), 64 files (@14 = 896) = ~19744.

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -45,7 +45,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 #endif
 
 #ifdef CONFIG_FS_DEV
-#define DEVDIR_SIZE             50              /* # entries in FAT device table */
+#define DEVDIR_SIZE             51              /* # entries in FAT device table */
 #define DEVINO_BASE             (MSDOS_DPB*2)   /* (DEVDIR_SIZE+MSDOS_DBP-1) & ~(MSDOS_DBP-1) */
 
 struct msdos_devdir_entry {

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -15,6 +15,8 @@
 #define RSINQ_SIZE	1024	/* serial input queue SLIP_MTU+128+8*/
 #define RSOUTQ_SIZE	80	/* serial output queue size*/
 
+#define MOUSEINQ_SIZE   64      /* PS/2 mouse input queue size */
+
 /*
  * Note: don't mess with NR_PTYS until you understand the tty minor
  * number allocation game...
@@ -35,9 +37,10 @@
 
 #define MAX_PTYS     4
 
-#define TTY_MINOR_OFFSET 0
-#define PTY_MINOR_OFFSET 8
-#define RS_MINOR_OFFSET 64
+#define TTY_MINOR_OFFSET   0
+#define PTY_MINOR_OFFSET   8
+#define MOUSE_MINOR_OFFSET 32
+#define RS_MINOR_OFFSET    64
 
 #if defined(CONFIG_CONSOLE_DIRECT) || defined(CONFIG_CONSOLE_BIOS) || defined(CONFIG_ARCH_NECV25)
 #define NR_CONSOLES	MAX_CONSOLES
@@ -57,7 +60,13 @@
 #define NR_SERIAL	0
 #endif
 
-#define MAX_TTYS (NR_CONSOLES+NR_SERIAL+NR_PTYS)
+#ifdef CONFIG_MOUSE_PS2
+#define NR_MOUSE 	1
+#else
+#define NR_MOUSE 	0
+#endif
+
+#define MAX_TTYS (NR_CONSOLES+NR_SERIAL+NR_PTYS+NR_MOUSE)
 
 #define DCGET_GRAPH	(('D'<<8)+0x01)
 #define DCREL_GRAPH	(('D'<<8)+0x02)
@@ -94,6 +103,8 @@ struct tty {
     unsigned char usecount;
     pid_t pgrp;
 };
+
+extern struct tty ttys[];
 
 extern int tty_intcheck(struct tty *,unsigned char);
 		/* Check for ctrl-C etc.. */

--- a/elkscmd/gui/Makefile
+++ b/elkscmd/gui/Makefile
@@ -37,7 +37,7 @@ OBJS = $(SRCS:.c=.oaj)
 ############# End of Standard Section ##############
 
 BINDIR = .
-LOCALFLAGS =
+LOCALFLAGS = -DDRIVER=1
 PROG = $(BINDIR)/paint
 SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c \
     drawscanline.c

--- a/elkscmd/gui/mouse.c
+++ b/elkscmd/gui/mouse.c
@@ -163,9 +163,9 @@ int open_mouse(void)
         cfsetispeed(&termios, (speed_t)B1200);
 
     termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
-    //termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
-    //termios.c_cflag &= ~(CSIZE | PARENB);
-    termios.c_cflag |= CS8;
+    termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
+    termios.c_cflag &= ~(CSIZE | PARENB);
+    termios.c_cflag |= CREAD | CS8;
     termios.c_cc[VMIN] = 0;
     termios.c_cc[VTIME] = 0;
     if(tcsetattr(mouse_fd, TCSAFLUSH, &termios) < 0) {

--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -163,9 +163,9 @@ int open_mouse(void)
         cfsetispeed(&termios, (speed_t)B1200);
 
     termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
-    //termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
-    //termios.c_cflag &= ~(CSIZE | PARENB);
-    termios.c_cflag |= CS8;
+    termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
+    termios.c_cflag &= ~(CSIZE | PARENB);
+    termios.c_cflag |= CREAD | CS8;
     termios.c_cc[VMIN] = 0;
     termios.c_cc[VTIME] = 0;
     if(tcsetattr(mouse_fd, TCSAFLUSH, &termios) < 0) {

--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -1,30 +1,51 @@
 /*
+ * ELKS user mode mouse driver and test program.
+ *  Use -DDRIVER=1 for elkscmd/gui (paint) mouse driver.
+ *
+ * Opens a serial port directly, and interprets serial data.
+ * Microsoft, PC/Logitech and PS/2 mice are supported.
+ *
+ * Mouse driver from Microwindows
  * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
  * Portions Copyright (c) 1991 David I. Bell
  * Permission is granted to use, distribute, or modify this source,
  * provided that this copyright notice remains intact.
- *
- * This program opens a serial port directly, and interprets serial data.
- * Microsoft, PC, and Logitech mice are supported.
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <termios.h>
 
-#define MOUSE_PORT    "/dev/ttyS0"  /* default port unless MOUSE_PORT= env specified */
-#define MOUSE_QEMU    "/dev/ttyS1"  /* default port on QEMU */
-#define MOUSE_MICROSOFT     1       /* microsoft mouse*/
-#define MOUSE_PC            0       /* pc/logitech mouse*/
+#ifdef DRIVER
+#include "event.h"
+#else
+/* default mouse button values */
+#define BUTTON_L            0x01    /* left button*/
+#define BUTTON_R            0x02    /* right button*/
+#define BUTTON_M            0x10    /* middle*/
+#define BUTTON_SCROLLUP     0x20    /* wheel up*/
+#define BUTTON_SCROLLDN     0x40    /* wheel down*/
+#endif
 
-/* states for the mouse*/
-#define IDLE            0       /* start of byte sequence */
-#define XSET            1       /* setting x delta */
-#define YSET            2       /* setting y delta */
-#define XADD            3       /* adjusting x delta */
-#define YADD            4       /* adjusting y delta */
+/* configurable options */
+#define MOUSE_PORT  "/dev/ttyS0"    /* default port unless MOUSE_PORT= env specified */
+#define MOUSE_QEMU  "/dev/ttyS1"    /* default port on QEMU */
+#define MOUSE_PS2   "/dev/psaux"    /* default port for PS/2 mouse */
+#define MOUSE_TYPE          "ms"    /* default mouse is microsoft mouse */
+
+#define USE_MOUSE_ACCEL     0       /* =1 to use mouse acceleration */
+#define SCALE               2       /* default scaling factor for acceleration */
+#define THRESH              5       /* default threshhold for acceleration */
+
+/* states for the mouse */
+#define IDLE                0       /* start of byte sequence */
+#define XSET                1       /* setting x delta */
+#define YSET                2       /* setting y delta */
+#define XADD                3       /* adjusting x delta */
+#define YADD                4       /* adjusting y delta */
 
 /* pc and ms button codes*/
 #define PC_LEFT_BUTTON      4
@@ -33,12 +54,11 @@
 #define MS_LEFT_BUTTON      2
 #define MS_RIGHT_BUTTON     1
 
-/* final button codes*/
-#define LBUTTON             0x01
-#define MBUTTON             0x10
-#define RBUTTON             0x02
+/* ps/2 button codes */
+#define PS2_LEFT_BUTTON     1
+#define PS2_RIGHT_BUTTON    2
 
-/* Bit fields in the bytes sent by the mouse.*/
+/* Bit fields in the bytes sent by the mouse */
 #define TOP_FIVE_BITS       0xf8
 #define BOTTOM_THREE_BITS   0x07
 #define TOP_BIT             0x80
@@ -46,10 +66,12 @@
 #define BOTTOM_TWO_BITS     0x03
 #define THIRD_FOURTH_BITS   0x0c
 #define BOTTOM_SIX_BITS     0x3f
+#define PS2_CTRL_BYTE       0x08
+
+int     mouse_fd = -1;      /* file descriptor for mouse */
 
 /* local data*/
 static int      rawmode;    /* show raw mouse data */
-static int      mouse_fd;   /* file descriptor for mouse */
 static int      state;      /* IDLE, XSET, ... */
 static int      buttons;    /* current mouse buttons pressed*/
 static int      availbuttons;   /* which buttons are available */
@@ -63,57 +85,70 @@ static int      right;      /* redefined */
 static unsigned char    *bp;/* buffer pointer */
 static int      nbytes;     /* number of bytes left */
 static int      (*parse)(); /* parse routine */
+static int      parsePC(int);       /* routine to interpret PC mouse */
+static int      parseMS(int);       /* routine to interpret MS mouse */
+static int      parsePS2(int);      /* routine to interpret MS mouse */
 
 /*
- * NOTE: MAX_BYTES can't be larger than 1 mouse read packet or select() can fail,
+ * NOTE: max_bytes can't be larger than 1 mouse read packet or select() can fail,
  * as mouse driver would be storing unprocessed data not seen by select.
  */
-#if MOUSE_PC
-static int      parsePC(int);       /* routine to interpret PC mouse */
-#define MAX_BYTES   5               /* max read() w/o storing excess mouse data */
-#endif
-
-#if MOUSE_MICROSOFT
-static int      parseMS(int);       /* routine to interpret MS mouse */
-#define MAX_BYTES   3               /* max read() w/o storing excess mouse data */
-#endif
-
-static int      read_mouse(int *dx, int *dy, int *dz, int *bptr);
+#define PC_MAX_BYTES   5            /* max read() w/o storing excess mouse data */
+#define MS_MAX_BYTES   3            /* max read() w/o storing excess mouse data */
+#define PS2_MAX_BYTES  3            /* max read() w/o storing excess mouse data */
+#define MAX_BYTES      5
+int max_bytes = MS_MAX_BYTES;
 
 /*
  * Open up the mouse device.
  * Returns the fd if successful, or negative if unsuccessful.
  */
-int
-open_mouse(void)
+int open_mouse(void)
 {
-    char *port;
+    char *port, *type;
     struct termios termios;
 
+    if( !(type = getenv("MOUSE_TYPE")))
+        type = MOUSE_TYPE;
+
     /* set button bits and parse procedure*/
-#if MOUSE_PC
-    /* pc or logitech mouse*/
-    left = PC_LEFT_BUTTON;
-    middle = PC_MIDDLE_BUTTON;
-    right = PC_RIGHT_BUTTON;
-    parse = parsePC;
-#elif MOUSE_MICROSOFT
-    /* microsoft mouse*/
-    left = MS_LEFT_BUTTON;
-    right = MS_RIGHT_BUTTON;
-    middle = 0;
-    parse = parseMS;
-#else
-    return -1;
-#endif
+    if(!strcmp(type, "pc")) {
+        /* pc or logitech mouse*/
+        left = PC_LEFT_BUTTON;
+        middle = PC_MIDDLE_BUTTON;
+        right = PC_RIGHT_BUTTON;
+        parse = parsePC;
+        max_bytes = PC_MAX_BYTES;
+    } else if (strcmp(type, "ms") == 0) {
+        /* microsoft mouse*/
+        left = MS_LEFT_BUTTON;
+        right = MS_RIGHT_BUTTON;
+        middle = 0;
+        parse = parseMS;
+        max_bytes = MS_MAX_BYTES;
+    } else if (strcmp(type, "ps2") == 0) {
+        printf("got PS2 %s\n", type);
+        /* PS/2 mouse*/
+        left = PS2_LEFT_BUTTON;
+        right = PS2_RIGHT_BUTTON;
+        middle = 0;
+        parse = parsePS2;
+        max_bytes = PS2_MAX_BYTES;
+    } else {
+        printf("Unknown mouse type: %s\n", type);
+        return -1;
+    }
 
     /* open mouse port*/
-    if (!(port = getenv("MOUSE_PORT")))
+    if (parse == parsePS2)
+        port = MOUSE_PS2;
+    else if (!(port = getenv("MOUSE_PORT")))
         port = getenv("QEMU")? MOUSE_QEMU: MOUSE_PORT;
     printf("Opening mouse on %s\n", port);
-    mouse_fd = open(port, O_EXCL | O_NOCTTY | O_NONBLOCK);
+    mouse_fd = open(port, O_RDWR | O_EXCL | O_NOCTTY | O_NONBLOCK);
     if (mouse_fd < 0) {
-        printf("Can't open %s, error %d\n", port, errno);
+        printf("Can't open mouse %s, error %d. Try export MOUSE_PORT=/dev/ttyS1\n",
+            port, errno);
         return -1;
     }
 
@@ -125,11 +160,11 @@ open_mouse(void)
     }
 
     if(cfgetispeed(&termios) != B1200)
-        cfsetispeed(&termios, B1200);
+        cfsetispeed(&termios, (speed_t)B1200);
 
     termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
-    termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
-    termios.c_cflag &= ~(CSIZE | PARENB);
+    //termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
+    //termios.c_cflag &= ~(CSIZE | PARENB);
     termios.c_cflag |= CS8;
     termios.c_cc[VMIN] = 0;
     termios.c_cc[VTIME] = 0;
@@ -138,6 +173,18 @@ open_mouse(void)
         close(mouse_fd);
         return -1;
     }
+
+#if UNUSED /* MOUSE_PS2 */
+    /* sequence to mouse device to send ImPS/2 events*/
+    static const unsigned char imps2[] = { 0xf3, 200, 0xf3, 100, 0xf3, 80 };
+    char buf[4];
+
+    /* try to switch the mouse to ImPS/2 protocol*/
+    if (write(mouse_fd, imps2, sizeof(imps2)) != sizeof(imps2))
+        /*printf("Can't switch to ImPS/2 protocol\n")*/;
+    if (read(mouse_fd, buf, 4) != 1 || buf[0] != 0xF4)
+        /*printf("Failed to switch to ImPS/2 protocol.\n")*/;
+#endif
 
     /* initialize data*/
     availbuttons = left | middle | right;
@@ -150,6 +197,96 @@ open_mouse(void)
     return mouse_fd;
 }
 
+void close_mouse(void)
+{
+    if (mouse_fd >= 0)
+        close(mouse_fd);
+    mouse_fd = -1;
+}
+
+#if USE_MOUSE_ACCEL
+static void filter_relative(int *xpos, int *ypos, int x, int y)
+{
+    int sign = 1;
+
+    if (x < 0) {
+        sign = -1;
+        x = -x;
+    }
+
+    if (x > THRESH)
+        x = THRESH + (x - THRESH) * SCALE;
+    x *= sign;
+
+    sign = 1;
+
+    if (y < 0) {
+        sign = -1;
+        y = -y;
+    }
+
+    if (y > THRESH)
+        y = THRESH + (y - THRESH) * SCALE;
+    y *= sign;
+
+    *xpos = x;
+    *ypos = y;
+}
+#endif
+
+#if UNUSED  /* MOUSE_PS2 */
+/* IntelliMouse PS/2 protocol uses four byte reports
+ * (PS/2 protocol omits last byte):
+ *      Bit   7     6     5     4     3     2     1     0
+ * --------+-----+-----+-----+-----+-----+-----+-----+-----
+ *  Byte 0 |  0     0   Neg-Y Neg-X   1    Mid  Right Left
+ *  Byte 1 |  X     X     X     X     X     X     X     X
+ *  Byte 2 |  Y     Y     Y     Y     Y     Y     Y     Y
+ *  Byte 3 |  W     W     W     W     W     W     W     W
+ *
+ * XXXXXXXX, YYYYYYYY, and WWWWWWWW are 8-bit two's complement values
+ * indicating changes in x-coordinate, y-coordinate, and scroll wheel.
+ * That is, 0 = no change, 1..127 = positive change +1 to +127,
+ * and 129..255 = negative change -127 to -1.
+ *
+ * Left, Right, and Mid are the three button states, 1 if being depressed.
+ * Neg-X and Neg-Y are set if XXXXXXXX and YYYYYYYY are negative, respectively.
+ */
+int read_mouse(int *dx, int *dy, int *dw, int *bp)
+{
+    int n, x, y, w, left, middle, right, button;
+    unsigned char data[4];
+
+    n = read(mouse_fd, data, sizeof(data));
+    if (n != 3 && n != 4)
+        return 0;
+
+    button = 0;
+    left = data[0] & 0x1;
+    right = data[0] & 0x2;
+    middle = data[0] & 0x4;
+
+    if (left)   button |= BUTTON_L;
+    if (middle) button |= BUTTON_M;
+    if (right)  button |= BUTTON_R;
+
+    x =   (signed char) data[1];
+    y = - (signed char) data[2];  /* y axis flipped between conventions */
+    if (n == 4) {
+        w = (signed char) data[3];
+        if (w > 0)
+            button |= BUTTON_SCROLLUP;
+        if (w < 0)
+            button |= BUTTON_SCROLLDN;
+    }
+    *dx = x;
+    *dy = y;
+    *dw = w;
+    *bp = button;
+    return 1;
+}
+#endif
+
 /*
  * Attempt to read bytes from the mouse and interpret them.
  * Returns -1 on error, 0 if either no bytes were read or not enough
@@ -157,8 +294,7 @@ open_mouse(void)
  * When a new state is read, the current buttons and x and y deltas
  * are returned.  This routine does not block.
  */
-int
-read_mouse(int *dx, int *dy, int *dz, int *bptr)
+int read_mouse(int *dx, int *dy, int *dz, int *bptr)
 {
     int b;
     static unsigned char buffer[MAX_BYTES];
@@ -170,7 +306,7 @@ read_mouse(int *dx, int *dy, int *dz, int *bptr)
      */
     if (nbytes <= 0) {
         bp = buffer;
-        nbytes = read(mouse_fd, bp, MAX_BYTES);
+        nbytes = read(mouse_fd, bp, max_bytes);
         if (nbytes < 0) {
             if (errno == EINTR || errno == EAGAIN)
                 return 0;
@@ -190,16 +326,20 @@ read_mouse(int *dx, int *dy, int *dz, int *bptr)
      */
     while (nbytes-- > 0) {
         if ((*parse)((int) *bp++)) {
+#if USE_MOUSE_ACCEL
+            if (parse == parseMS)   /* filter works on MS mouse only */
+                filter_relative(&xd, &yd, xd, yd);
+#endif
             *dx = xd;
             *dy = yd;
             *dz = 0;
             b = 0;
             if(buttons & left)
-                b |= LBUTTON;
+                b |= BUTTON_L;
             if(buttons & right)
-                b |= RBUTTON;
+                b |= BUTTON_R;
             if(buttons & middle)
-                b |= MBUTTON;
+                b |= BUTTON_M;
             *bptr = b;
             return 1;
         }
@@ -208,13 +348,11 @@ read_mouse(int *dx, int *dy, int *dz, int *bptr)
     return 0;
 }
 
-#if MOUSE_PC
 /*
  * Input routine for PC mouse.
  * Returns nonzero when a new mouse state has been completed.
  */
-int
-parsePC(int byte)
+static int parsePC(int byte)
 {
     int sign;           /* sign of movement */
 
@@ -268,15 +406,12 @@ parsePC(int byte)
     }
     return 0;
 }
-#endif
 
-#if MOUSE_MICROSOFT
 /*
  * Input routine for Microsoft mouse.
  * Returns nonzero when a new mouse state has been completed.
  */
-int
-parseMS(int byte)
+static int parseMS(int byte)
 {
     switch (state) {
         case IDLE:
@@ -304,8 +439,39 @@ parseMS(int byte)
     }
     return 0;
 }
-#endif
 
+/*
+ * Input routine for PS/2 mouse.
+ * Returns nonzero when a new mouse state has been completed.
+ */
+static int parsePS2(int byte)
+{
+    switch (state) {
+    case IDLE:
+        if (byte & PS2_CTRL_BYTE) {
+            buttons = byte & (PS2_LEFT_BUTTON|PS2_RIGHT_BUTTON);
+            state = XSET;
+        }
+        break;
+
+    case XSET:
+        if(byte > 127)
+                byte -= 256;
+        xd = byte;
+        state = YSET;
+        break;
+
+    case YSET:
+        if(byte > 127)
+                byte -= 256;
+        yd = -byte;
+        state = IDLE;
+        return 1;
+    }
+    return 0;
+}
+
+#ifndef DRIVER
 int main(int argc, char **argv)
 {
     int x, y, z, b;
@@ -323,3 +489,4 @@ int main(int argc, char **argv)
     }
     return 0;
 }
+#endif

--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -14,55 +14,55 @@
 #include <fcntl.h>
 #include <termios.h>
 
-#define	MOUSE_PORT    "/dev/ttyS0"  /* default port unless MOUSE_PORT= env specified */
-#define	MOUSE_QEMU    "/dev/ttyS1"  /* default port on QEMU */
-#define	MOUSE_MICROSOFT		1		/* microsoft mouse*/
-#define	MOUSE_PC			0		/* pc/logitech mouse*/
+#define MOUSE_PORT    "/dev/ttyS0"  /* default port unless MOUSE_PORT= env specified */
+#define MOUSE_QEMU    "/dev/ttyS1"  /* default port on QEMU */
+#define MOUSE_MICROSOFT     1       /* microsoft mouse*/
+#define MOUSE_PC            0       /* pc/logitech mouse*/
 
 /* states for the mouse*/
-#define	IDLE			0		/* start of byte sequence */
-#define	XSET			1		/* setting x delta */
-#define	YSET			2		/* setting y delta */
-#define	XADD			3		/* adjusting x delta */
-#define	YADD			4		/* adjusting y delta */
+#define IDLE            0       /* start of byte sequence */
+#define XSET            1       /* setting x delta */
+#define YSET            2       /* setting y delta */
+#define XADD            3       /* adjusting x delta */
+#define YADD            4       /* adjusting y delta */
 
 /* pc and ms button codes*/
-#define	PC_LEFT_BUTTON		4
-#define PC_MIDDLE_BUTTON	2
-#define PC_RIGHT_BUTTON		1
-#define	MS_LEFT_BUTTON		2
-#define MS_RIGHT_BUTTON		1
+#define PC_LEFT_BUTTON      4
+#define PC_MIDDLE_BUTTON    2
+#define PC_RIGHT_BUTTON     1
+#define MS_LEFT_BUTTON      2
+#define MS_RIGHT_BUTTON     1
 
 /* final button codes*/
-#define LBUTTON				0x01
-#define MBUTTON				0x10
-#define RBUTTON				0x02
+#define LBUTTON             0x01
+#define MBUTTON             0x10
+#define RBUTTON             0x02
 
 /* Bit fields in the bytes sent by the mouse.*/
-#define TOP_FIVE_BITS		0xf8
-#define BOTTOM_THREE_BITS	0x07
-#define TOP_BIT				0x80
-#define SIXTH_BIT			0x40
-#define BOTTOM_TWO_BITS		0x03
-#define THIRD_FOURTH_BITS	0x0c
-#define BOTTOM_SIX_BITS  	0x3f
+#define TOP_FIVE_BITS       0xf8
+#define BOTTOM_THREE_BITS   0x07
+#define TOP_BIT             0x80
+#define SIXTH_BIT           0x40
+#define BOTTOM_TWO_BITS     0x03
+#define THIRD_FOURTH_BITS   0x0c
+#define BOTTOM_SIX_BITS     0x3f
 
 /* local data*/
-static int		rawmode;    /* show raw mouse data */
-static int		mouse_fd;	/* file descriptor for mouse */
-static int		state;		/* IDLE, XSET, ... */
-static int		buttons;	/* current mouse buttons pressed*/
-static int		availbuttons;	/* which buttons are available */
-static int		xd;			/* change in x */
-static int		yd;			/* change in y */
+static int      rawmode;    /* show raw mouse data */
+static int      mouse_fd;   /* file descriptor for mouse */
+static int      state;      /* IDLE, XSET, ... */
+static int      buttons;    /* current mouse buttons pressed*/
+static int      availbuttons;   /* which buttons are available */
+static int      xd;         /* change in x */
+static int      yd;         /* change in y */
 
-static int		left;		/* because the button values change */
-static int		middle;		/* between mice, the buttons are */
-static int		right;		/* redefined */
+static int      left;       /* because the button values change */
+static int      middle;     /* between mice, the buttons are */
+static int      right;      /* redefined */
 
-static unsigned char	*bp;/* buffer pointer */
-static int		nbytes;		/* number of bytes left */
-static int		(*parse)();	/* parse routine */
+static unsigned char    *bp;/* buffer pointer */
+static int      nbytes;     /* number of bytes left */
+static int      (*parse)(); /* parse routine */
 
 /*
  * NOTE: MAX_BYTES can't be larger than 1 mouse read packet or select() can fail,
@@ -78,7 +78,7 @@ static int      parseMS(int);       /* routine to interpret MS mouse */
 #define MAX_BYTES   3               /* max read() w/o storing excess mouse data */
 #endif
 
-static int  	read_mouse(int *dx, int *dy, int *dz, int *bptr);
+static int      read_mouse(int *dx, int *dy, int *dz, int *bptr);
 
 /*
  * Open up the mouse device.
@@ -88,66 +88,66 @@ int
 open_mouse(void)
 {
     char *port;
-	struct termios termios;
+    struct termios termios;
 
-	/* set button bits and parse procedure*/
+    /* set button bits and parse procedure*/
 #if MOUSE_PC
-	/* pc or logitech mouse*/
-	left = PC_LEFT_BUTTON;
-	middle = PC_MIDDLE_BUTTON;
-	right = PC_RIGHT_BUTTON;
-	parse = parsePC;
+    /* pc or logitech mouse*/
+    left = PC_LEFT_BUTTON;
+    middle = PC_MIDDLE_BUTTON;
+    right = PC_RIGHT_BUTTON;
+    parse = parsePC;
 #elif MOUSE_MICROSOFT
-	/* microsoft mouse*/
-	left = MS_LEFT_BUTTON;
-	right = MS_RIGHT_BUTTON;
-	middle = 0;
-	parse = parseMS;
+    /* microsoft mouse*/
+    left = MS_LEFT_BUTTON;
+    right = MS_RIGHT_BUTTON;
+    middle = 0;
+    parse = parseMS;
 #else
-	return -1;
+    return -1;
 #endif
 
-	/* open mouse port*/
-	if (!(port = getenv("MOUSE_PORT")))
-	    port = getenv("QEMU")? MOUSE_QEMU: MOUSE_PORT;
-	printf("Opening mouse on %s\n", port);
-	mouse_fd = open(port, O_EXCL | O_NOCTTY | O_NONBLOCK);
-	if (mouse_fd < 0) {
-		printf("Can't open %s, error %d\n", port, errno);
- 		return -1;
-	}
+    /* open mouse port*/
+    if (!(port = getenv("MOUSE_PORT")))
+        port = getenv("QEMU")? MOUSE_QEMU: MOUSE_PORT;
+    printf("Opening mouse on %s\n", port);
+    mouse_fd = open(port, O_EXCL | O_NOCTTY | O_NONBLOCK);
+    if (mouse_fd < 0) {
+        printf("Can't open %s, error %d\n", port, errno);
+        return -1;
+    }
 
-	/* set rawmode serial port using termios*/
-	if (tcgetattr(mouse_fd, &termios) < 0) {
-		printf("Can't get termio on %s, error %d\n", port, errno);
-		close(mouse_fd);
-		return -1;
-	}
+    /* set rawmode serial port using termios*/
+    if (tcgetattr(mouse_fd, &termios) < 0) {
+        printf("Can't get termio on %s, error %d\n", port, errno);
+        close(mouse_fd);
+        return -1;
+    }
 
-	if(cfgetispeed(&termios) != B1200)
-		cfsetispeed(&termios, B1200);
+    if(cfgetispeed(&termios) != B1200)
+        cfsetispeed(&termios, B1200);
 
-	termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
-	termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
-	termios.c_cflag &= ~(CSIZE | PARENB);
-	termios.c_cflag |= CS8;
-	termios.c_cc[VMIN] = 0;
-	termios.c_cc[VTIME] = 0;
-	if(tcsetattr(mouse_fd, TCSAFLUSH, &termios) < 0) {
-		printf("Can't set termio on %s, error %d\n", port, errno);
-		close(mouse_fd);
-		return -1;
-	}
+    termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
+    termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
+    termios.c_cflag &= ~(CSIZE | PARENB);
+    termios.c_cflag |= CS8;
+    termios.c_cc[VMIN] = 0;
+    termios.c_cc[VTIME] = 0;
+    if(tcsetattr(mouse_fd, TCSAFLUSH, &termios) < 0) {
+        printf("Can't set termio on %s, error %d\n", port, errno);
+        close(mouse_fd);
+        return -1;
+    }
 
-	/* initialize data*/
-	availbuttons = left | middle | right;
-	state = IDLE;
-	nbytes = 0;
-	buttons = 0;
-	xd = 0;
-	yd = 0;
+    /* initialize data*/
+    availbuttons = left | middle | right;
+    state = IDLE;
+    nbytes = 0;
+    buttons = 0;
+    xd = 0;
+    yd = 0;
 
-	return mouse_fd;
+    return mouse_fd;
 }
 
 /*
@@ -160,52 +160,52 @@ open_mouse(void)
 int
 read_mouse(int *dx, int *dy, int *dz, int *bptr)
 {
-	int	b;
+    int b;
     static unsigned char buffer[MAX_BYTES];
 
-	/*
-	 * If there are no more bytes left, then read some more,
-	 * waiting for them to arrive.  On a signal or a non-blocking
-	 * error, return saying there is no new state available yet.
-	 */
-	if (nbytes <= 0) {
-		bp = buffer;
-		nbytes = read(mouse_fd, bp, MAX_BYTES);
-		if (nbytes < 0) {
-			if (errno == EINTR || errno == EAGAIN)
-				return 0;
-			return -1;
-		}
-	}
-	if (rawmode) {
-		while (nbytes-- > 0)
-			printf("%02x ", *bp++);
-		return 0;
-	}
+    /*
+     * If there are no more bytes left, then read some more,
+     * waiting for them to arrive.  On a signal or a non-blocking
+     * error, return saying there is no new state available yet.
+     */
+    if (nbytes <= 0) {
+        bp = buffer;
+        nbytes = read(mouse_fd, bp, MAX_BYTES);
+        if (nbytes < 0) {
+            if (errno == EINTR || errno == EAGAIN)
+                return 0;
+            return -1;
+        }
+    }
+    if (rawmode) {
+        while (nbytes-- > 0)
+            printf("%02x ", *bp++);
+        return 0;
+    }
 
-	/*
-	 * Loop over all the bytes read in the buffer, parsing them.
-	 * When a complete state has been read, return the results,
-	 * leaving further bytes in the buffer for later calls.
-	 */
-	while (nbytes-- > 0) {
-		if ((*parse)((int) *bp++)) {
-			*dx = xd;
-			*dy = yd;
-			*dz = 0;
-			b = 0;
-			if(buttons & left)
-				b |= LBUTTON;
-			if(buttons & right)
-				b |= RBUTTON;
-			if(buttons & middle)
-				b |= MBUTTON;
-			*bptr = b;
-			return 1;
-		}
-	}
+    /*
+     * Loop over all the bytes read in the buffer, parsing them.
+     * When a complete state has been read, return the results,
+     * leaving further bytes in the buffer for later calls.
+     */
+    while (nbytes-- > 0) {
+        if ((*parse)((int) *bp++)) {
+            *dx = xd;
+            *dy = yd;
+            *dz = 0;
+            b = 0;
+            if(buttons & left)
+                b |= LBUTTON;
+            if(buttons & right)
+                b |= RBUTTON;
+            if(buttons & middle)
+                b |= MBUTTON;
+            *bptr = b;
+            return 1;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 #if MOUSE_PC
@@ -216,57 +216,57 @@ read_mouse(int *dx, int *dy, int *dz, int *bptr)
 int
 parsePC(int byte)
 {
-	int	sign;			/* sign of movement */
+    int sign;           /* sign of movement */
 
-	switch (state) {
-		case IDLE:
-			if ((byte & TOP_FIVE_BITS) == TOP_BIT) {
-				buttons = ~byte & BOTTOM_THREE_BITS;
-				state = XSET;
-			}
-			break;
+    switch (state) {
+        case IDLE:
+            if ((byte & TOP_FIVE_BITS) == TOP_BIT) {
+                buttons = ~byte & BOTTOM_THREE_BITS;
+                state = XSET;
+            }
+            break;
 
-		case XSET:
-			sign = 1;
-			if (byte > 127) {
-				byte = 256 - byte;
-				sign = -1;
-			}
-			xd = byte * sign;
-			state = YSET;
-			break;
+        case XSET:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            xd = byte * sign;
+            state = YSET;
+            break;
 
-		case YSET:
-			sign = 1;
-			if (byte > 127) {
-				byte = 256 - byte;
-				sign = -1;
-			}
-			yd = -byte * sign;
-			state = XADD;
-			break;
+        case YSET:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            yd = -byte * sign;
+            state = XADD;
+            break;
 
-		case XADD:
-			sign = 1;
-			if (byte > 127) {
-				byte = 256 - byte;
-				sign = -1;
-			}
-			xd += byte * sign;
-			state = YADD;
-			break;
+        case XADD:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            xd += byte * sign;
+            state = YADD;
+            break;
 
-		case YADD:
-			sign = 1;
-			if (byte > 127) {
-				byte = 256 - byte;
-				sign = -1;
-			}
-			yd -= byte * sign;
-			state = IDLE;
-			return 1;
-	}
-	return 0;
+        case YADD:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            yd -= byte * sign;
+            state = IDLE;
+            return 1;
+    }
+    return 0;
 }
 #endif
 
@@ -278,48 +278,48 @@ parsePC(int byte)
 int
 parseMS(int byte)
 {
-	switch (state) {
-		case IDLE:
-			if (byte & SIXTH_BIT) {
-				buttons = (byte >> 4) & BOTTOM_TWO_BITS;
-				yd = ((byte & THIRD_FOURTH_BITS) << 4);
-				xd = ((byte & BOTTOM_TWO_BITS) << 6);
-				state = XADD;
-			}
-			break;
+    switch (state) {
+        case IDLE:
+            if (byte & SIXTH_BIT) {
+                buttons = (byte >> 4) & BOTTOM_TWO_BITS;
+                yd = ((byte & THIRD_FOURTH_BITS) << 4);
+                xd = ((byte & BOTTOM_TWO_BITS) << 6);
+                state = XADD;
+            }
+            break;
 
-		case XADD:
-			xd |= (byte & BOTTOM_SIX_BITS);
-			state = YADD;
-			break;
+        case XADD:
+            xd |= (byte & BOTTOM_SIX_BITS);
+            state = YADD;
+            break;
 
-		case YADD:
-			yd |= (byte & BOTTOM_SIX_BITS);
-			state = IDLE;
-			if (xd > 127)
-				xd -= 256;
-			if (yd > 127)
-				yd -= 256;
-			return 1;
-	}
-	return 0;
+        case YADD:
+            yd |= (byte & BOTTOM_SIX_BITS);
+            state = IDLE;
+            if (xd > 127)
+                xd -= 256;
+            if (yd > 127)
+                yd -= 256;
+            return 1;
+    }
+    return 0;
 }
 #endif
 
 int main(int argc, char **argv)
 {
-	int x, y, z, b;
+    int x, y, z, b;
 
-	rawmode = (argc > 1);
+    rawmode = (argc > 1);
 
-	if(open_mouse() < 0)
-		return 1;
+    if(open_mouse() < 0)
+        return 1;
 
-	printf("[Mouse test, ^C to quit]\n");
-	while(1) {
-		if(read_mouse(&x, &y, &z, &b) == 1) {
-			printf("x:%4d, y:%4d, b:%2d\n", x, y, b);
-		}
-	}
-	return 0;
+    printf("[Mouse test, ^C to quit]\n");
+    while(1) {
+        if(read_mouse(&x, &y, &z, &b) == 1) {
+            printf("x:%4d, y:%4d, b:%2d\n", x, y, b);
+        }
+    }
+    return 0;
 }

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -134,6 +134,10 @@ devices:
 	$(MKDEV) /dev/ttyS2 c 4 66
 	$(MKDEV) /dev/ttyS3 c 4 67
 
+# PS/2 mouse port
+
+	$(MKDEV) /dev/psaux c 4 32
+
 ##############################################################################
 # Parallel devices, as detected by the ROM BIOS.
 


### PR DESCRIPTION
Requested and discussed in https://github.com/ghaerr/microwindows/issues/109#issuecomment-3790802841.

This PR takes @toncho11's initial PS/2 mouse driver and adapts it into the TTY infrastructure in ELKS. The driver is not tested on any real hardware nor emulator. The mouse driver is accessible from /dev/psaux and likely only supports the base 3-byte PS/2 protocol. I have tested the basic operation of the TTY infrastructure around the driver, which works. I doubt the driver works as-is though.

There are likely serious issues with this driver, noted within the source with FIXME comments. These include the following:
- PS/2 controller status bit 1 should be checked before writing data to it
- IRQ 12 is not likely enabled using the required 8042 command sequence
- Opening /dev/psaux without a PS/2 controller will likely hang the system
- IRQ 12 interrupts need to be disabled on the controller on mouse close or the system may crash

These will be further researched by @toncho11 and tested on copy.sh/v86.

For now, the driver is always compiled and included on IBM PC builds by having the CONFIG_MOUSE_PS2 define set in linuxmt/config.h.

There is further work to do in Nano-X and ELKS to automatically access this driver when MOUSE_TYPE=ps2. I will be adding those changes either within this PR or as follow ups. The ELKS `mouse` program will be included allowing for easier debugging by enabling a user to see mouse activity using ASCII print statements rather than inside a GUI where that is much harder.

