### PR TITLE
[kernel] Show CONFIG_FAST_IRQx status on boot screen

### DIFF
--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -11,7 +11,7 @@
 	.code16
 	.text
 
-#ifdef CONFIG_FAST_IRQ4
+#if CONFIG_FAST_IRQ4
 //
 // Entry for ttyS0 top half interrupt handler, called by CALLF within dynamic handler
 //
@@ -44,7 +44,7 @@ asm_fast_irq4:
 	iret
 #endif
 
-#ifdef CONFIG_FAST_IRQ3
+#if CONFIG_FAST_IRQ3
 //
 // Entry for ttyS1 top half interrupt handler, called by CALLF within dynamic handler
 //

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -89,8 +89,7 @@ void timer_bh(void)
     /*  Test timer_bh delay message and BH reentrancy when running loop program */
     //for (volatile long i=0; i<30000L; i++);
 
-#if (defined(CONFIG_CHAR_DEV_RS) &&                               \
-        (defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3))) \
+#if (defined(CONFIG_CHAR_DEV_RS) && (CONFIG_FAST_IRQ4 || CONFIG_FAST_IRQ3)) \
     || defined(CONFIG_FAST_IRQ1_NECV25)
 
     /* call serial bottom half every 10ms instead of after every byte received */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -37,8 +37,8 @@
 #define UTS_MACHINE             "ibmpc i8086"
 
 /* Fast serial input handler for arrow keys or fast SLIP on very slow systems */
-#define CONFIG_FAST_IRQ4                        /* com1 */
-#define CONFIG_FAST_IRQ3                        /* com2 */
+#define CONFIG_FAST_IRQ4        1               /* com1 */
+#define CONFIG_FAST_IRQ3        1               /* com2 */
 
 /* temp always enable experimental PS/2 mouse driver for IBM PC */
 #define CONFIG_MOUSE_PS2


### PR DESCRIPTION
The status of CONFIG_FAST_IRQ4 and CONFIG_FAST_IRQ3 are now shown on the boot screen tty line(s):
<img width="832" height="540" alt="Screenshot 2026-01-27 at 7 48 05 PM" src="https://github.com/user-attachments/assets/ed24e53e-dd6e-429c-83c5-f54ef9dde375" />
