### PR TITLE
[kernel] Fix PS/2 mouse operation on copy.sh/v86 emulator

### DIFF
--- a/elks/arch/i86/drivers/char/mouse-ps2.c
+++ b/elks/arch/i86/drivers/char/mouse-ps2.c
@@ -72,6 +72,7 @@ static void set_ctrl_reg(int cmd)
     outb_p(SET_CTRL_REG, COMMAND);      /* control register byte follows */
     poll_aux_status();
     outb_p(cmd, DATA);                  /* control register bits */
+    poll_aux_status();
 }
 
 /* send command to mouse */
@@ -86,10 +87,8 @@ static void send_aux_cmd(int cmd)
 
 static void ps2_mouse_disable(void)
 {
-    poll_aux_status();
     send_aux_cmd(AUX_DISABLE_DEV);      /* stop mouse packets */
     set_ctrl_reg(DISABLE_INTS);         /* disable mouse interrupts */
-    poll_aux_status();
     outb_p(DISABLE_AUX, COMMAND);       /* disable aux (mouse) port */
     poll_aux_status();
 }
@@ -100,7 +99,6 @@ static void ps2_mouse_enable(void)
     outb_p(ENABLE_AUX, COMMAND);        /* enable aux (mouse) port */
     send_aux_cmd(AUX_ENABLE_DEV);       /* enable mouse (aux device) */
     set_ctrl_reg(ENABLE_INTS);          /* enable mouse interrupts */
-    poll_aux_status();
 }
 
 /* IRQ handler */

--- a/elks/arch/i86/drivers/char/mouse-ps2.c
+++ b/elks/arch/i86/drivers/char/mouse-ps2.c
@@ -24,56 +24,68 @@
 #define STATUS          0x64
 #define COMMAND         0x64
 
+/* 8042 status register bits */
+#define OBUF_FULL       0x01        /* output buffer full */
+#define IBUF_FULL       0x02        /* input buffer to device full */
+#define ABUF_FULL       0x20        /* aux (mouse) output buffer full */
+
 /* 8042 commands using outb() */
-#define WRITE_CTRLR     0x60        /* send command to controller */
-#define WRITE_MOUSE     0xd4        /* send command to aux device (mouse) */
+#define SET_CTRL_REG    0x60        /* set control register byte in 8042 */
+#define SEND_AUX_CMD    0xd4        /* send command to aux device (mouse) */
 #define DISABLE_AUX     0xa7        /* disable aux (mouse) port */
 #define ENABLE_AUX      0xa8        /* enable aux (mouse) port */
 
-/* commands using WRITE_CTRLR/write_controller() */
-#define ENABLE_INTS     0x47        /* enable interrupts */
-#define DISABLE_INTS    0x65        /* disable interrupts */
+/* preset control register bit values for set_ctrl_reg() */
+#define ENABLE_INTS     0x47        /* enable mouse & keyboard interrupts, scan conv */
+#define DISABLE_INTS    0x65        /* disable mouse & interrupts, enable keyboard/scan */
 
-/* comands using WRITE_MOUSE/write_mouse() */
-#define ENABLE_AUX_DEV  0xf4        /* enable aux device */
-#define DISABLE_AUX_DEV 0xf5        /* disable aux device */
-
-/* controller status bits */
-#define IBUF_FULL       0x02        /* input buffer to device full */
-#define OBUF_FULL       0x21        /* aux (mouse) output and output buffer full */
+/* aux device (mouse) commands for send_aux_cmd() */
+#define AUX_ENABLE_DEV  0xf4        /* enable aux device */
+#define AUX_DISABLE_DEV 0xf5        /* disable aux device */
 
 static void poll_aux_status(void)
 {
-    int retries = 0;
+    int retries = MAX_RETRIES;
 
-    while ((inb(STATUS) & 0x03) && retries < MAX_RETRIES) {
-        if ((inb_p(STATUS) & OBUF_FULL) == OBUF_FULL)
-            inb_p(DATA);
-        retries++;
-    }
+    do {
+        unsigned char st = inb_p(STATUS);
+
+        /* Drain any pending output byte (kbd or mouse) */
+        if (st & OBUF_FULL) {
+			(void)inb_p(DATA);
+			continue;
+		}
+
+        /* Input buffer clear and no output pending -> ready */
+        if (!(st & IBUF_FULL))
+            return;
+    } while (--retries);
 }
 
-/* write command to mouse */
-static void write_mouse(int cmd)
+/* set 8042 control register bits */
+static void set_ctrl_reg(int cmd)
 {
     poll_aux_status();
-    outb_p(WRITE_MOUSE, COMMAND);       /* send command to mouse (aux device) */
+    outb_p(SET_CTRL_REG, COMMAND);      /* control register byte follows */
     poll_aux_status();
-    outb_p(cmd, DATA);                  /* command */
+    outb_p(cmd, DATA);                  /* control register bits */
 }
 
