### PR TITLE
[kernel] Fix not reparenting children to init task on exit bug

### DIFF
--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -34,8 +34,8 @@ static void FARPROC reparent_children(void)
                     p->tty->pgrp = 0;
                 p->session = p->pgrp = p->pid;
 
-                p->p_parent = &task[1];
-                p->ppid = task[1].pid;
+                p->p_parent = &task[0];
+                p->ppid = task[0].pid;
             }
         }
     }


### PR DESCRIPTION
Fixes the somewhat major bug of child processes being reparented to the wrong parent (i.e. not the init task) on exit. This was introduced in PR #2531 and found by @Mellvik, discussed in https://github.com/ghaerr/elks/commit/6d00d176c7d83a426ae24b772731e79f95420cd7#commitcomment-182274340.

While not always problematic, the PPID (parent PID) of the child process will appear incorrectly in `ps -l`, and execution by the child of a `wait` system call (or `getppid`) will not work properly.