### PR TITLE
[ekermit] Add gitignore

### DIFF
--- a/elkscmd/ekermit/.gitignore
+++ b/elkscmd/ekermit/.gitignore
@@ -1,0 +1,2 @@
+ekermit
+hostek


### PR DESCRIPTION
This PR adds missing `.gitignore` for ekermit binaries.