### PR TITLE
[build] Add bochs emulator support for IBM PC text and graphics

### DIFF
--- a/bochs.rc
+++ b/bochs.rc
@@ -1,0 +1,49 @@
+# Bochs configuration file for ELKS
+# Use by running: ./bochs.sh or bochs -qf bochs.rc
+#
+
+# filename of ROM images
+romimage: file="$BXSHARE/BIOS-bochs-latest"
+vgaromimage: file="$BXSHARE/VGABIOS-lgpl-latest.bin"
+
+# default disk image is 2880k floppy. Change below for other sizes:
+#floppya: 360k=Unix360.img, status=inserted
+#floppya: 1_44=image/fd1440-minix.img, status=inserted
+#floppya: 2_88=image/fd2880-minix.img, status=inserted
+floppya: 2_88=image/fd2880.img, status=inserted
+
+# hard disk
+ata0: enabled=1, ioaddr1=0x1f0, ioaddr2=0x3f0, irq=14
+#ata0-master: type=disk, path="hd32-minix.img", mode=flat, cylinders=63, heads=16, spt=63
+
+# choose the boot disk.
+boot: a
+
+# default 1MB memory
+megs: 1
+
+# defines the parameters of the clock inside Bochs
+clock: sync=realtime, time0=938581955   # Wed Sep 29 07:12:35 1999
+
+# use term to run in existing terminal window, otherwise sdl2 for new (graphical) window
+display_library: sdl2
+#display_library: term
+
+# default PS/2 mouse emulation
+# (must set 'export MOUSE_TYPE=ps2' from shell or in /etc/profile on ELKS)
+# then use CTRL-ALT to enable/disable mouse emulation when running bochs
+#mouse: enabled=1, type=serial, toggle=ctrl+alt
+mouse: enabled=1, type=ps2, toggle=ctrl+alt
+
+# start with mouse disabled
+mouse: enabled=0
+
+#com1: enabled=1, mode=term, dev=/dev/ttys001
+#com1: enabled=1, mode=mouse
+
+# where do we send log messages?
+#log: bochsout.txt
+panic: action=ask
+error: action=report
+info: action=report
+#debug: action=report

--- a/bochs.sh
+++ b/bochs.sh
@@ -1,0 +1,9 @@
+# Helper to run ELKS in bochs
+#
+# Prior to running this script:
+# export BXSHARE= to bochs installation directory
+
+[ -z "$BXSHARE" ] && export BXSHARE=/usr/local/Cellar/bochs/3.0/share/bochs
+
+# default image is 2880k floppy, change floppya: in bochs.rc for other sizes
+bochs -qf bochs.rc


### PR DESCRIPTION
Adds support for emulating ELKS by using `./bochs.sh`. 

By default, a 2880k floppy image is required. Other image sizes can be set by editing `bochs.rc`. 
Use `export BXSHARE=/path/to/bochs` before running. 

Bochs emulates a VGA screen as well as PS/2 mouse. Use `export MOUSE_TYPE=ps2` in the shell or edit /etc/profile and uncomment MOUSE_TYPE=ps2, then run `nxstart` to demo the Nano-X. The mouse is enabled/disabled using the CTRL-ALT keyboard combination.

Bochs can also run directly within the open terminal window: set `display_library: term` in bochs.rc.