### PR TITLE
[console] VirtCon save/restore on graphics enter/exit

### DIFF
--- a/Documentation/text/Configure.help.txt
+++ b/Documentation/text/Configure.help.txt
@@ -477,15 +477,11 @@ Number of valid text consoles
 CONFIG_CONSOLES_MAX
   ELKS (like Linux) can run with multiple virtual text consoles. Unlike
   Linux, there is a definite limit on the amount of memory available to
-  implement this feature, and there is thus a need to limit the number
-  of these consoles that are made available.
-
-  This option allows the number of consoles to be made available to be
-  configured, and valid responses are in the range from 3 to 9.
-
-  Because of a historical legacy, the default is 3 consoles, as the
-  serial ports were originally mapped to conflict with virtual text
-  consoles 4 to 7.
+  implement this feature. By default text consoles are backed by video
+  RAM. For CGA cards this means you get 4 for free. For EGA/VGA you 
+  get 8. On MDA cards only 1 console fits in video RAM. If the number
+  of consoles exceeds these limits then *all* consoles use main RAM
+  buffers, each one costing 4 KB.
 
 # Block devices
 # ~~~~~~~~~~~~~

--- a/config/Configure.help
+++ b/config/Configure.help
@@ -435,15 +435,11 @@ Number of valid text consoles
 CONFIG_CONSOLES_MAX
   ELKS (like Linux) can run with multiple virtual text consoles. Unlike
   Linux, there is a definite limit on the amount of memory available to
-  implement this feature, and there is thus a need to limit the number
-  of these consoles that are made available.
-
-  This option allows the number of consoles to be made available to be
-  configured, and valid responses are in the range from 3 to 9.
-
-  Because of a historical legacy, the default is 3 consoles, as the
-  serial ports were originally mapped to conflict with virtual text
-  consoles 4 to 7.
+  implement this feature. By default text consoles are backed by video
+  RAM. For CGA cards this means you get 4 for free. For EGA/VGA you 
+  get 8. On MDA cards only 1 console fits in video RAM. If the number
+  of consoles exceeds these limits then *all* consoles use main RAM
+  buffers, each one costing 4 KB.
 
 # Block devices
 # ~~~~~~~~~~~~~

--- a/elks/arch/i86/drivers/char/config.in
+++ b/elks/arch/i86/drivers/char/config.in
@@ -19,6 +19,7 @@ mainmenu_option next_comment
 		fi
 		bool '  Scancode keyboard driver'	CONFIG_KEYBOARD_SCANCODE y
 		bool '  Dual-screen console support'    CONFIG_CONSOLE_DUAL n
+		int  '  Number of virtual consoles (1-8)' CONFIG_CONSOLES_MAX 4
 	fi
 	bool 'Serial Console'	CONFIG_CONSOLE_SERIAL		n
 	if [[ "$CONFIG_CONSOLE_DIRECT" = "y" || "$CONFIG_CONSOLE_BIOS" = "y" ]]; then

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -19,7 +19,9 @@
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
 #include <linuxmt/kd.h>
+#include <linuxmt/heap.h>
 #include <arch/io.h>
+#include <arch/segment.h>
 #include "console.h"
 #include "crtc-6845.h"
 
