### PR TITLE
[kernel] Don't prohibit using IRQ 12 on 8086 machines when opening PS/2 mouse port

### DIFF
--- a/elks/arch/i86/drivers/char/mouse-ps2.c
+++ b/elks/arch/i86/drivers/char/mouse-ps2.c
@@ -10,6 +10,7 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/ntty.h>
+#include <linuxmt/kernel.h>
 #include <arch/io.h>
 #include <arch/irq.h>
 
@@ -23,19 +24,23 @@
 #define STATUS          0x64
 #define COMMAND         0x64
 
-/* 8042 commands */
-#define DISABLE_INTS    0x65        /* disable interrupts */
-#define ENABLE_INTS     0x47        /* enable interrupts */
-#define DISABLE_AUX     0xa7        /* disable aux */
-#define ENABLE_AUX      0xa8        /* enable aux */
-#define DISABLE_AUX_DEV 0xf5        /* disable aux device */
-#define ENABLE_AUX_DEV  0xf4        /* enable aux device */
-#define MAGIC_WRITE     0xd4        /* value to send aux device data */
-#define CMD_WRITE       0x60        /* value to write to controller */
+/* 8042 commands using outb() */
+#define WRITE_CTRLR     0x60        /* send command to controller */
+#define WRITE_MOUSE     0xd4        /* send command to aux device (mouse) */
+#define DISABLE_AUX     0xa7        /* disable aux (mouse) port */
+#define ENABLE_AUX      0xa8        /* enable aux (mouse) port */
 
-/* aux controller status bits */
-#define IBUF_FULL       0x02        /* input buffer (to device) full */
-#define OBUF_FULL       0x21        /* output buffer (from device) full */
+/* commands using WRITE_CTRLR/write_controller() */
+#define ENABLE_INTS     0x47        /* enable interrupts */
+#define DISABLE_INTS    0x65        /* disable interrupts */
+
+/* comands using WRITE_MOUSE/write_mouse() */
+#define ENABLE_AUX_DEV  0xf4        /* enable aux device */
+#define DISABLE_AUX_DEV 0xf5        /* disable aux device */
+
+/* controller status bits */
+#define IBUF_FULL       0x02        /* input buffer to device full */
+#define OBUF_FULL       0x21        /* aux (mouse) output and output buffer full */
 
 static void poll_aux_status(void)
 {
@@ -48,38 +53,38 @@ static void poll_aux_status(void)
     }
 }
 
-/* write to aux device */
-static void aux_write_dev(int val)
+/* write command to mouse */
+static void write_mouse(int cmd)
 {
     poll_aux_status();
-    outb_p(MAGIC_WRITE, COMMAND);       /* next byte to mouse */
+    outb_p(WRITE_MOUSE, COMMAND);       /* send command to mouse (aux device) */
     poll_aux_status();
-    outb_p(val, DATA);                  /* write data */
+    outb_p(cmd, DATA);                  /* command */
 }
 
-/* write aux device command */
-static void aux_write_cmd(int val)
+/* write command to controller */
+static void write_controller(int cmd)
 {
     poll_aux_status();
-    outb_p(CMD_WRITE, COMMAND);         /* next byte to controller */
+    outb_p(WRITE_CTRLR, COMMAND);       /* send command to controller */
     poll_aux_status();
-    outb_p(val, DATA);                  /* write data */
+    outb_p(cmd, DATA);                  /* command */
 }
 
 static void ps2_mouse_disable(void)
 {
-    aux_write_cmd(DISABLE_INTS);        /* disable controller interrupts */
+    write_controller(DISABLE_INTS);     /* disable controller interrupts */
     poll_aux_status();
-    outb_p(DISABLE_AUX, COMMAND);       /* disable aux device */
+    outb_p(DISABLE_AUX, COMMAND);       /* disable aux (mouse) port */
     poll_aux_status();
 }
 
 static void ps2_mouse_enable(void)
 {
     poll_aux_status();
-    outb_p(ENABLE_AUX, COMMAND);        /* enable aux */
-    aux_write_dev(ENABLE_AUX_DEV);      /* enable aux device streaming */
-    aux_write_cmd(ENABLE_INTS);         /* enable controller interrupts */
+    outb_p(ENABLE_AUX, COMMAND);        /* enable aux (mouse) port */
+    write_mouse(ENABLE_AUX_DEV);        /* enable mouse (aux device) */
+    write_controller(ENABLE_INTS);      /* enable controller interrupts */
     poll_aux_status();
 }
 
