### PR TITLE
[cmds] Allow max 16k buffer in dd, stops SBRK kernel error

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -73,7 +73,7 @@ file_utils/chmod                :be-fileutil    :360k
 file_utils/chown                :be-fileutil            :1200k
 file_utils/cmp                  :be-fileutil            :1200k
 file_utils/cp                   :be-fileutil    :360k
-file_utils/dd                   :be-fileutil            :1200k
+file_utils/dd                   :be-fileutil    :360k
 file_utils/md5sum               :fileutil                               :1440c
 file_utils/mkdir                :fileutil       :360k
 file_utils/mknod                :fileutil       :360k

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -32,7 +32,7 @@ cp: cp.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-heap=0xffff -o cp cp.o $(TINYPRINTF) $(LDLIBS)
 
 dd: dd.o
-	$(LD) $(LDFLAGS) -maout-heap=12288 -o dd dd.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=16384 -o dd dd.o $(LDLIBS)
 
 grep: grep.o
 	$(LD) $(LDFLAGS) -o grep grep.o $(LDLIBS)

--- a/elkscmd/file_utils/dd.c
+++ b/elkscmd/file_utils/dd.c
@@ -222,9 +222,11 @@ int main(int argc, char **argv)
 
 	buf = localbuf;
 	if (blocksize > sizeof(localbuf)) {
-		buf = malloc(blocksize);
+        buf = NULL;
+        if (blocksize <= 16384)
+		    buf = malloc(blocksize);
 		if (buf == NULL) {
-			errmsg("Cannot allocate buffer\n");
+			errmsg("Cannot allocate buffer, max 16k\n");
 			return retval;
 		}
 	}


### PR DESCRIPTION
Fixes some issues seen in [The Phintage Collector's ELKS demonstration](https://www.youtube.com/watch?v=tN7DgIWkdTo) .

Increases `dd` heap size to allow a max bs=16k buffer size, doesn't try allocating memory if larger, so the kernel SBRK FAIL message isn't seen. The `dd` error message now also specifies the maximum buffer size.

Also adds `dd` to 360k floppy images.