### PR TITLE
ssd-xms.c build crash

### DIFF
--- a/elks/arch/i86/drivers/block/ssd-xms.c
+++ b/elks/arch/i86/drivers/block/ssd-xms.c
@@ -25,6 +25,8 @@
 /* current implementation requires no other XMS allocations other than XMS buffers */
 static ramdesc_t     xms_ram_base;      /* ramdisk XMS memory start address */
 static unsigned  int xms_ram_size;      /* ramdisk size in Kbytes */
+extern int xms_enabled;
+extern unsigned int xms_alloc_ptr;
 
 /* initialize SSD device */
 sector_t ssddev_init(void)


### PR DESCRIPTION
Got a crash while building.  Had open code investigate and then manually confirmed fix.

### Steps to produce error:

Starting from master:

git checkout master
cp elks/arch/i86/defconfig .config

Then edit .config to enable:
CONFIG_FS_XMS=y
CONFIG_FS_XMS_RAMDISK=y
Then:
source env.sh && make -C elks clean && make -C elks


Reason: (according to open code): In C89, undeclared globals were implicitly int (just a warning), but the ia16-elf-gcc toolchain with -melks -mcmodel=small rejects them as hard errors.)

### build result after changes:

...
ia16-elf-ar rcs mm.a malloc.o user.o memcpyfs.o xms.o
ia16-elf-ar rcs akernel.a strace.o irq.o irqtab.o process.o entry.o signal.o timer.o softirq.o irq-8259.o reset-ibm.o timer-8254.o divzero.o nmi.o system
(cd ../.. ; ia16-elf-ld.gold  -M  -T /Users/derekjohansen/djelksclone/elks/elks/elks-small.ld \
		arch/i86/boot/crt0.o \
		init/main.o '-(' fs/fs.a kernel/kernel.a lib/lib.a net/net.a fs/minix/minixfs.a fs/msdos/msdos.a arch/i86/kernel/akernel.a arch/i86/lib/l
		-o arch/i86/boot/system > arch/i86/boot/system-full.map ; \
		ia16-elf-nm arch/i86/boot/system | sed -e '/&/d; /!/d' | sort > \
			arch/i86/boot/system.map; \
		elf2elks --symfile arch/i86/boot/system.sym arch/i86/boot/system)
tools/build arg_ignored boot/setup boot/system > boot/Image
Root device is (3, 128)
Setup is 1576 bytes (4 sectors).
Kernel is 101952 B (57456 B code, 27552 B fartext, 9296 B data and 7648 B bss)
System is 100200 B (0x1877 paras)
Load segment start 0x1400 end 0x1ba7Load segment start 0x1400 end 0x1ba7



