### PR TITLE
[kernel] Cancel alarm timer on process exit

### DIFF
--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -36,4 +36,8 @@ void spin_timer(int);
 void enable_timer_tick(void);
 void disable_timer_tick(void);
 
+/* sys2.c */
+struct timer_list *find_alarm(struct task_struct *t);
+void cancel_alarm(struct timer_list *ap);
+
 #endif

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -5,6 +5,7 @@
  */
 
 #include <linuxmt/sched.h>
+#include <linuxmt/timer.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/init.h>
@@ -134,6 +135,7 @@ void do_exit(int status)
 
     /* Let go of the process */
     current->state = TASK_EXITING;
+    cancel_alarm(find_alarm(current));
     for (i = 0; i < MAX_SEGS; i++) {
         if (current->mm[i])
             seg_put(current->mm[i]);

--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -24,7 +24,7 @@ static void alarm_callback(int data)
     send_sig(SIGALRM, p, 1);
 }
 
-static struct timer_list *find_alarm(struct task_struct *t)
+struct timer_list *find_alarm(struct task_struct *t)
 {
     struct timer_list *ap;
 
@@ -35,17 +35,22 @@ static struct timer_list *find_alarm(struct task_struct *t)
     return NULL;
 }
 
+void cancel_alarm(struct timer_list *ap)
+{
+    if (ap) {
+        del_timer(ap);
+        ap->tl_data = 0;
+    }
+}
+
 static int setalarm(unsigned long jiffs)
 {
     struct timer_list *ap;
 
     ap = find_alarm(current);
     if (jiffs == 0) {
-        if (ap) {
-            del_timer(ap);
-            ap->tl_data = 0;
-            return 0;
-        }
+        cancel_alarm(ap);
+        return 0;
     } else {
         if (!ap && !(ap = find_alarm(NULL))) {
             printk("No more alarms\n");


### PR DESCRIPTION
Previously, process exit did not clear any active alarm() timer, which could cause the same alarm to incorrectly fire for a subsequent process using the same task slot.

Found by AI in #2646.