### PR TITLE
[kernel] Retire slow IBM PC serial handler, default fast handlers for all ports

### DIFF
--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -11,6 +11,8 @@
 	.code16
 	.text
 
+#ifdef CONFIG_ARCH_IBMPC
+
 	.global asm_fast_com1		// entry points
 	.global asm_fast_com2
 	.global asm_fast_com3
@@ -100,6 +102,7 @@ asm_fast_com4:
 	call	rs_fast_com4		// call special 2nd part of top half C handler
 					// which doesn't use any SS/SP/BP addressing
 	jmp     common_return
+#endif
 
 #ifdef CONFIG_FAST_IRQ1_NECV25
 //

--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -2,7 +2,7 @@
 //
 // Runs on any stack and skips ELKS _irqit stack switching overhead.
 // Must run with interrupts disabled as could interrupt user, kernel or interrupt stack.
-// Calls the second part of the top half (rs_fast_irq4) to read and queue received byte.
+// Calls the second part of the top half (rs_fast_com1) to read and queue received byte.
 // The bottom half (serial_bh) runs later, which processes queue and calls wake_up.
 //
 // 25 June 2020 Greg Haerr
@@ -11,13 +11,18 @@
 	.code16
 	.text
 
-#if CONFIG_FAST_IRQ4
+	.global asm_fast_com1		// entry points
+	.global asm_fast_com2
+	.global asm_fast_com3
+	.global asm_fast_com4
+	.extern	rs_fast_com1		// 2nd parts of handlers
+	.extern	rs_fast_com2
+	.extern	rs_fast_com3
+	.extern	rs_fast_com4
 //
 // Entry for ttyS0 top half interrupt handler, called by CALLF within dynamic handler
 //
-	.extern	rs_fast_irq4
-	.global asm_fast_irq4
-asm_fast_irq4:
+asm_fast_com1:
 	push	%ax			// save regs, uses 18 bytes of current stack
 	push	%bx
 	push	%cx
@@ -28,10 +33,9 @@ asm_fast_irq4:
 	// Was pushed by the CALLF of the dynamic handler
 	mov	%sp,%bx
 	mov	%ss:12(%bx),%ds
-
-	call	rs_fast_irq4		// call special 2nd part of top half C handler
+	call	rs_fast_com1		// call special 2nd part of top half C handler
 					// which doesn't use any SS/SP/BP addressing
-
+common_return:
 	mov	$0x20,%al		// EOI on primary controller
 	out	%al,$0x20
 
@@ -42,15 +46,11 @@ asm_fast_irq4:
 	pop	%ax
 	add	$4,%sp			// skip the trampoline DS:*irq
 	iret
-#endif
 
-#if CONFIG_FAST_IRQ3
 //
 // Entry for ttyS1 top half interrupt handler, called by CALLF within dynamic handler
 //
-	.extern	rs_fast_irq3
-	.global	asm_fast_irq3
-asm_fast_irq3:
+asm_fast_com2:
 	push	%ax			// save regs, uses 18 bytes of current stack
 	push	%bx
 	push	%cx
@@ -61,21 +61,45 @@ asm_fast_irq3:
 	// Was pushed by the CALLF of the dynamic handler
 	mov	%sp,%bx
 	mov	%ss:12(%bx),%ds
-
-	call	rs_fast_irq3		// call special 2nd part of top half C handler
+	call	rs_fast_com2		// call special 2nd part of top half C handler
 					// which doesn't use any SS/SP/BP addressing
+	jmp     common_return
 
-	mov	$0x20,%al		// EOI on primary controller
-	out	%al,$0x20
+//
+// Entry for ttyS2 top half interrupt handler, called by CALLF within dynamic handler
+//
+asm_fast_com3:
+	push	%ax			// save regs, uses 18 bytes of current stack
+	push	%bx
+	push	%cx
+	push	%dx
+	push	%ds
 