-/* write command to controller */
-static void write_controller(int cmd)
+/* send command to mouse */
+static void send_aux_cmd(int cmd)
 {
     poll_aux_status();
-    outb_p(WRITE_CTRLR, COMMAND);       /* send command to controller */
+    outb_p(SEND_AUX_CMD, COMMAND);      /* command to aux device (mouse) follows */
     poll_aux_status();
     outb_p(cmd, DATA);                  /* command */
+    poll_aux_status();                  /* discard any ACK */
 }
 
 static void ps2_mouse_disable(void)
 {
-    write_controller(DISABLE_INTS);     /* disable controller interrupts */
+    poll_aux_status();
+    send_aux_cmd(AUX_DISABLE_DEV);      /* stop mouse packets */
+    set_ctrl_reg(DISABLE_INTS);         /* disable mouse interrupts */
     poll_aux_status();
     outb_p(DISABLE_AUX, COMMAND);       /* disable aux (mouse) port */
     poll_aux_status();
@@ -83,8 +95,8 @@ static void ps2_mouse_enable(void)
 {
     poll_aux_status();
     outb_p(ENABLE_AUX, COMMAND);        /* enable aux (mouse) port */
-    write_mouse(ENABLE_AUX_DEV);        /* enable mouse (aux device) */
-    write_controller(ENABLE_INTS);      /* enable controller interrupts */
+    send_aux_cmd(AUX_ENABLE_DEV);       /* enable mouse (aux device) */
+    set_ctrl_reg(ENABLE_INTS);          /* enable mouse interrupts */
     poll_aux_status();
 }
 
@@ -95,7 +107,7 @@ static void ps2_irq(int irq, struct pt_regs *regs)
     unsigned char c;
 
     /* Read all available mouse bytes */
-    while ((inb(STATUS) & OBUF_FULL) == OBUF_FULL) {
+    while ((inb(STATUS) & (OBUF_FULL | ABUF_FULL)) == (OBUF_FULL | ABUF_FULL)) {
         c = inb(DATA);
         chq_addch_nowakeup(q, c);
     }

--- a/elks/arch/i86/drivers/char/mouse-ps2.c
+++ b/elks/arch/i86/drivers/char/mouse-ps2.c
@@ -1,7 +1,10 @@
 /*
  * Minimal PS/2 mouse driver for ELKS
  *
- * 23 Jan 2026 Original version by @toncho11, adapted by Greg Haerr
+ * No support for extensions IntelliMouse PS/2 (ImPS/2) and
+ * IntelliMouse Explorer PS/2 (IMEX / Explorer).
+ *
+ * 23 Jan 2026 Original version by Anton Andreev, adapted by Greg Haerr
  */
 
 #include <linuxmt/config.h>

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -5,6 +5,7 @@ umask 022
 #if test "$USER" = "root"; then chmod 777 /tmp; fi
 #uname -v
 #export MOUSE_PORT=none
+#export MOUSE_TYPE=ps2
 #export MANPATH=/root/man:/lib
 #export TZ=GMT0
 # if TZ= set in /bootopts or above it overrides CONFIG_TIME_TZ, so don't set TZ= below


### PR DESCRIPTION
Corrects problem of keyboard not working after closing mouse device from `mouse` or Nano-X using the PS/2 mouse driver.  Reported and fixed by  @toncho11 in #2602 from testing #2600. This PR includes code from #2602, thank you @toncho11!

Further research into the 8042 keyboard/mouse controller was performed, as it remained unclear exactly why #2602 was working, given that testing on copy.sh/v86 showed the 8042 control register bits for enabling and disabling the aux mouse device IRQ 12 were identical, whether set all at once or by reading the 8042 control register byte and OR/ANDing to enable/disable interrupts.

It was finally found that the reason the fixed driver was actually working was the inclusion of the single line:
```
    write_mouse(DISABLE_AUX_DEV);        /* stop mouse packets */
```
The method of reading then writing the controller command byte (control register bits) had no effect. I think what was actually happening is that when the mouse driver was previously closed, but the aux device not actually disabled but interrupts turned off, the 8042 stopped triggering IRQ 12 whenever the AUXDEV status bit indicated mouse data ready. In turn, since the 8042 will only process KBD and AUX (mouse) devices serially-in-order, the mouse continued to send data, but the AUXDEV status bit was never tested or cleared, causing the normal keyboard read routines to fail by effectively sending mouse data to the keyboard scan code interpretation routines.

Another problem was that the `poll_aux_status` routine didn't properly clear both the input and output buffers before returning, which sometimes caused spurious incorrect "keyboard" data to be displayed onscreen. This was also fixed by @toncho11 in #2602.

With better understanding of the actual operation of the 8042 and its control, status and aux device handling, this PR renames several routines and defines to hopefully better convey what the driver is actually doing, while also including both of @toncho11's above fixes.

Tested on Bochs and copy.sh/v86. Both `mouse` and `nxstart` work well with `export MOUSE_TYPE=ps2`, which is now also included (commented out) in /etc/profile for convenience.


