### PR TITLE
[kernel] Add BH interrupt check after syscall

### DIFF
--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -164,7 +164,11 @@ save_regs:
         // strace.c must be compiled with tail optimization off to protect top of stack
         call    trace_end       // syscall return value is top of stack
 #endif
-        call    do_signal       // process signals
+
+        cmpw    $0,bh_active    // Any active bottom halfs?
+        je      1f              // No
+        call    do_bottom_half  // Run bottom halves
+1:      call    do_signal       // process signals
         cli
         jmp     restore_regs
 //


### PR DESCRIPTION
Discussed with @Mellvik in https://github.com/Mellvik/TLVC/pull/238#issuecomment-4194986284 as a result of rewriting the NIC drivers for the new BH architecture, this PR adds a check for any requested bottom half executions occurring during a system call and schedules them immediately after the syscall, before returning to user mode. 

This increases networking send speed significantly, since ktcp's `write` system call of the ethernet packet then gets operated on by the NIC driver directly after the system call.