### PR TITLE
[kernel] Fix AF_UNIX kernel overwrite from sun_path[sockaddr_len]

### DIFF
--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -146,16 +146,19 @@ static int unix_bind(struct socket *sock, struct sockaddr *umyaddr, int sockaddr
 {
     struct unix_proto_data *upd = sock->data;
     unsigned short old_ds;
-    int i;
-
-    if (sockaddr_len <= 0 || sockaddr_len > sizeof(struct sockaddr_un))
-	return -EINVAL;
+    int i, path_len;
 
     if (upd->sockaddr_len || upd->inode)
 	return -EINVAL;		/* already bound */
 
+    if (sockaddr_len <= offsetof(struct sockaddr_un, sun_path) ||
+        sockaddr_len > offsetof(struct sockaddr_un, sun_path) + UNIX_PATH_MAX - 1)
+            return -EINVAL;
+    path_len = sockaddr_len - offsetof(struct sockaddr_un, sun_path);
+    memset(&upd->sockaddr_un, 0, sizeof(upd->sockaddr_un));
+
     memcpy_fromfs(&upd->sockaddr_un, umyaddr, sockaddr_len);
-    upd->sockaddr_un.sun_path[sockaddr_len] = '\0';
+    upd->sockaddr_un.sun_path[path_len] = '\0';
 
     if (upd->sockaddr_un.sun_family != AF_UNIX)
 	return -EINVAL;
@@ -186,14 +189,11 @@ static int unix_bind(struct socket *sock, struct sockaddr *umyaddr, int sockaddr
 static int
 unix_connect(struct socket *sock, struct sockaddr *uservaddr, int sockaddr_len, int flags)
 {
-    struct sockaddr_un sockun;
     struct unix_proto_data *serv_upd;
     struct inode *inode;
     unsigned short old_ds;
-    int i;
-
-    if (sockaddr_len <= 0 || sockaddr_len > sizeof(struct sockaddr_un))
-	return -EINVAL;
+    int i, path_len;
+    struct sockaddr_un sockun;
 
     if (sock->state == SS_CONNECTING)
 	return -EINPROGRESS;
@@ -201,11 +201,17 @@ unix_connect(struct socket *sock, struct sockaddr *uservaddr, int sockaddr_len, 
 /*    if (sock->state == SS_CONNECTED)
 	return -EISCONN;*/	/*Already checked in socket.c*/
 
-    if (get_user(&(((struct sockaddr_un *)uservaddr)->sun_family)) != AF_UNIX)
-	return -EINVAL;
+    if (sockaddr_len <= offsetof(struct sockaddr_un, sun_path) ||
+        sockaddr_len > offsetof(struct sockaddr_un, sun_path) + UNIX_PATH_MAX - 1)
+            return -EINVAL;
+    path_len = sockaddr_len - offsetof(struct sockaddr_un, sun_path);
+    memset(&sockun, 0, sizeof(sockun));
 
     memcpy_fromfs(&sockun, uservaddr, sockaddr_len);
-    sockun.sun_path[sockaddr_len] = '\0';
+    sockun.sun_path[path_len] = '\0';
+
+    if (get_user(&(((struct sockaddr_un *)uservaddr)->sun_family)) != AF_UNIX)
+	return -EINVAL;
 
 /*
  * Try to open the name in the filesystem - this is how we identify ourselves

--- a/elkscmd/test/syscall/10_connect_unix_short_len.c
+++ b/elkscmd/test/syscall/10_connect_unix_short_len.c
@@ -1,0 +1,28 @@
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include "common.h"
+
+int main(void)
+{
+    struct {
+        unsigned char b[2];
+    } tiny;
+    int s;
+    int rc;
+
+    tiny.b[0] = AF_UNIX;
+    tiny.b[1] = 0;
+
+    s = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (s < 0)
+        return skip_rc("connect_unix_short_len", "AF_UNIX unavailable");
+
+    errno = 0;
+    rc = connect(s, (struct sockaddr *)&tiny, 1);
+    close(s);
+
+    return expect_errno_eq("connect_unix_short_len", rc, EINVAL);
+}

--- a/elkscmd/test/syscall/11_connect_inet_short_len.c
+++ b/elkscmd/test/syscall/11_connect_inet_short_len.c
@@ -1,0 +1,28 @@
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include "common.h"
+
+int main(void)
+{
+    struct {
+        unsigned char b[2];
+    } tiny;
+    int s;
+    int rc;
+
+    tiny.b[0] = AF_INET;
+    tiny.b[1] = 0;
+
+    s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s < 0)
+        return skip_rc("connect_inet_short_len", "AF_INET unavailable");
+
+    errno = 0;
+    rc = connect(s, (struct sockaddr *)&tiny, 1);
+    close(s);
+
+    return expect_errno_eq("connect_inet_short_len", rc, EINVAL);
+}

--- a/elkscmd/test/syscall/12_bind_unix_full_len.c
+++ b/elkscmd/test/syscall/12_bind_unix_full_len.c
@@ -1,0 +1,31 @@
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include "common.h"
+
+int main(void)
+{
+    struct sockaddr_un sun;
+    int s;
+    int rc;
+
+    memset(&sun, 'A', sizeof(sun));
+    sun.sun_family = AF_UNIX;
+
+    s = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (s < 0)
+        return skip_rc("bind_unix_full_len", "AF_UNIX unavailable");
+
+    errno = 0;
+    rc = bind(s, (struct sockaddr *)&sun, sizeof(sun));
+    close(s);
+
+    /*
+     * Under the minimal hardening patch, this should be rejected because
+     * there is no room for a kernel-added terminator. If your fix chooses
+     * a different API policy, adjust this expected result accordingly.
+     */
+    return expect_errno_eq("bind_unix_full_len", rc, EINVAL);
+}

--- a/elkscmd/test/syscall/README.txt
+++ b/elkscmd/test/syscall/README.txt
@@ -1,0 +1,39 @@
+ELKS user-access regression tests
+=================================
+
+These tests target the confirmed Step 1 user/kernel memory-boundary bugs.
+Run them one by one on an instrumented or disposable kernel: several of the
+buggy-kernel behaviors involve out-of-range reads/writes and may crash,
+hang, or corrupt user/kernel memory.
+
+Expected result on a fixed kernel
+---------------------------------
+Each test should print PASS and exit 0.
+SKIP means the environment does not expose the needed device or protocol.
+
+Important
+---------
+12_bind_unix_full_len.c matches the minimal AF_UNIX hardening policy from the
+patch-oriented report: reject a full-size sockaddr_un that leaves no room for
+an added terminator. If you implement a different but still-correct fix, update
+that test's expected result while keeping the core invariant: no kernel memory
+overwrite and no unsafe handling of unterminated sun_path.
+
+
+Host-side helper
+----------------
+`run-regress.sh` is a small wrapper for the extracted regression tree.
+
+Typical flow:
+1. On the host: `./run-regress.sh build`
+2. Copy the resulting binaries into an ELKS test filesystem, or use
+   `./run-regress.sh stage /path/to/staging/dir`
+3. Inside ELKS: run each test, or invoke the script again as
+   `./run-regress.sh run` if the script is present there too.
+
+If auto-detection fails, set:
+- `ELKS_SRC=/path/to/elks`
+- `LIBC_SRC=/path/to/libc`
+
+The script uses the ELKS source trees for headers and expects an
+ELKS-capable `ia16-elf-gcc` toolchain with libc installed in its sysroot.

--- a/elkscmd/test/syscall/run-regress.sh
+++ b/elkscmd/test/syscall/run-regress.sh
@@ -1,0 +1,192 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ACTION=${1:-build}
+if [ $# -gt 0 ]; then
+    shift
+fi
+
+PROGS="
+01_verify_area_wrap_read
+02_lseek_bad_ptr
+03_utime_bad_times
+04_ioctl_fionbio_bad_arg
+05_tiosetconsole_bad_arg
+06_kmem_getusage_bad_arg
+07_sysctl_bad_name
+08_symlink_bad_oldname
+09_chdir_bad_path
+10_connect_unix_short_len
+11_connect_inet_short_len
+12_bind_unix_full_len
+"
+
+usage() {
+    cat <<USAGE
+Usage:
+  $(basename "$0") [build|stage|run|clean|list|help] [args]
+
+Modes:
+  build            Cross-build all regression tests for ELKS (default)
+  stage DIR        Build and copy binaries plus README into DIR
+  run              Run already-built tests in the current ELKS userspace
+  clean            Remove built artifacts
+  list             Print test program names
+  help             Show this help
+
+Environment:
+  ELKS_SRC         Path to ELKS kernel source tree (auto-detected if possible)
+  LIBC_SRC         Path to ELKS libc source tree (auto-detected if possible)
+  CC               Cross-compiler (default: ia16-elf-gcc)
+  STRIP            Binary stripper (default: ia16-elf-strip if available)
+  EXTRA_CFLAGS     Extra compiler flags
+  EXTRA_LDFLAGS    Extra linker flags
+  DESTDIR          Optional alias for stage destination
+
+Notes:
+  - build/stage use the ELKS source trees for header selection, but rely on an
+    ELKS-capable ia16 toolchain and libc being installed in the compiler sysroot.
+  - run is intended to execute inside ELKS after the binaries have been copied
+    into a test filesystem or image.
+USAGE
+}
+
+autodetect_tree() {
+    name=$1
+    envvar=$2
+    eval current='${'$envvar':-}'
+    if [ -n "$current" ] && [ -d "$current" ]; then
+        printf '%s\n' "$current"
+        return 0
+    fi
+    for d in \
+        "$SCRIPT_DIR/../$name" \
+        "$SCRIPT_DIR/../../$name" \
+        "$PWD/$name" \
+        "$PWD/../$name"
+    do
+        if [ -d "$d" ]; then
+            printf '%s\n' "$d"
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_elks_runtime() {
+    if [ -f /bin/elks ]; then
+        return 0
+    fi
+    if uname -s 2>/dev/null | grep -qi '^elks$'; then
+        return 0
+    fi
+    return 1
+}
+
+build_tests() {
+    CC=${CC:-ia16-elf-gcc}
+    STRIP=${STRIP:-ia16-elf-strip}
+
+    ELKS_SRC=$(autodetect_tree elks ELKS_SRC || true)
+    LIBC_SRC=$(autodetect_tree libc LIBC_SRC || true)
+
+    if [ -z "${ELKS_SRC:-}" ] || [ -z "${LIBC_SRC:-}" ]; then
+        echo "error: could not auto-detect ELKS_SRC and LIBC_SRC" >&2
+        echo "set ELKS_SRC=/path/to/elks and LIBC_SRC=/path/to/libc" >&2
+        exit 2
+    fi
+
+    if ! command -v "$CC" >/dev/null 2>&1; then
+        echo "error: compiler '$CC' not found" >&2
+        exit 2
+    fi
+
+    BASE_CFLAGS='-ffreestanding -fno-inline -melks -mtune=i8086 -mcmodel=small -mno-segment-relocation-stuff -Wall -Wextra -Wtype-limits -Wno-unused-parameter -Wno-sign-compare -Os'
+    INCLUDES="-I$SCRIPT_DIR -I$LIBC_SRC/include -I$ELKS_SRC/include"
+    CFLAGS="${CFLAGS:-} $BASE_CFLAGS $INCLUDES ${EXTRA_CFLAGS:-}"
+    LDFLAGS="${LDFLAGS:-} ${EXTRA_LDFLAGS:-}"
+
+    echo "== building ELKS regression tests =="
+    echo "   ELKS_SRC=$ELKS_SRC"
+    echo "   LIBC_SRC=$LIBC_SRC"
+    echo "   CC=$CC"
+    make -C "$SCRIPT_DIR" clean >/dev/null
+    make -C "$SCRIPT_DIR" CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
+
+    if command -v "$STRIP" >/dev/null 2>&1; then
+        for t in $PROGS; do
+            [ -f "$SCRIPT_DIR/$t" ] && "$STRIP" "$SCRIPT_DIR/$t" || true
+        done
+    fi
+}
+
+stage_tests() {
+    dest=${1:-${DESTDIR:-}}
+    if [ -z "$dest" ]; then
+        echo "error: stage requires a destination directory" >&2
+        exit 2
+    fi
+    build_tests
+    mkdir -p "$dest"
+    for t in $PROGS; do
+        cp "$SCRIPT_DIR/$t" "$dest/"
+    done
+    cp "$SCRIPT_DIR/README.txt" "$dest/"
+    echo "staged test binaries in $dest"
+}
+
+run_tests() {
+    if ! is_elks_runtime; then
+        echo "error: run mode is intended to execute inside ELKS" >&2
+        echo "build on the host, copy the binaries into the ELKS filesystem, then re-run there" >&2
+        exit 2
+    fi
+    missing=0
+    for t in $PROGS; do
+        if [ ! -x "$SCRIPT_DIR/$t" ]; then
+            echo "missing binary: $SCRIPT_DIR/$t" >&2
+            missing=1
+        fi
+    done
+    if [ "$missing" -ne 0 ]; then
+        echo "error: build or copy the binaries first" >&2
+        exit 2
+    fi
+
+    rc=0
+    for t in $PROGS; do
+        echo "== $t =="
+        "$SCRIPT_DIR/$t" || rc=$?
+        echo
+    done
+    exit "$rc"
+}
+
+case "$ACTION" in
+    build)
+        build_tests
+        ;;
+    stage)
+        stage_tests "$@"
+        ;;
+    run)
+        run_tests
+        ;;
+    clean)
+        make -C "$SCRIPT_DIR" clean
+        ;;
+    list)
+        for t in $PROGS; do
+            echo "$t"
+        done
+        ;;
+    help|-h|--help)
+        usage
+        ;;
+    *)
+        echo "error: unknown mode '$ACTION'" >&2
+        usage >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
Fixes an internal socket structure overwrite when passing an AF_UNIX sockaddr_un struct with length > 20. Found by ChatGTP in #2646.

@Vutshi, thank you for running the AI kernel audit. I wrestled with this particular problem a couple times thinking I had finally fixed it, but never realized the big problem was that the passed sockaddr_len was indexing a non-zero offset of sun_path within the sockaddr_un struct. This should finally fix the memory corruption errors I had been seeing but didn't actually finally fix.

The ChatGPT proposed fix also includes a bit more argument validation as well.

Tested by running Nano-X, which uses UNIX named pipes, which exercises this code. To keep the task structure small, the max string length of named pipes (UNIX_PATH_MAX) remains at 20 including NUL (e.g. /tmp/nxsock), but is now more firmly checked and corruption potential removed.

Currently unused regression tests included in elkscmd/test/syscall/.

Thank you!