### PR TITLE
Elks sys fix warning

### DIFF
--- a/elksemu/elks_sys.c
+++ b/elksemu/elks_sys.c
@@ -151,7 +151,7 @@ elks_open(int bx, int cx, int dx, int di, int si)
         if (fd < 0)
             return fd;
         unlink("/tmp/perror");
-        write(fd, efile, sizeof(efile));
+        int tmp = write(fd, efile, sizeof(efile));
         lseek(fd, 0L, 0);
         return fd;
     }

--- a/slattach.sh
+++ b/slattach.sh
@@ -3,7 +3,7 @@
 # run "net start slip" on ELKS after running this script as root
 #
 
-if [[ $(id -u) != 0 ]];
+if [ "$(id -un)" != "root" ];
 then
 	echo "Please run me as root."
 	exit 1


### PR DESCRIPTION
Fixing a compile warning, which is at the very end of the build cycle and thus being very visible/annoying:

make[1]: Entering directory '/home/mf/src/elks/elksemu'
cp /home/mf/src/elks/cross/share/misc/elks/call_tab.v call_tab.v
cp /home/mf/src/elks/cross/share/misc/elks/defn_tab.v defn_tab.v
cc -O  -DUSE_PTRACE=1   -c -o elks_sys.o elks_sys.c
elks_sys.c: In function ‘elks_open’:
elks_sys.c:154:9: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  154 |         write(fd, efile, sizeof(efile));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc -O  -DUSE_PTRACE=1 -o elksemu elks.o elks_sys.o elks_signal.o elks_pid.o minix.o
make[1]: Leaving directory '/home/mf/src/elks/elksemu'