### PR TITLE
[kernel] Fix stale mm[] segment pointers on exec and fork

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -522,8 +522,10 @@ static void FARPROC finalize_exec(struct inode *inode, segment_s *seg_code,
 
     /* From this point, the old code and data segments are not needed anymore */
     for (i = 0; i < MAX_SEGS; i++) {
-        if (currentp->mm[i])
+        if (currentp->mm[i]) {
             seg_put(currentp->mm[i]);
+            currentp->mm[i] = 0;
+        }
     }
 
 #ifdef CONFIG_EXEC_OS2

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -94,8 +94,10 @@ pid_t do_fork(int virtual)
                 } else {
                     t->mm[j] = seg_dup(s);
                     if (t->mm[j] == 0) {
-                        for (k = 0; k < j; k++)
-                            seg_put(t->mm[k]);
+                        for (k = 0; k < j; k++) {
+                            if (t->mm[k])
+                                seg_put(t->mm[k]);
+                        }
                         t->state = TASK_UNUSED;
                         task_slots_unused++;
                         next_task_slot = t;

--- a/elkscmd/test/syscall/lifecycle_exec_mm_stale_multiseg.c
+++ b/elkscmd/test/syscall/lifecycle_exec_mm_stale_multiseg.c
@@ -1,0 +1,59 @@
+/*
+ * This helper is intended to be built with OpenWatcom as an OS/2 NE binary,
+ * then converted to ELKS a.out with os2toelks.
+ *
+ * Goal: start life as a genuinely multisegment executable, then exec a normal
+ * 2-segment ELKS binary. On a buggy kernel this can leave stale mm[] entries
+ * behind in the replacement image.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __WATCOMC__
+#pragma code_seg("MSCODE1")
+static int code1(void) { return 11; }
+#pragma code_seg("MSCODE2")
+static int code2(void) { return 22; }
+#pragma code_seg()
+
+#pragma data_seg("MSDATA1")
+static char data1[1024] = { 1 };
+#pragma data_seg("MSDATA2")
+static char data2[1024] = { 2 };
+#pragma data_seg()
+#else
+static int code1(void) { return 11; }
+static int code2(void) { return 22; }
+static char data1[1024] = { 1 };
+static char data2[1024] = { 2 };
+#endif
+
+static int touch_segments(void)
+{
+    data1[0]++;
+    data2[0]++;
+    return code1() + code2() + data1[0] + data2[0];
+}
+
+int main(int argc, char **argv)
+{
+    char *av[2];
+    int v = touch_segments();
+
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s /path/to/plain-helper\n", argv[0]);
+        return 2;
+    }
+
+    /* Keep the segment-touch logic live. */
+    if (v == -1)
+        write(1, "impossible\n", 11);
+
+    av[0] = argv[1];
+    av[1] = (char *)0;
+    execv(argv[1], av);
+    perror("multiseg: execv(plain)");
+    return 111;
+}

--- a/elkscmd/test/syscall/lifecycle_exec_mm_stale_plain.c
+++ b/elkscmd/test/syscall/lifecycle_exec_mm_stale_plain.c
@@ -1,0 +1,33 @@
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define INNER_FORKS 16
+
+int main(void)
+{
+    int i;
+    int status;
+
+    for (i = 0; i < INNER_FORKS; i++) {
+        pid_t child = fork();
+        if (child < 0) {
+            perror("plain: fork");
+            return 2;
+        }
+        if (child == 0)
+            _exit(0);
+        if (waitpid(child, &status, 0) != child) {
+            perror("plain: waitpid");
+            return 2;
+        }
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            printf("plain: unexpected child status 0x%04x\n", status);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/elkscmd/test/syscall/lifecycle_exec_mm_stale_runner.c
+++ b/elkscmd/test/syscall/lifecycle_exec_mm_stale_runner.c
@@ -1,0 +1,45 @@
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define OUTER_ITERS 200
+
+int main(int argc, char **argv)
+{
+    const char *multiseg = (argc > 1)? argv[1]: "/bin/lifecycle_exec_mm_stale_multiseg";
+    const char *plain = (argc > 2)? argv[2]: "/bin/lifecycle_exec_mm_stale_plain";
+    int i;
+    int status;
+
+    printf("[exec-mm-stale] starting with multiseg='%s' plain='%s'\n", multiseg, plain);
+
+    for (i = 0; i < OUTER_ITERS; i++) {
+        pid_t child = fork();
+        if (child < 0) {
+            perror("runner: fork");
+            return 2;
+        }
+        if (child == 0) {
+            char *av[3];
+            av[0] = (char *)multiseg;
+            av[1] = (char *)plain;
+            av[2] = (char *)0;
+            execv(multiseg, av);
+            perror("runner: execv(multiseg)");
+            _exit(111);
+        }
+        if (waitpid(child, &status, 0) != child) {
+            perror("runner: waitpid");
+            return 2;
+        }
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            printf("[exec-mm-stale] FAIL at iter=%d status=0x%04x\n", i, status);
+            return 1;
+        }
+    }
+
+    printf("[exec-mm-stale] PASS (stress completed)\n");
+    return 0;
+}


### PR DESCRIPTION
Two more obvious but potentially major kernel fixes found by @Vutshi's AI kernel audit in #2646. 

Stale segment pointers not being cleared in the mm[] array when a multisegment binary exec's a single-segment binary were found by both ChatGPT Plus and Claude, while only Claude found the problem of `seg_put` being passed a NULL pointer in the case of out of memory during a fork(). 

Both bugs would be quite rare in occurrence.

Associated untested regression tests added to elkscmd/test/syscall/.