-	pop	%ds			// restore regs
-	pop	%dx
-	pop	%cx
-	pop	%bx
-	pop	%ax
-	add	$4,%sp			// skip the trampoline DS:*irq
-	iret
-#endif
+	// Recover kernel data segment
+	// Was pushed by the CALLF of the dynamic handler
+	mov	%sp,%bx
+	mov	%ss:12(%bx),%ds
+	call	rs_fast_com3		// call special 2nd part of top half C handler
+					// which doesn't use any SS/SP/BP addressing
+	jmp     common_return
+
+//
+// Entry for ttyS3 top half interrupt handler, called by CALLF within dynamic handler
+//
+asm_fast_com4:
+	push	%ax			// save regs, uses 18 bytes of current stack
+	push	%bx
+	push	%cx
+	push	%dx
+	push	%ds
+
+	// Recover kernel data segment
+	// Was pushed by the CALLF of the dynamic handler
+	mov	%sp,%bx
+	mov	%ss:12(%bx),%ds
+	call	rs_fast_com4		// call special 2nd part of top half C handler
+					// which doesn't use any SS/SP/BP addressing
+	jmp     common_return
 
 #ifdef CONFIG_FAST_IRQ1_NECV25
 //

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -417,19 +417,20 @@ static int rs_open(struct tty *tty)
         return -ENXIO;
 
     /* increment use count, don't init if already open*/
-    if (tty->usecount)
+    if (tty->usecount++)
         return 0;
 
     err = request_irq(port->irq, (irq_handler) asm_fast_irq[n], INT_SPECIFIC);
     if (err)
-        return err;
+        goto errout;
     err = tty_allocq(tty, RSINQ_SIZE, RSOUTQ_SIZE);
     if (err) {
         free_irq(port->irq);
+errout:
+        --tty->usecount;
         return err;
     }
 
-    ++tty->usecount;
     port->intrchar = 0;
     //init_bh(SERIAL_BH, serial_bh);
     //irq_to_port[port->irq] = n;       /* Map irq to this tty #, slow handler only */

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -89,7 +89,8 @@ void timer_bh(void)
     /*  Test timer_bh delay message and BH reentrancy when running loop program */
     //for (volatile long i=0; i<30000L; i++);
 
-#if defined(CONFIG_CHAR_DEV_RS) || defined(CONFIG_FAST_IRQ1_NECV25)
+#if (defined(CONFIG_CHAR_DEV_RS) && defined(CONFIG_ARCH_IBMPC)) \
+    || defined(CONFIG_FAST_IRQ1_NECV25)
     /* call serial bottom half every 10ms instead of after every byte received */
     serial_bh();        /* process serial input and call wake_up */
 #endif

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -89,9 +89,7 @@ void timer_bh(void)
     /*  Test timer_bh delay message and BH reentrancy when running loop program */
     //for (volatile long i=0; i<30000L; i++);
 
-#if (defined(CONFIG_CHAR_DEV_RS) && (CONFIG_FAST_IRQ4 || CONFIG_FAST_IRQ3)) \
-    || defined(CONFIG_FAST_IRQ1_NECV25)
-
+#if defined(CONFIG_CHAR_DEV_RS) || defined(CONFIG_FAST_IRQ1_NECV25)
     /* call serial bottom half every 10ms instead of after every byte received */
     serial_bh();        /* process serial input and call wake_up */
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -36,10 +36,6 @@
 #endif
 #define UTS_MACHINE             "ibmpc i8086"
 
-/* Fast serial input handler for arrow keys or fast SLIP on very slow systems */
-#define CONFIG_FAST_IRQ4        1               /* com1 */
-#define CONFIG_FAST_IRQ3        1               /* com2 */
-
 /* temp always enable experimental PS/2 mouse driver for IBM PC */
 #define CONFIG_MOUSE_PS2
 


### PR DESCRIPTION
Adds fast serial handlers for /dev/ttyS2 and /dev/ttyS3, and removes original (slow) serial input IRQ handler since no longer called. The previous options CONFIG_FAST_IRQ4 and CONFIG_FAST_IRQ3 are removed as no longer needed.

Discussed briefly in https://github.com/Mellvik/TLVC/pull/224#issuecomment-3811804142.

