### PR TITLE
Fix error to enable set_a20 and reset_a20 when USE_HIMEM_AT is configured

### DIFF
--- a/elks/arch/i86/lib/a20-ibm.inc
+++ b/elks/arch/i86/lib/a20-ibm.inc
@@ -128,7 +128,7 @@ empty_8042:
 set_a20:
 	pushf			# save interrupt status
 	cli			# interrupts off
-	xor	%ah,%ah
+	or	%ah,%ah
 	jz	reset_a20
 
 	call	sync_8042


### PR DESCRIPTION
With `xor %ah, %ah` only reset_a20 can be selected.