### PR TITLE
[kernel] Improve sys_signal signal number validation - reject 0

### DIFF
--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -134,7 +134,7 @@ int sys_signal(int signr, __kern_sighandler_t handler)
 
     debug_sig("SIGNAL(%P) sys_signal %2d action %x:%x\n", signr,
         _FP_SEG(handler), _FP_OFF(handler));
-    if (((unsigned int)signr > NSIG) || signr == SIGKILL || signr == SIGSTOP)
+    if (((unsigned int)(signr - 1) > (NSIG - 1)) || signr == SIGKILL || signr == SIGSTOP)
         return -EINVAL;
     if (handler == KERN_SIG_DFL)
         current->sig.action[signr - 1].sa_dispose = SIGDISP_DFL;


### PR DESCRIPTION
Rejects signal 0. While seemingly not a big deal, accepting such corrupts task data, referencing task->sig.action[-1].

Found by ChatGPT in #2646.