### PR TITLE
[kernel] Clear inherited pending signals in fork()

### DIFF
--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -121,6 +121,8 @@ pid_t do_fork(int virtual)
     t->fs.root->i_count++;
     t->fs.pwd->i_count++;
 
+    t->signal = 0;
+    t->timeout = 0;
     t->exit_status = 0;
 
     t->ppid = current->pid;

--- a/elkscmd/test/syscall/lifecycle_fork_pending_signal.c
+++ b/elkscmd/test/syscall/lifecycle_fork_pending_signal.c
@@ -1,0 +1,125 @@
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FORK_ITERS   250
+#define SIGNAL_ITERS 5000
+#define SIGNAL_USEC  1000UL
+#define BALLAST_SIZE 4096
+
+static int alert_pipe[2] = { -1, -1 };
+static pid_t parent_pid;
+static char ballast[BALLAST_SIZE];
+
+static void sigusr1_handler(int sig)
+{
+    pid_t me;
+
+    (void)sig;
+    signal(SIGUSR1, sigusr1_handler);     /* ELKS signal handlers are one-shot */
+
+    me = getpid();
+    if (me != parent_pid && alert_pipe[1] >= 0)
+        (void)write(alert_pipe[1], (char *)&me, sizeof(me));
+}
+
+static int waitpid_retry(pid_t pid, int *status, int options)
+{
+    int rc;
+
+    do {
+        errno = 0;
+        rc = waitpid(pid, status, options);
+    } while (rc < 0 && errno == EINTR);
+
+    return rc;
+}
+
+int main(void)
+{
+    pid_t sender;
+    int i;
+    int status;
+    int bad = 0;
+    pid_t offender;
+    int n;
+
+    printf("[fork-pending-signal] starting\n");
+
+    for (i = 0; i < BALLAST_SIZE; i++)
+        ballast[i] = (char)(i ^ 0x5a);
+
+    parent_pid = getpid();
+
+    if (pipe(alert_pipe) < 0) {
+        perror("pipe");
+        return 2;
+    }
+
+    signal(SIGUSR1, sigusr1_handler);
+
+    sender = fork();
+    if (sender < 0) {
+        perror("fork(sender)");
+        return 2;
+    }
+
+    if (sender == 0) {
+        for (i = 0; i < SIGNAL_ITERS; i++) {
+            if (kill(parent_pid, SIGUSR1) < 0)
+                break;
+            usleep(SIGNAL_USEC);
+        }
+        _exit(0);
+    }
+
+    for (i = 0; i < FORK_ITERS; i++) {
+        pid_t child = fork();
+        if (child < 0) {
+            perror("fork(worker)");
+            kill(sender, SIGKILL);
+            return 2;
+        }
+        if (child == 0)
+            _exit(0);
+
+        if (waitpid_retry(child, &status, 0) != child) {
+            perror("waitpid(worker)");
+            kill(sender, SIGKILL);
+            return 2;
+        }
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            printf("FAIL: worker child exited unexpectedly: status=0x%04x\n", status);
+            kill(sender, SIGKILL);
+            return 1;
+        }
+    }
+
+    if (waitpid_retry(sender, &status, 0) != sender) {
+        perror("waitpid(sender)");
+        return 2;
+    }
+
+    close(alert_pipe[1]);
+    alert_pipe[1] = -1;
+
+    while ((n = read(alert_pipe[0], (char *)&offender, sizeof(offender))) == sizeof(offender)) {
+        if (!bad)
+            printf("FAIL: child %d executed parent-directed SIGUSR1 handler\n", offender);
+        bad++;
+    }
+
+    if (bad) {
+        printf("[fork-pending-signal] FAIL (%d offending child event%s)\n",
+            bad, bad == 1 ? "" : "s");
+        return 1;
+    }
+
+    printf("[fork-pending-signal] PASS\n");
+    return 0;
+}

--- a/elkscmd/test/syscall/lifecycle_orphan_zombie_pid1.c
+++ b/elkscmd/test/syscall/lifecycle_orphan_zombie_pid1.c
@@ -1,0 +1,118 @@
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static volatile sig_atomic_t got_alarm;
+
+static void alarm_handler(int sig)
+{
+    (void)sig;
+    signal(SIGALRM, alarm_handler);
+    got_alarm = 1;
+}
+
+static int wait_any_with_alarm(int *status, int seconds)
+{
+    int rc;
+
+    got_alarm = 0;
+    signal(SIGALRM, alarm_handler);
+    errno = 0;
+    alarm(seconds);
+    rc = waitpid((pid_t)-1, status, 0);
+    alarm(0);
+    return rc;
+}
+
+static void finish_by_execing_shell(void)
+{
+    char *argv_sh[] = { "sh", (char *)0 };
+    char *argv_sash[] = { "sash", (char *)0 };
+
+    printf("[orphan-zombie-pid1] trying to exec a shell\n");
+    execv("/bin/sh", argv_sh);
+    execv("/bin/sash", argv_sash);
+
+    printf("[orphan-zombie-pid1] no shell found, sleeping forever\n");
+    for (;;)
+        sleep(60);
+}
+
+int main(void)
+{
+    pid_t middle;
+    pid_t r1, r2;
+    int st1 = 0, st2 = 0;
+    int saw_24 = 0, saw_42 = 0;
+
+    printf("[orphan-zombie-pid1] starting\n");
+
+    if (getpid() != 1) {
+        printf("SKIP: this test must run as pid 1 (temporary /bin/init)\n");
+        return 77;
+    }
+
+    middle = fork();
+    if (middle < 0) {
+        perror("fork(middle)");
+        return 2;
+    }
+
+    if (middle == 0) {
+        pid_t leaf = fork();
+        if (leaf < 0)
+            _exit(100);
+        if (leaf == 0)
+            _exit(42);
+
+        /* Exit without waiting: the grandchild is now an orphaned zombie case. */
+        _exit(24);
+    }
+
+    r1 = waitpid((pid_t)-1, &st1, 0);
+    if (r1 < 0) {
+        perror("waitpid(first)");
+        return 2;
+    }
+
+    if (WIFEXITED(st1)) {
+        if (WEXITSTATUS(st1) == 24)
+            saw_24 = 1;
+        if (WEXITSTATUS(st1) == 42)
+            saw_42 = 1;
+    }
+
+    errno = 0;
+    r2 = wait_any_with_alarm(&st2, 2);
+    if (r2 < 0) {
+        if (errno == ECHILD) {
+            printf("FAIL: second wait returned -ECHILD; adopted zombie was lost\n");
+            finish_by_execing_shell();
+        }
+        if (errno == EINTR && got_alarm) {
+            printf("FAIL: second wait blocked until SIGALRM; adopted zombie was not waitable\n");
+            finish_by_execing_shell();
+        }
+        perror("waitpid(second)");
+        finish_by_execing_shell();
+    }
+
+    if (WIFEXITED(st2)) {
+        if (WEXITSTATUS(st2) == 24)
+            saw_24 = 1;
+        if (WEXITSTATUS(st2) == 42)
+            saw_42 = 1;
+    }
+
+    if (saw_24 && saw_42)
+        printf("[orphan-zombie-pid1] PASS\n");
+    else
+        printf("[orphan-zombie-pid1] FAIL: statuses seen were 0x%04x and 0x%04x\n", st1, st2);
+
+    finish_by_execing_shell();
+    return 0;
+}


### PR DESCRIPTION
Fixes another somewhat serious kernel bug from the AI kernel audit #2646. 

Previously, process children would inherit any pending signals from their parent during fork(). Kernel timeouts are also cleared in the new process, as suggested by ChatGPT as a good measure.