@@ -60,9 +62,14 @@ struct console {
     unsigned char attr;         /* current attribute */
     unsigned char XN;           /* delayed newline on column 80 */
     void (*fsm)(Console *, int);
-    unsigned int vseg;          /* vram for this console page */
-    unsigned int vseg_offset;   /* vram offset of vseg for this console page */
+    unsigned int vseg;          /* current render target: video page seg when foreground,
+                                   ram_buf_seg when backgrounded in RAM-buffer mode */
+    unsigned int vseg_offset;   /* CRTC start address (chars) for this VC's video page;
+                                   only meaningful when this VC is video-page-backed */
     unsigned short crtc_base;   /* 6845 CRTC base I/O address */
+    unsigned char *ram_buf;     /* heap_alloc'd backing buffer (RAM-buffer mode);
+                                   NULL if this VC is video-page-backed */
+    unsigned int ram_buf_seg;   /* paragraph-aligned segment alias for ram_buf */
 #ifdef CONFIG_EMUL_ANSI
     int savex, savey;           /* saved cursor position */
     unsigned char *parmptr;     /* ptr to params */
@@ -75,6 +82,12 @@ static struct wait_queue glock_wait;
 static Console *Visible[MAX_DISPLAYS];
 static Console Con[MAX_CONSOLES];
 static int NumConsoles;
+/* When non-zero, MAX_CONSOLES exceeds the number of video text pages this
+ * adapter can back natively. In that mode every VC has a RAM backing buffer;
+ * Console_set_vc() blits buffer<->video on switch instead of just flipping
+ * the CRTC start address. Single-display only; CONFIG_CONSOLE_DUAL retains
+ * pure page-flip behavior bounded by hardware page count. */
+static int g_use_rambuf;
 
 unsigned int VideoSeg = 0xb800;
 int Current_VCminor;
@@ -168,6 +181,12 @@ static void ScrollDown(Console * C, int y)
 }
 #endif
 
+/* Enable graphics-mode text page save/restore in the shared Console_ioctl().
+ * Only the IBM-PC direct driver provides the heap_alloc, kernel_ds, fmemcpyw
+ * and vseg ingredients the save/restore relies on. Other CONFIG_CONSOLE_DIRECT
+ * variants (PC-98) define a different Console struct and skip it. */
+#define VC_GRAPH_SAVE_RESTORE 1
+
 /* shared console routines*/
 #include "console.c"
 
