### PR TITLE
[libc] Enhance debug function tracing

### DIFF
--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -25,7 +25,7 @@ void check_ustack(void)
 
     if (sp < brk) {
         printk("(%P)STACK OVERFLOW by %u\n", brk - sp);
-        printk("curbreak %u, SP %u\n", current->t_endbrk, current->t_regs.sp);
+        printk("CURBREAK %x, SP %x\n", brk, sp);
         do_exit(SIGSEGV);
     }
     if (sp < stacklow) {
@@ -33,7 +33,7 @@ void check_ustack(void)
         printk("(%P)STACK USING %u UNUSED HEAP\n", stacklow - sp);
     }
     if (sp > current->t_begstack) {
-        printk("(%P)STACK UNDERFLOW\n");
+        printk("(%P)STACK UNDERFLOW: SP %x BEGSTACK %x\n", sp, current->t_begstack);
         do_exit(SIGSEGV);
     }
 }

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -34,3 +34,4 @@ xms=on
 #istack
 #console=ttyS0,19200 3
 #MOUSE_PORT=/dev/ttyS1
+#DEBUG_PORT=none

--- a/libc/debug/instrument.c
+++ b/libc/debug/instrument.c
@@ -107,7 +107,7 @@ void noinstrument __cyg_profile_func_enter_simple(void)
     fprintf(stderr, ">%s, from %s %d/%u SP %x %lk", sym_text_symbol(calling_fn, 0),
         callsite, stack_used, max_stack, getsp(), get_ptime());
     fputc('\n', stderr);
-    save_calling_fn[count] = calling_fn;
+    save_calling_fn[count & 63] = calling_fn;
     if (ftrace & 2) _print_stack(0);
     ++count;
 }

--- a/libc/debug/instrument.c
+++ b/libc/debug/instrument.c
@@ -14,10 +14,19 @@
 #include "debug/instrument.h"
 #include "debug/syms.h"
 
+#define getsp() __extension__ ({        \
+        unsigned int _v;                \
+        asm volatile ("mov %%sp,%%ax"   \
+            :"=a" (_v)                  \
+            : /* no input */            \
+        );                              \
+        _v; })
+
 static size_t ftrace;
 static size_t start_sp;
 static size_t max_stack;
 static int count;
