### PR TITLE
[scripts] Modify qemu.sh to use port 2121 instead of 8021.

### DIFF
--- a/qemu.sh
+++ b/qemu.sh
@@ -74,7 +74,7 @@ KEYBOARD=
 # Uncomment the following line to emulate two serial devices, required for Nano-X:
 SERIAL="-chardev msmouse,id=c1 -device isa-serial,chardev=c1,id=s1 -chardev msmouse,id=c2 -device isa-serial,chardev=c2,id=s2"
 
-# Uncomment this to route ELKS /dev/ttyS0 to host terminal
+# Route ELKS serial /dev/ttyS0 to host terminal
 CONSOLE="-serial stdio"
 # Hides qemu window also
 #CONSOLE="-serial stdio -nographic"
@@ -92,7 +92,7 @@ FWD="\
 hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,\
 hostfwd=tcp:127.0.0.1:2323-10.0.2.15:23,\
 hostfwd=tcp::8020-:20,\
-hostfwd=tcp::8021-:21,\
+hostfwd=tcp::2121-:21,\
 hostfwd=tcp::8041-:49821,\
 hostfwd=tcp::8042-:49822,\
 hostfwd=tcp::8043-:49823,\


### PR DESCRIPTION
Port 8021 conflicts with an ftp proxy server in macOS 26.5.

From @djohanse in #2699.