### PR TITLE
[kernel] Various minor kernel bug fixes found by AI

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -57,8 +57,8 @@ include $(TOPDIR)/Make.defs
 
 VERSION     = 0	# (0-255)
 PATCHLEVEL  = 9	# (0-255)
-SUBLEVEL    = 0	# (0-255)
-PRE         =
+SUBLEVEL    = 1	# (0-255)
+PRE         = pre
 
 #########################################################################
 # Specify the architecture we will use.

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -77,14 +77,13 @@ int pty_select (struct inode *inode, struct file *file, int sel_type)
 /* /dev/ptyp0 master read (from slave /dev/ttyp0 outq to telnetd) */
 size_t pty_read (struct inode *inode, struct file *file, char *data, size_t len)
 {
+	struct tty *tty = determine_tty (inode->i_rdev); /* get slave TTY*/
 	size_t count = 0;
 	int err;
 
-	struct tty *tty = determine_tty (inode->i_rdev); /* get slave TTY*/
-	if (tty == NULL) return -EBADF;
-
-	/* return EOF on master closed*/
-	if (!tty->usecount)
+	if (tty == NULL)
+		return -EBADF;
+	if (!tty->usecount)	/* return EOF on master closed*/
 		return 0;
 
 	while (count < len) {
@@ -106,11 +105,14 @@ size_t pty_read (struct inode *inode, struct file *file, char *data, size_t len)
 /* /dev/ptyp0 master write (from telnetd to slave /dev/ttyp0 inq) */
 size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len)
 {
+	struct tty *tty = determine_tty (inode->i_rdev); /* get slave TTY*/
 	size_t count = 0;
 	int ret;
 
-	struct tty *tty = determine_tty (inode->i_rdev); /* get slave TTY*/
-	if (tty == NULL) return -EBADF;
+	if (tty == NULL)
+		return -EBADF;
+	if (!tty->usecount)
+		return -EIO;
 
 	while (count < len) {
 		ret = chq_wait_wr (&tty->inq, (file->f_flags & O_NONBLOCK) | count);

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -104,11 +104,16 @@ void arch_setup_user_stack (register struct task_struct * t, word_t entry, seg_t
  * as we don't have any way of sorting out a return value yet.
  */
 
-void arch_setup_sighandler_stack(register struct task_struct *t,
+int arch_setup_sighandler_stack(register struct task_struct *t,
                                  __kern_sighandler_t addr,unsigned signr)
 {
+    segoff_t sp = t->t_regs.sp;
+
     debug("Stack %x:%x was %x %x %x %x\n", _FP_SEG(addr), _FP_OFF(addr),
            get_ustack(t,0), get_ustack(t,2), get_ustack(t,4), get_ustack(t,6));
+
+    if (sp > t->t_begstack || sp < t->t_endbrk + 6)
+        return -1;
     put_ustack(t, -6, (int)get_ustack(t,0));
     put_ustack(t, -4, _FP_OFF(addr));
     put_ustack(t, -2, _FP_SEG(addr));
@@ -118,6 +123,7 @@ void arch_setup_sighandler_stack(register struct task_struct *t,
     debug("Stack is %x %x %x %x %x %x %x\n", get_ustack(t,0), get_ustack(t,2),
            get_ustack(t,4), get_ustack(t,6), get_ustack(t,8), get_ustack(t,10),
            get_ustack(t,12));
+    return 0;
 }
 
 /*

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -71,7 +71,8 @@ top:
 	else if (*sd != SIGDISP_IGN) {			/* Set handler */
 	    debug_sig("SIGNAL(%P) calling handler %x:%x\n",
 		_FP_SEG(sah), _FP_OFF(sah));
-	    arch_setup_sighandler_stack(current, sah, signr);
+	    if (arch_setup_sighandler_stack(current, sah, signr) < 0)
+                do_exit(SIGSEGV);
 	    *sd = SIGDISP_DFL;
 	    clr_irq();		/* stop race between reset signal and return to user */
 	    current->signal &= ~mask;

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -96,7 +96,7 @@ void timer_bh(void)
 #endif
 
 #if defined(CONFIG_BLK_DEV_SSD_TEST) && defined(CONFIG_ASYNCIO)
-    if (ssd_timeout && time_after(jiffies, ssd_timeout))
+    if (ssd_timeout && time_after(jiffies(), ssd_timeout))
         ssd_io_complete();
 #endif
 

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -137,6 +137,7 @@ segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
 segment_s * seg_alloc (segext_t size, word_t type)
 {
     segment_s * seg = 0;
+
     seg = seg_free_get (size, type);
     if (seg && (type & SEG_FLAG_ALIGN1K))
         seg->base += ((~seg->base + 1) & ((1024 >> 4) - 1));
@@ -340,6 +341,8 @@ int sys_fmemalloc(int paras, unsigned short *pseg)
     err = verify_area(VERIFY_WRITE, pseg, sizeof(*pseg));
     if (err)
         return err;
+    if (paras == 0)
+        return -EINVAL;
     seg = seg_alloc((segext_t)paras, SEG_FLAG_FDAT);
     if (!seg) {
         debug_brk("(%P)FMEMALLOC %ld FAIL\n", (unsigned long)paras << 4);

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -155,7 +155,7 @@ void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 	  else {
 		/* lots of extra work on odd transfers because INT 15 block moves words only */
 		if ((count & 1) && xms_enabled == XMS_INT15) {
-			static char buf[2];
+			char buf[2];
 			size_t wc = count >> 1;
 
 			if (wc)

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -145,7 +145,7 @@ int FATPROC msdos_get_entry_long(
 			int i,i2,last;
 			int long_len = 0;
 			unsigned char c;
-			ASYNCIO_REENTRANT char longname[14];
+			ASYNCIO_REENTRANT char longname[15];
 
 			if (is_long) {
 				unsigned char sum;

--- a/elks/fs/pipe.c
+++ b/elks/fs/pipe.c
@@ -229,12 +229,13 @@ static int pipe_rdwr_open(register struct inode *inode,
     }
 
     if (filp->f_mode & FMODE_WRITE) {
+        if (!PIPE_READERS(inode) && filp->f_flags & O_NONBLOCK)
+            return -ENXIO;
         PIPE_WRITERS(inode)++;
         if (PIPE_READERS(inode) > 0) {
             if (PIPE_WRITERS(inode) < 2)
                 wake_up_interruptible(&PIPE_WAIT(inode));
         } else {
-            if (filp->f_flags & O_NONBLOCK) return -ENXIO;
             while (!PIPE_READERS(inode))
                 interruptible_sleep_on(&PIPE_WAIT(inode));
         }

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -184,6 +184,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
             break;
     }
 
+    memset(s, 0, sizeof(*s));
     s->s_dev = dev;
     s->s_flags = flags;
 

--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -240,7 +240,7 @@ struct __kern_sigaction_struct {
 #ifdef __KERNEL__
 struct task_struct;
 int send_sig(sig_t,struct task_struct *,int);
-void arch_setup_sighandler_stack(struct task_struct *, __kern_sighandler_t,unsigned);
+int arch_setup_sighandler_stack(struct task_struct *, __kern_sighandler_t, unsigned);
 int sys_kill(pid_t, sig_t);
 void do_signal(void);
 #endif /* __KERNEL__*/

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -489,7 +489,7 @@ int sock_register(int family, register struct proto_ops *ops)
 	if (*props == NULL) {
 	    *props = ops;
 	    ops->family = family;
-	    return (props - pops)/sizeof(struct proto_ops *);
+	    return props - pops;
 	}
     return -ENOMEM;
 }


### PR DESCRIPTION
This PR adds the following mostly minor fixes, found by AI in #2646:

- Disallow master PTY writing into slave input queue when closed and queue freed.
- Check enough user stack available for signal stack frame when crafting application signal callback, otherwise terminate process with SIGSEGV.
- Fix potential buf[2] overwrite in xms_fmemcpyb when XMS=int15 amidst multiple interrupts (rare or not possible).
- Fix FAT filesystem internal buffer longname[14] overwrite on 14-character long filename conversion.
- Fix pipe open w/O_NONBLOCK|O_WRONLY from leaking PIPE_WRITERS when no readers.
- Fix reused super block entries not fully cleared across mounts, possibly allowing stale fields to be reused.
- Fix return value in sock_register (never checked).
- Disallow `fmemalloc` of zero paragraphs to prevent allocator corruption.
- Version number incremented to v0.9.1pre.