+static int *save_calling_fn[64];
 
 /* runs before main and rewrites argc/argv on stack if --ftrace found */
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
@@ -25,16 +34,21 @@ static noinstrument CONSTRUCTOR(ftrace_checkargs, _INIT_PRI_FTRACE);
 static noinstrument void ftrace_checkargs(void)
 {
     char **avp = __argv + 1;
+    char *p;
     int fd;
 
-    ftrace = (size_t)getenv("FTRACE");
-    if ((*avp && !strcmp(*avp, "--ftrace"))) {
+    if (*avp && !strncmp("--ftrace", *avp, 8)) {
+        p = *avp + 8;
         while (*avp) {
             *avp = *(avp + 1);
             avp++;
         }
         __argc--;
-        ftrace = 1;
+    } else
+        p = getenv("FTRACE");
+    if (p) {
+        if (*p) ftrace = *p - '0';
+        else ftrace = 1;
     }
     if (ftrace) {
         fd = open(_PATH_CONSOLE, O_WRONLY);
@@ -90,16 +104,23 @@ void noinstrument __cyg_profile_func_enter_simple(void)
     fprintf(stderr, "(%d)", getpid());
     for (i=0; i<count; i++)
        fputc('|', stderr);
-    fprintf(stderr, ">%s, from %s %d/%u %lk", sym_text_symbol(calling_fn, 0),
-        callsite, stack_used, max_stack, get_ptime());
+    fprintf(stderr, ">%s, from %s %d/%u SP %x %lk", sym_text_symbol(calling_fn, 0),
+        callsite, stack_used, max_stack, getsp(), get_ptime());
     fputc('\n', stderr);
+    save_calling_fn[count] = calling_fn;
+    if (ftrace & 2) _print_stack(0);
     ++count;
 }
 
 void noinstrument __cyg_profile_func_exit_simple(void)
 {
-    if (ftrace)
-        --count;
+    if (ftrace) {
+        int *calling_fn = save_calling_fn[--count];
+        fprintf(stderr, "(%d)", getpid());
+        for (int i=0; i<count; i++)
+            fputc('|', stderr);
+        fprintf(stderr, "<%s EXIT SP %x\n", sym_text_symbol(calling_fn, 0), getsp());
+    }
 }
 
 #if UNUSED

--- a/libc/debug/stacktrace.c
+++ b/libc/debug/stacktrace.c
@@ -32,19 +32,19 @@ static void noinstrument _print_stack_line(int level, int **addr, int *fn,
 {
     int j = 0;
 
-    printf("%4d: %04x =>", level, (int)addr);
+    fprintf(stderr, "%4d: %04x =>", level, (int)addr);
     do {
         if ((j == 0 && !(flag & BP_PUSHED))
          || (j == 1 && !(flag & DI_PUSHED))
          || (j == 2 && !(flag & SI_PUSHED)))
-            printf("     ");
-        else printf(" %04x", (int)*addr++);
+            fprintf(stderr, "     ");
+        else fprintf(stderr, " %04x", (int)*addr++);
     } while (++j < STACKCOLS);
-    printf(" (%04x)", (int)fn);
-    printf(" %s", sym_text_symbol(fn, (size_t)fn - (size_t)fnstart));
+    fprintf(stderr, " (%04x)", (int)fn);
+    fprintf(stderr, " %s", sym_text_symbol(fn, (size_t)fn - (size_t)fnstart));
     if (!(flag & BP_PUSHED))
-        printf("*");
-    printf("\n");
+        fprintf(stderr, "*");
+    fprintf(stderr, "\n");
 }
 
 /* display call stack, arg1 ignored but displayed for testing */
@@ -56,7 +56,7 @@ void noinstrument _print_stack(int arg1)
     int i = 0;
 
     sym_read_exe_symbols(__program_filename);
-    printf("Level Addr    BP   DI   SI   Ret  Arg  Arg2 Arg3 Arg4\n"
+    fprintf(stderr, "Level Addr    BP   DI   SI   Ret  Arg  Arg2 Arg3 Arg4\n"
            "~~~~~ ~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
     do {
         int *fnstart = _get_fn_start_address(fn);


### PR DESCRIPTION
Adds additional stack-backtrace option for specially-compiled ELKS applications to display a stack backtrace in addition to the existing function tracing capability. This option can be turned on either through `export FTRACE=2` or `--ftrace2` as the first argument command. Normal function tracing remains available through `export FTRACE` or `--ftrace` command line.

Applications must be compiled with the following additional ia16-elf-gcc command line options in order to link in runtime function tracing:
```
    -fno-omit-frame-pointer -fno-optimize-sibling-calls -finstrument-functions-simple
```

The combined stack tracing was developed to track down a stack corruption bug in DCC ([Open DeSmet C Compiler for ELKS](https://github.com/ghaerr/DeSmetC)) which is a work in progress. This particular C compiler is able to compile itself on ELKS, possibly providing the capability of compiling the toolchain itself inside ELKS, slowly marching towards a self-replicating system.

Some examples of the usage of function tracing output follow.

DCC --ftrace function tracing showing recursive descent parser functions being called:
<img width="752" height="1122" alt="C88 parse ftrace1" src="https://github.com/user-attachments/assets/10df3bcd-944f-45ea-87ed-aa7f42a2e51e" />

ELKS kernel catching stack underflow as the result of SP being clobbered (pretty cool for non-MMU system):
<img width="752" height="1122" alt="C88 parse segfault ftrace1" src="https://github.com/user-attachments/assets/ed7f5e17-e4b2-4472-a0a1-0c40be9c5d42" />

DCC --ftrace2 stack backtrace display showing BP being zeroed (clobbered) directly before tree4() is called from heir25(). This information finally allowed finding the buggy source code, which ended up being that of writing outside the bounds of a local array which clobbered BP and SP in the addresses directly above the array variable:
<img width="752" height="1122" alt="C88 parse BP overwrite ftrace2 copy" src="https://github.com/user-attachments/assets/301b7958-ae5e-4459-af3b-e04b40e7fc2d" />