@@ -178,11 +197,30 @@ static void ScrollDown(Console * C, int y)
 void Console_set_vc(int N)
 {
     Console *C = &Con[N];
+    Console *outgoing;
     if ((N >= NumConsoles) || glock)
         return;
 
+    outgoing = Visible[C->display];
+    if (g_use_rambuf) {
+        /* RAM-buffer mode: foreground VC writes go to VideoSeg directly;
+         * backgrounded VCs write to their ram_buf_seg. Swap on transition. */
+        if (outgoing && outgoing != C) {
+            /* save outgoing's screen into its RAM buffer, retarget its writes there */
+            fmemcpyw((void *)0, (seg_t) outgoing->ram_buf_seg,
+                     (void *)0, (seg_t) outgoing->vseg,
+                     outgoing->Width * outgoing->Height);
+            outgoing->vseg = outgoing->ram_buf_seg;
+            /* restore incoming's screen from its RAM buffer, retarget writes to video */
+            fmemcpyw((void *)0, (seg_t) VideoSeg,
+                     (void *)0, (seg_t) C->ram_buf_seg,
+                     C->Width * C->Height);
+            C->vseg = VideoSeg;
+        }
+    } else {
+        SetDisplayPage(C);
+    }
     Visible[C->display] = C;
-    SetDisplayPage(C);
     PositionCursor(C);
     DisplayCursor(&Con[Current_VCminor], 0);
     Current_VCminor = N;
@@ -199,12 +237,27 @@ struct tty_ops dircon_ops = {
 };
 
 #ifndef CONFIG_CONSOLE_DUAL
+/* Number of native text pages each adapter type can hold in its video RAM. */
+static unsigned char INITPROC pages_for_type(unsigned char t)
+{
+    switch (t) {
+    case OT_MDA: return 1;      /* 4 KB at 0xB000 holds one 80x25 page */
+    case OT_CGA: return 4;      /* 16 KB at 0xB800 holds four pages */
+    default:     return 8;      /* EGA/VGA, 32 KB holds eight pages */
+    }
+}
+
 void INITPROC console_init(void)
 {
     Console *C = &Con[0];
     int i;
+    int j;
     int Width, Height;
     unsigned int PageSizeW;
+    unsigned int bufsize;
+    unsigned int linear_off;
+    unsigned char *raw;
+    unsigned char avail_pages;
     unsigned short boot_crtc;
     unsigned char output_type = OT_EGA;
 
@@ -214,14 +267,44 @@ void INITPROC console_init(void)
     boot_crtc = peekw(0x63, 0x40);
     PageSizeW = ((unsigned int)peekw(0x4C, 0x40) >> 1);
 
-    NumConsoles = MAX_CONSOLES - 1;
     if (peekb(0x49, 0x40) == 7) {
         VideoSeg = 0xB000;
-        NumConsoles = 1;
         output_type = OT_MDA;
     } else {
         if (peekw(0xA8+2, 0x40) == 0)
             output_type = OT_CGA;
+    }
+    avail_pages = pages_for_type(output_type);
+
+    NumConsoles = MAX_CONSOLES;
+    /* Kernel built for more VCs than the adapter can back.  
+     * Alloc paragraph-aligned RAM buffers up front.
+     * Failure rolls back and clamps to avail_pages (pure video-page mode). */
+    if (NumConsoles > avail_pages) {
+        int alloc_ok = 1;
+        bufsize = Width * Height * 2;
+        for (j = 0; j < NumConsoles; j++) {
+            raw = heap_alloc(bufsize + 15, HEAP_TAG_DRVR | HEAP_TAG_CLEAR);
+            if (!raw) {
+                alloc_ok = 0;
+                break;
+            }
+            Con[j].ram_buf = raw;
+            linear_off = ((unsigned int)raw + 15) & ~0xF;
+            Con[j].ram_buf_seg = kernel_ds + (linear_off >> 4);
+        }
+        if (alloc_ok) {
+            g_use_rambuf = 1;
+        } else {
+            while (--j >= 0) {
+                heap_free(Con[j].ram_buf);
+                Con[j].ram_buf = NULL;
+                Con[j].ram_buf_seg = 0;
+            }
+            NumConsoles = avail_pages;
+            printk("console: RAM buffer alloc failed, clamping to %d VCs\n",
+                   NumConsoles);
+        }
     }
 
     Visible[0] = C;
@@ -234,8 +317,17 @@ void INITPROC console_init(void)
             C->cy = peekb(0x51, 0x40);
         }
         C->fsm = std_char;
-        C->vseg_offset = i * PageSizeW;
-        C->vseg = VideoSeg + (C->vseg_offset >> 3);
+        if (g_use_rambuf) {
+            /* Foreground VC writes go to video RAM, 
+             * backgrounded VCs to their own buffers. 
+             * SetDisplayPage() is unused in this mode -
+             * only one video page is ever displayed. */
+            C->vseg_offset = 0;
+            C->vseg = (i == 0) ? VideoSeg : C->ram_buf_seg;
+        } else {
+            C->vseg_offset = i * PageSizeW;
+            C->vseg = VideoSeg + (C->vseg_offset >> 3);
+        }
         C->attr = A_DEFAULT;
         C->type = output_type;
         C->Width = Width;
@@ -246,16 +338,20 @@ void INITPROC console_init(void)
         C->savex = C->savey = 0;
 #endif
 
-        /* Do not erase early printk() */
-        /* ClearRange(C, 0, C->cy, MaxCol, MaxRow); */
+        /* Background VCs in RAM-buffer mode start with cleared screens.
+         * The foreground VC's video memory is left alone to preserve 
+         * printk() output.  */
+        if (g_use_rambuf && i > 0)
+            ClearRange(C, 0, 0, Width - 1, Height - 1);
 
         C++;
     }
 
     kbd_init();
 
-    printk("Direct console, %s kbd %ux%u"TERM_TYPE"(%d virtual consoles)\n",
-           kbd_name, Width, Height, NumConsoles);
+    printk("Direct console, %s kbd %ux%u"TERM_TYPE"(%d virtual consoles%s)\n",
+           kbd_name, Width, Height, NumConsoles,
+           g_use_rambuf ? ", RAM-buffered" : "");
 }
 #else
 

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -318,6 +318,29 @@ static void std_char(Console * C, int c)
     }
 }
 
