### PR TITLE
[kernel] Don't dereference sp->tty in serial_bh for nonexistent serial ports

### DIFF
--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -294,7 +294,7 @@ void serial_bh(void)
     struct serial_info *sp;
 
     for (sp = ports; sp < &ports[NR_SERIAL]; sp++) {
-        if (sp->tty->usecount)
+        if (sp->tty && sp->tty->usecount)
             pump_port(sp);
     }
 }


### PR DESCRIPTION
Another possible NULL pointer dereference found by ChatGPT in #2646.