### PR TITLE
[build] Fix buildimages.sh to build IBM PC nano-X for IBM PC images

### DIFF
--- a/buildimages.sh
+++ b/buildimages.sh
@@ -137,6 +137,7 @@ build_ibm_fast
 build_pc98
 build_pc98_1200
 build_pc98_1440
+build_ibm_fast
 ./buildext.sh microwindows
 build_rom_8018x
 build_rom_necv25


### PR DESCRIPTION
The ELKS v0.9.0 release has a major error where the PC/98 version of Nano-X is placed on the IBM PC images. 

When nano-X is started, the system crashes, due to Nano-X's direct access to the PC/98 graphics adapter which is nonexistent on the IBM PC.

Unfortunately, this will require rebuilding all images and a release of ELKS v0.9.1, coming shortly.

Fixes #2651.

