### PR TITLE
[kernel] Fix sys_wait4 not returning -ECHILD immediately in certain cases

### DIFF
--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -45,9 +45,25 @@ static void FARPROC reparent_children(void)
 int sys_wait4(pid_t pid, int *status, int options, void *usage)
 {
     register struct task_struct *p;
-    int waitagain;
+    int waitagain, has_child;
 
     debug_wait("WAIT(%P) for %d opts %x\n", pid, options);
+
+    /*
+     * If a specific pid is requested, verify it is actually our child first,
+     * otherwise return -ECHILD immediately.
+     */
+    if ((int)pid > 0) {
+        has_child = 0;
+        for_each_task(p) {
+            if (p->p_parent == current && p->state != TASK_UNUSED && p->pid == pid) {
+                has_child = 1;
+                break;
+            }
+        }
+        if (!has_child)
+            return -ECHILD;
+    }
 
  for (;;) {
     waitagain = 0;
@@ -79,17 +95,17 @@ int sys_wait4(pid_t pid, int *status, int options, void *usage)
                 return p->pid;
             }
         } else {
-            /* keep waiting while process has non-zombie children*/
+            /* keep waiting while process has running/exiting children */
             debug_wait("WAIT(%P) again for pid %d state %d\n", p->pid, p->state);
             waitagain = 1;
         }
       }
     }
 
-    if (options & WNOHANG)
-        return 0;
     if (!waitagain)
         break;
+    if (options & WNOHANG)
+        return 0;
 
     debug_wait("WAIT(%P) sleep\n");
     interruptible_sleep_on(&current->child_wait);

--- a/elkscmd/test/syscall/wait_nochild.c
+++ b/elkscmd/test/syscall/wait_nochild.c
@@ -1,0 +1,147 @@
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static volatile int got_alarm;
+
+static void alarm_handler(int sig)
+{
+    (void)sig;
+    signal(SIGALRM, alarm_handler);
+    got_alarm = 1;
+}
+
+static int expect_echild_wnohang(pid_t pid, const char *label)
+{
+    int status = 0;
+    int rc;
+    int saved_errno;
+
+    errno = 0;
+    rc = waitpid(pid, &status, WNOHANG);
+    saved_errno = errno;
+
+    if (rc == -1 && saved_errno == ECHILD) {
+        printf("PASS: %s -> -1/ECHILD\n", label);
+        return 0;
+    }
+
+    printf("FAIL: %s -> rc=%d errno=%d status=0x%04x (expected -1/ECHILD)\n",
+        label, rc, saved_errno, status);
+    return 1;
+}
+
+static int cleanup_child(int child, int write_fd)
+{
+    int status;
+    int rc;
+
+    close(write_fd);
+    errno = 0;
+    rc = waitpid(child, &status, 0);
+    if (rc != child) {
+        printf("FAIL: cleanup waitpid(child=%d) -> rc=%d errno=%d status=0x%04x\n",
+            child, rc, errno, status);
+        return 1;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        printf("FAIL: cleanup child exited abnormally status=0x%04x\n", status);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int expect_echild_blocking_with_live_nonmatching_child(void)
+{
+    int pipefd[2];
+    int child;
+    pid_t nonmatch;
+    int status = 0;
+    int rc;
+    int saved_errno;
+    int fails = 0;
+    char ch;
+
+    if (pipe(pipefd) < 0) {
+        perror("pipe");
+        return 1;
+    }
+
+    child = fork();
+    if (child < 0) {
+        perror("fork");
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return 1;
+    }
+
+    if (child == 0) {
+        signal(SIGALRM, SIG_DFL);
+        close(pipefd[1]);
+        while (read(pipefd[0], &ch, 1) < 0) {
+            if (errno != EINTR)
+                _exit(2);
+        }
+        close(pipefd[0]);
+        _exit(0);
+    }
+
+    close(pipefd[0]);
+
+    nonmatch = child + 1;
+    if (nonmatch <= 0)
+        nonmatch = child + 2;
+
+    got_alarm = 0;
+    signal(SIGALRM, alarm_handler);
+    errno = 0;
+    alarm(2);
+    rc = waitpid(nonmatch, &status, 0);
+    saved_errno = errno;
+    alarm(0);
+
+    if (rc == -1 && saved_errno == ECHILD && !got_alarm) {
+        printf("PASS: waitpid(non-child-pid=%d, ..., 0) with live child %d -> -1/ECHILD immediately\n",
+            nonmatch, child);
+    } else if (rc == -1 && saved_errno == EINTR && got_alarm) {
+        printf("FAIL: waitpid(non-child-pid=%d, ..., 0) with live child %d slept until SIGALRM\n",
+            nonmatch, child);
+        fails++;
+    } else {
+        printf("FAIL: waitpid(non-child-pid=%d, ..., 0) with live child %d -> rc=%d errno=%d status=0x%04x alarm=%d\n",
+            nonmatch, child, rc, saved_errno, status, (int)got_alarm);
+        fails++;
+    }
+
+    fails += cleanup_child(child, pipefd[1]);
+    return fails;
+}
+
+int main(void)
+{
+    int fails = 0;
+    pid_t impossible_pid = 32767;
+
+    printf("[wait-nochild] starting\n");
+
+    fails += expect_echild_wnohang((pid_t)-1,
+        "waitpid(-1, ..., WNOHANG) with no children");
+    fails += expect_echild_wnohang(impossible_pid,
+        "waitpid(non-child-pid, ..., WNOHANG) with no children");
+    fails += expect_echild_blocking_with_live_nonmatching_child();
+
+    if (fails) {
+        printf("[wait-nochild] FAIL (%d subtest%s failed)\n",
+            fails, fails == 1 ? "" : "s");
+        return 1;
+    }
+
+    printf("[wait-nochild] PASS\n");
+    return 0;
+}

--- a/elkscmd/test/syscall/wait_nohang.c
+++ b/elkscmd/test/syscall/wait_nohang.c
@@ -1,0 +1,22 @@
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <stdio.h>
+
+int main(void)
+{
+    int st = 0;
+    int r;
+
+    errno = 0;
+    r = waitpid(-1, &st, WNOHANG);
+
+    if (r == 0)
+        printf("BUG: returned 0 with no children\n");
+    else if (r == -1 && errno == ECHILD)
+        printf("OK: returned ECHILD with no children\n");
+    else
+        printf("Unexpected: r=%d errno=%d\n", r, errno);
+
+    return 0;
+}


### PR DESCRIPTION
Since it was recently found that the IBM PC ELKS v0.9.0 images contain the wrong binary for Nano-X, a version increment to v0.9.1 will have to be made soon and new images produced. Since another wait-oriented kernel reparenting bug was also fixed recently in #2639, I thought to include a few other important kernel fixes recently found by @Vutshi's exploration into AI tools.

This PR fixes the `wait4` syscall issue found by @Vutshi's ChatGPT Plus and Claude kernel audit in #2646. The primary issue was that `wait4` would wait rather than return -ECHILD when a process ID passed that was not a child of the calling process. 

This fix includes my modified code from Claude's proposed fix, as it was much less messy than that proposed by ChatGPT Plus.

Claude also pointed out another issue which is that in the case of the parent only having stopped or zombie children which do not match the passed PID, an extra sleep/wakeup cycle is performed. This inefficiency will be handled at a later time, and there is no regression test yet built for it.

The regression tests used to verify correctness, provided by ChatGPT and Claude, are also add here in elkscmd/test/syscall/. These are not yet compiled and distributed on images, but will be after more regression tests are seen. Both tests initially showed failure and now show success.



