### PR TITLE
[kernel] Fix race condition between mulitple mark_bh() and bottom half execution

### DIFF
--- a/elks/arch/i86/kernel/softirq.c
+++ b/elks/arch/i86/kernel/softirq.c
@@ -52,7 +52,9 @@ void do_bottom_half(void)
     active = bh_active;
     for (mask = 1, left = ~0; left & active; bh++, mask <<= 1, left <<= 1) {
         if (mask & active) {
-            bh_active &= ~mask;
+            clr_irq();
+            bh_active &= ~mask; /* bh_active is modified by mark_bh() at interrupt time*/
+            set_irq();
             if (*bh)
                 (*bh)();
         }

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -49,9 +49,14 @@ enum {
 };
 extern unsigned int bh_active;
 extern void (*bh_base[MAX_SOFTIRQ])(void);
-#define init_bh(nr, routine)    { bh_base[nr] = routine; }
-#define mark_bh(nr)             { bh_active |= 1 << (nr);  }
 void do_bottom_half(void);
+#define init_bh(nr, routine)    { bh_base[nr] = routine; }
+#define mark_bh(nr)             \
+    {                           \
+        clr_irq();              \
+        bh_active |= 1 << (nr); \
+        set_irq();              \
+    }
 
 #endif /* __ASSEMBLER__ */
 #endif /* __KERNEL__ */


### PR DESCRIPTION
Fixes possible bottom half execution not being scheduled due to cases of either other interrupts occurring during execution of mark_bh() within an interrupt handler, as well as an the bottom half scheduler being interrupted by an interrupt calling mark_bh(). Both cases would be quite rare but could happen.

Identified by AI in #2646.
