### PR TITLE
[config] Allow for easier configuration running in 256k RAM

### DIFF
--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -23,11 +23,11 @@ hma=kernel
 #enable=df0
 #disable=fd0
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
-#task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min
+#task=6 buf=8 cache=4 file=20 inode=24 heap=15000 # min
 #sync=30
 #3	# multiuser serial
 #n	# no rc.sys
-#init=/bin/sash
+#init=/bin/sh
 #kstack
 #strace
 #FTRACE=1


### PR DESCRIPTION
How to get ELKS to boot on an IBM PC with 256k RAM was discussed in [The Phintage Collector's demo video](https://www.youtube.com/watch?v=tN7DgIWkdTo), and Gianpaolo didn't find how to make this work.

The [ELKS Wiki Boot Options](https://github.com/ghaerr/elks/wiki#boot-options) documentation has been updated to better explain many boot options. This PR's slightly-modified /bootopts file now contains two lines that can be uncommented in order to configure kernel minimal system resources, skip running /bin/init and /etc/rc.sys, and boot directly to a shell prompt:
```
task=6 buf=8 cache=4 file=20 inode=24 heap=15000 # min
init=/bin/sh
```
These lines reduce the task array from 16 to 6, and the kernel heap to 15k, which saves a lot of memory. The kernel file and inode table are also reduced significantly. This allows the system to easily boot and run in 256k RAM from a 360k floppy disk.

Tested on `pcem`.