+#ifdef VC_GRAPH_SAVE_RESTORE
+/* Per-VC backing store for text page contents across a graphics-mode
+ * acquisition. Allocated on DCGET_GRAPH, freed on DCREL_GRAPH. The graphics
+ * app is expected to restore text mode (e.g. INT 10h AH=0 AL=3) before
+ * releasing; we then restore each saved page on top of that.
+ *
+ * In RAM-buffer mode (g_use_rambuf), only the visible VC's page lives in
+ * actual video memory; backgrounded VCs live in the kernel heap and are
+ * untouched by any video write. So one save buffer suffices.
+ *
+ * In page-flip mode, every VC's text page shares the same physical video
+ * segment (e.g. four CGA text pages at 0xB800). A graphics mode that
+ * overwrites that segment (notably CGA mode 4) destroys all of them, so
+ * we save and restore every active VC. Cost is: 
+ *
+ *   Num-VCs * Width * Height * 2 bytes  (commonly works out to 16 KB)
+ *
+ * and only for the duration of the graphics session. */
+static unsigned char *graph_save_buf[MAX_CONSOLES];
+static seg_t graph_save_seg[MAX_CONSOLES];
+static unsigned int graph_save_words;
+#endif
+
 static int Console_ioctl(struct tty *tty, int cmd, char *arg)
 {
     Console *C = &Con[tty->minor];
@@ -325,12 +348,58 @@ static int Console_ioctl(struct tty *tty, int cmd, char *arg)
     switch (cmd) {
     case DCGET_GRAPH:
         if (!glock) {
+#ifdef VC_GRAPH_SAVE_RESTORE
+            unsigned int sz = C->Width * C->Height * 2;
+            int i, n;
+            graph_save_words = sz >> 1;
+            n = g_use_rambuf ? 1 : NumConsoles;
+            for (i = 0; i < n; i++) {
+                /* In RAM-buffer mode, the only at-risk page is the one
+                 * currently displayed (Visible[]); all others live in heap. */
+                Console *V = g_use_rambuf ? Visible[C->display] : &Con[i];
+                unsigned char *raw = heap_alloc(sz + 15, HEAP_TAG_DRVR);
+                if (raw) {
+                    unsigned int al = ((unsigned int)raw + 15) & ~0xF;
+                    graph_save_buf[i] = raw;
+                    graph_save_seg[i] = kernel_ds + (al >> 4);
+                    fmemcpyw((void *)0, graph_save_seg[i],
+                             (void *)0, (seg_t) V->vseg,
+                             graph_save_words);
+                }
+                /* Per-VC alloc failure is non-fatal: that slot stays
+                 * NULL and the matching restore is skipped. The lock
+                 * still proceeds. */
+            }
+#endif
             glock = C;
             return 0;
         }
         return -EBUSY;
     case DCREL_GRAPH:
         if (glock == C) {
+#ifdef VC_GRAPH_SAVE_RESTORE
+            int i, n;
+            n = g_use_rambuf ? 1 : NumConsoles;
+            for (i = 0; i < n; i++) {
+                Console *V = g_use_rambuf ? Visible[C->display] : &Con[i];
+                if (graph_save_buf[i]) {
+                    fmemcpyw((void *)0, (seg_t) V->vseg,
+                             (void *)0, graph_save_seg[i],
+                             graph_save_words);
+                    heap_free(graph_save_buf[i]);
+                    graph_save_buf[i] = NULL;
+                    graph_save_seg[i] = 0;
+                }
+            }
+            graph_save_words = 0;
+            /* The graphics app's BIOS mode reset left CRTC at page 0. In
+             * page-flip mode that may not be the foreground VC's page;
+             * re-program the start address so the user lands on the same
+             * VC they left. RAM-buffer mode never page-flips and needs
+             * no fixup. */
+            if (!g_use_rambuf)
+                SetDisplayPage(Visible[C->display]);
+#endif
             glock = NULL;
             wake_up(&glock_wait);
             return 0;

--- a/elks/arch/i86/drivers/char/kbd-scancode.c
+++ b/elks/arch/i86/drivers/char/kbd-scancode.c
@@ -277,8 +277,9 @@ static void keyboard_irq(int irq, struct pt_regs *regs)
     /* F11 and F12 function keys need 89 byte table like keys-de.h */
     /* function keys are not posix standard here */
     
-	/* AltF1-F4 are console switch*/
-	if ((ModeState & ALT) && code <= SCAN_F1+3) {
+	/* AltF1-F8 are console switch (downstream Console_set_vc validates
+	 * against NumConsoles, so unwired keys are silently ignored).*/
+	if ((ModeState & ALT) && code <= SCAN_F1+7) {
 	    Console_set_vc(code - SCAN_F1);
 	    return;
 	}
@@ -356,8 +357,8 @@ static void keyboard_irq(int irq, struct pt_regs *regs)
 
         /* Step 6: Modify keyboard character based on some special states*/
 	if ((ModeState & (CTRL|ALT)) == ALT) {
-	    /* Alt-1 - Alt-4 are also console switch (for systems w/no fnkeys)*/
-	    if (key >= '1' && key <= '4') {
+	    /* Alt-1 - Alt-8 are also console switch (for systems w/no fnkeys)*/
+	    if (key >= '1' && key <= '8') {
 		Console_set_vc(key - '1');
 		return;
 	    }

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -25,8 +25,13 @@
 
 /* Predefined maximum number of tty character devices */
 
-#if defined(CONFIG_CONSOLE_DUAL)
-#define MAX_CONSOLES 4
+/*
+ * MAX_CONSOLES upper bound is PTY_MINOR_OFFSET (defined below): consoles
+ * occupy minors 0..MAX_CONSOLES-1, so MAX_CONSOLES > PTY_MINOR_OFFSET would
+ * collide with the pty block.
+ */
+#if defined(CONFIG_CONSOLE_DIRECT)
+#define MAX_CONSOLES CONFIG_CONSOLES_MAX
 #elif defined(CONFIG_FAST_IRQ2_NECV25)
 #define MAX_CONSOLES 2
 #elif defined(CONFIG_FAST_IRQ1_NECV25)

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -12,6 +12,8 @@ si::sysinit:/etc/rc.sys
 # 4 multiuser serial only (ttyS0,ttyS1)
 # 5 multiuser console only (tty1,tty2,tty3,tty4)
 # 6 multiuser console and serial
+# tN entries need CONFIG_CONSOLES_MAX >= N in the kernel build.
+# Comment out lines for missing ttys, or raise CONSOLES_MAX and rebuild.
 t1:1356:respawn:/bin/getty /dev/tty1
 t2:56:respawn:/bin/getty /dev/tty2
 t3:56:respawn:/bin/getty /dev/tty3

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -114,6 +114,10 @@ devices:
 	$(MKDEV) /dev/tty2	c 4 1
 	$(MKDEV) /dev/tty3	c 4 2
 	$(MKDEV) /dev/tty4	c 4 3
+	$(MKDEV) /dev/tty5	c 4 4
+	$(MKDEV) /dev/tty6	c 4 5
+	$(MKDEV) /dev/tty7	c 4 6
+	$(MKDEV) /dev/tty8	c 4 7
 
 ##############################################################################
 # Pseudo-TTY slave devices.


### PR DESCRIPTION
This change allows someone to start a game on one virtual console and then return to text mode with all consoles' content preserved.

  * RAM-backed virtual consoles for small-memory video adapters:

    Re-enables CONFIG_CONSOLES_MAX (1-8). When the requested VC count exceeds the adapter's video RAM, heap buffers are allocated for backing VCs. If video memory is sufficient, this has no impact.

  * Console text preservation through video mode changes:

    The DCGET_GRAPH ioctl snapshots console text pages to heap; DCREL_GRAPH restores them and resets the CRTC start address.

    If VCs are RAM-backed, only the current console page is saved since background VCs already live on the heap. Page-flip mode must save every VC since graphics writes may destroy all text pages (e.g. CGA mode 4).

  * Why bundle:

    Bundled into one change-set because MDA cards didn't have more than one supported VC, and many MDA cards are actually Hercules graphics, which would use this feature. Since detecting Hercules is error-prone, using RAM buffers when the BIOS equipment word indicates MDA is the safe bet.

Alt-F1..F8 keybindings widened from F1..F4 to match the new VC upper bound.

Tested on Leading Edge Model D with both MDA and CGA monitors, 2 VCs each. 20+ graphics entry/exit cycles per config; text preserved across every transition in each console; no memory leaks.