### PR TITLE
[kernel] Fix off-by-one error in RAM disk segment offset

### DIFF
--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -23,6 +23,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/debug.h>
+//#define debug(...)      printk(__VA_ARGS__)
 
 #define MAJOR_NR    RAM_MAJOR
 #include "blk.h"
@@ -147,7 +148,7 @@ static int rd_ioctl(register struct inode *inode, struct file *file,
     if (!suser())
 	return -EPERM;
 
-    debug("RD: ioctl %d %s\n", target, (cmd ? "kill" : "make"));
+    debug("RD: ioctl %d\n", cmd);
     switch (cmd) {
     case RDCREATE:
 	if (rd_info[target].valid)
@@ -253,10 +254,11 @@ static void do_rd_request(void)
             /* find appropriate memory segment and sector offset*/
             offset = start;
             index = rd_info[target].start;
-            debug("index %d, ", index);
-            while (offset > rd_segment[index].sectors) {
+            debug("off/ind/sec %u/%u/%u\n", offset, index, rd_segment[index].sectors);
+            while (offset >= rd_segment[index].sectors) {
                 offset -= rd_segment[index].sectors;
                 index = rd_segment[index].next;
+                debug("off/ind/sec %u/%u/%u\n", offset, index, rd_segment[index].sectors);
             }
             debug("entry %d, seg %x, offset %d\n", index, rd_segment[index].seg, offset);
 


### PR DESCRIPTION
Found by AI in #2646.

It took a while for me to understand why the RAM disk previously worked even with the off-by-one error (despite previous data integrity testing), but found that due to the particular modulo arithmetic and the MINIX filesystem involved, the 128th sector got swapped with the 0th sector and all subsequent sectors slid up by one, so no data errors occurred.

Verified by adding a few new debug statements and running the following script, which copied 124k of data to use multiple segments:
```
ramdisk /dev/rd0 make 132
mkfs /dev/rd0 132
mount -t minix /dev/rd0 /mnt
cp /bin/memopad /mnt
cmp /bin/memopad /mnt/memopad
```