@@ -101,15 +106,19 @@ static void ps2_irq(int irq, struct pt_regs *regs)
 
 static int ps2_open(struct tty *tty)
 {
-    int err;
+    int err, sav_caps;
 
-    if (tty->usecount)      /* exclusive use only */
+    if (tty->usecount)          /* exclusive use only */
         return -EBUSY;
 
+    sav_caps = sys_caps;
+    sys_caps |= CAP_IRQ8TO15;   /* force-allow IRQ 12 to allow 8086 emulators to work */
     err = request_irq(IRQ_MOUSE, ps2_irq, INT_GENERIC);
-    if (err)
+    sys_caps = sav_caps;
+    if (err) {
+        printk("mouse: irq %d not available, error %d\n", IRQ_MOUSE, -err);
         return err;
-
+    }
     err = tty_allocq(tty, MOUSEINQ_SIZE, 0);  /* input only */
     if (err) {
         free_irq(IRQ_MOUSE);

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -41,7 +41,7 @@
 #define CONFIG_FAST_IRQ3                        /* com2 */
 
 /* temp always enable experimental PS/2 mouse driver for IBM PC */
-#define CONFIG_MOUSE_PS2        1
+#define CONFIG_MOUSE_PS2
 
 /* The following can be set for minimal systems or for QEMU emulation testing:
  * 10 buffers (@20 = 200), 2 ttyq (@80 = 160), 4k L1 cache, 512 heap free,

--- a/elkscmd/gui/mouse.c
+++ b/elkscmd/gui/mouse.c
@@ -127,7 +127,6 @@ int open_mouse(void)
         parse = parseMS;
         max_bytes = MS_MAX_BYTES;
     } else if (strcmp(type, "ps2") == 0) {
-        printf("got PS2 %s\n", type);
         /* PS/2 mouse*/
         left = PS2_LEFT_BUTTON;
         right = PS2_RIGHT_BUTTON;

--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -127,7 +127,6 @@ int open_mouse(void)
         parse = parseMS;
         max_bytes = MS_MAX_BYTES;
     } else if (strcmp(type, "ps2") == 0) {
-        printf("got PS2 %s\n", type);
         /* PS/2 mouse*/
         left = PS2_LEFT_BUTTON;
         right = PS2_RIGHT_BUTTON;


### PR DESCRIPTION
Allows open of PS/2 mouse port (/dev/psaux) using IRQ 12, even when running on or emulating an 8086 CPU. 

Discussed as an option in https://github.com/ghaerr/elks/pull/2598#issuecomment-3797423466. Rather than adding a /bootopts option which would require a user to do something, this option automatically tries to allocate IRQ 12 using the second 8259 PIC, even though there is no second 8259 PIC on real PC/XT hardware. Since most real hardware users won't try to use a hardware PS/2 mouse on PC/XTs but some 8086 emulators (e.g. [FabGL](https://github.com/fdivitto/FabGL)) do implement a PS/2 mouse on IRQ 12, it was reasoned that getting an emulated PS/2 mouse working without the user doing anything is better than what the system may do when allocating IRQ 12 on a non-existent PIC and subsequently sending commands to an 8042 that will likely ignore them.

The PS/2 mouse driver now displays an error message if IRQ 12 is otherwise in use, or for any other errors.

Also, various mouse driver function names were renamed and better comments added.

