### PR TITLE
Improved PS2 code

### DIFF
--- a/elks/arch/i86/drivers/char/mouse-ps2.c
+++ b/elks/arch/i86/drivers/char/mouse-ps2.c
@@ -1,7 +1,8 @@
 /*
- * Minimal PS/2 mouse driver for ELKS
+ * PS/2 mouse driver for ELKS
  *
  * 23 Jan 2026 Original version by Anton Andreev, adapted by Greg Haerr
+ * No support for extensions IntelliMouse PS/2 (ImPS/2) and IntelliMouse Explorer PS/2 (IMEX / Explorer). 
  */
 
 #include <linuxmt/config.h>
@@ -40,7 +41,7 @@
 
 /* controller status bits */
 #define IBUF_FULL       0x02        /* input buffer to device full */
-#define OBF             0x01        /* output buffer full */
+#define OBUF_FULL       0x01        /* output buffer full */
 #define AUXDATA         0x20        /* mouse data */
 
 static void poll_aux_status(void)
@@ -51,7 +52,7 @@ static void poll_aux_status(void)
         unsigned char st = inb_p(STATUS);
 
         /* Drain any pending output byte (kbd or mouse) */
-        if (st & OBF) {
+        if (st & OBUF_FULL) {
 			(void)inb_p(DATA);
 			continue;
 		}
@@ -134,7 +135,7 @@ static void ps2_irq(int irq, struct pt_regs *regs)
     unsigned char c;
 
     /* Read all available mouse bytes */
-    while ((inb(STATUS) & (OBF | AUXDATA)) == (OBF | AUXDATA)) {
+    while ((inb(STATUS) & (OBUF_FULL | AUXDATA)) == (OBUF_FULL | AUXDATA)) {
 		c = inb(DATA);
 		chq_addch_nowakeup(q, c);
 	}

--- a/elks/arch/i86/drivers/char/mouse-ps2.c
+++ b/elks/arch/i86/drivers/char/mouse-ps2.c
@@ -31,11 +31,9 @@
 #define DISABLE_AUX      0xa7        /* disable aux (mouse) port */
 #define ENABLE_AUX       0xa8        /* enable aux (mouse) port */
 #define GET_CMD_BYTE     0x20        /* read command byte */
-#define ENABLE_MOUSE_IRQ 0x02        /* enable mouse irq 12 */
 
-/* commands using WRITE_CTRLR/write_controller() */
-#define ENABLE_INTS     0x47        /* enable interrupts */
-#define DISABLE_INTS    0x65        /* disable interrupts */
+/* command byte status bits */
+#define ENABLE_MOUSE_IRQ 0x02        /* enable mouse irq 12 */
 
 /* comands using WRITE_MOUSE/write_mouse() */
 #define ENABLE_AUX_DEV  0xf4        /* enable aux device */
@@ -68,17 +66,17 @@ static void poll_aux_status(void)
 static unsigned int read_ccb(void)
 {
     poll_aux_status();
-    outb_p(GET_CMD_BYTE, COMMAND);          /* read command byte */
+    outb_p(GET_CMD_BYTE, COMMAND);      /* read command byte */
     poll_aux_status();
-    return (unsigned int)inb_p(DATA);
+    return inb_p(DATA);
 }
 
 static void write_ccb(unsigned int ccb)
 {
     poll_aux_status();
-    outb_p(WRITE_CTRLR, COMMAND);   /* 0x60 */
+    outb_p(WRITE_CTRLR, COMMAND);       /* 0x60 */
     poll_aux_status();
-    outb_p((unsigned char)ccb, DATA);
+    outb_p(ccb, DATA);
 }
 
 /* write command to mouse */
@@ -86,15 +84,6 @@ static void write_mouse(int cmd)
 {
     poll_aux_status();
     outb_p(WRITE_MOUSE, COMMAND);       /* send command to mouse (aux device) */
-    poll_aux_status();
-    outb_p(cmd, DATA);                  /* command */
-}
-
-/* write command to controller */
-static void write_controller(int cmd)
-{
-    poll_aux_status();
-    outb_p(WRITE_CTRLR, COMMAND);       /* send command to controller */
     poll_aux_status();
     outb_p(cmd, DATA);                  /* command */
 }
@@ -124,7 +113,7 @@ static void ps2_mouse_enable(void)
     write_mouse(ENABLE_AUX_DEV);        /* enable mouse (aux device) */
 
     ccb = read_ccb();
-    ccb |= 0x02;                        /* set IRQ12 enable ONLY */
+    ccb |= ENABLE_MOUSE_IRQ;                        /* set IRQ12 enable ONLY */
     write_ccb(ccb);
 
     poll_aux_status();


### PR DESCRIPTION
Keyboard lock on application exit seems fixed.

PS/2 handling safe by splitting status bits, draining any pending controller output, and enabling/disabling only the mouse IRQ via read-modify-write - avoids keyboard lock.
