### PR TITLE
fix traceroute and ifconfig bugs

### DIFF
--- a/elkscmd/inet/ifconfig.c
+++ b/elkscmd/inet/ifconfig.c
@@ -27,6 +27,7 @@ struct config_info_s {
 	unsigned long	netmask_ip;
 	unsigned long	gateway_ip;
 	unsigned char	hwaddr[6];
+	char		name[8];		/* interface name e.g. "ne0" */
 };
 
 static int netconf_connect(void)
@@ -99,8 +100,8 @@ static int show_config(int s)
 		return -1;
 	}
 
-	printf("ne0       HWaddr %02x:%02x:%02x:%02x:%02x:%02x\n",
-	       hw[0], hw[1], hw[2], hw[3], hw[4], hw[5]);
+	printf("%-8s HWaddr %02x:%02x:%02x:%02x:%02x:%02x\n",
+	       config.name, hw[0], hw[1], hw[2], hw[3], hw[4], hw[5]);
 	printf("          inet addr:%s", in_ntoa(config.local_ip));
 	printf("  Mask:%s", in_ntoa(config.netmask_ip));
 	if (config.gateway_ip)

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -29,6 +29,7 @@ struct ip_ll {			//FIXME rename or combine w/above
 };
 
 extern eth_addr_t eth_local_addr;
+extern char ethdev[10];
 
 int  deveth_init(char *fdev);
 void eth_printhex(unsigned char *packet, int len);

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -104,6 +104,8 @@ void netconf_send(struct tcpcb_s *cb)
 	config.netmask_ip = netmask_ip;
 	config.gateway_ip = gateway_ip;
 	memcpy(config.hwaddr, eth_local_addr, 6);
+	strncpy(config.name, ethdev + 5, sizeof(config.name) - 1);
+	config.name[sizeof(config.name) - 1] = '\0';
 	tcpcb_buf_write(cb, (unsigned char *)&config, sizeof(config));
 	break;
     case NS_SET_IP:

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -72,6 +72,7 @@ struct config_info_s {
 	ipaddr_t	netmask_ip;
 	ipaddr_t	gateway_ip;
 	__u8		hwaddr[6];
+	char		name[8];		/* interface name e.g. "ne0" */
 };
 
 struct icmp_echo_request_s {

--- a/libc/net/in_resolv.c
+++ b/libc/net/in_resolv.c
@@ -159,7 +159,10 @@ ipaddr_t in_resolv(const char *hostname, char *server, int *ancount)
 		signal(SIGALRM, old);
 		close(fd);
 
-		if (rc < sizeof(struct DNS_HEADER) + sizeof(struct RR))
+		/* must check rc <= 0: read() returning -1 promotes to unsigned
+		 * in the comparison below, making -1 appear > 28 and skipping
+		 * the retry, then parsing the stale request buffer as a response */
+		if (rc <= 0 || (unsigned)rc < sizeof(struct DNS_HEADER) + sizeof(struct RR))
 			continue;
 
 		dns = (struct DNS_HEADER *)buf;

--- a/libc/net/in_resolv.c
+++ b/libc/net/in_resolv.c
@@ -159,10 +159,7 @@ ipaddr_t in_resolv(const char *hostname, char *server, int *ancount)
 		signal(SIGALRM, old);
 		close(fd);
 
-		/* must check rc <= 0: read() returning -1 promotes to unsigned
-		 * in the comparison below, making -1 appear > 28 and skipping
-		 * the retry, then parsing the stale request buffer as a response */
-		if (rc <= 0 || (unsigned)rc < sizeof(struct DNS_HEADER) + sizeof(struct RR))
+		if (rc < (int)(sizeof(struct DNS_HEADER) + sizeof(struct RR)))
 			continue;
 
 		dns = (struct DNS_HEADER *)buf;


### PR DESCRIPTION
Couple bug fixes.  

1. ifconfig had the interface name hardcoded to ne0.

2. for in_resolve, if you did:

ping -c 1 google.com
traceroute google.com
ping -c 1 google.com
traceroute google.com

the second traceroute  would fail. 

Now can consistently call ping and/or traceroute successfully

