### PR TITLE
[kernel] Warn when cylinder count too large for BIOS HD driver, increase kstack

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -122,6 +122,9 @@ notMFM1024:
     BD_BP = offset;
 #else
 
+    if (drivep->cylinders > 1023)       /* return special error on cylinder overflow */
+        return -1;
+
 #if RESET_DISK_CHG
     static unsigned last = 0;
     if (running_qemu && drive != last) {

--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -122,7 +122,8 @@ notMFM1024:
     BD_BP = offset;
 #else
 
-    if (drivep->cylinders > 1023)       /* return special error on cylinder overflow */
+    /* return special error on BIOS cylinder overflow */
+    if (cylinder > 1023 && drivep->cylinders > 1023)
         return -1;
 
 #if RESET_DISK_CHG

--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -123,7 +123,7 @@ notMFM1024:
 #else
 
     /* return special error on BIOS cylinder overflow */
-    if (cylinder > 1023 && drivep->cylinders > 1023)
+    if (cylinder > 1023 && drivep->cylinders > 1024)
         return -1;
 
 #if RESET_DISK_CHG

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -516,7 +516,7 @@ static int BFPROC do_readwrite(struct drive_infot *drivep, sector_t start, char 
         segment = (seg_t)seg;
         offset = (unsigned) buf;
     }
-    errs = MAX_ERRS;        /* BIOS disk reads should be retried at least five times */
+    errs = 0;               /* BIOS disk reads should be retried at least five times */
     do {
         debug_cache("%s%s%d CHS %d/%d/%d count %d\n",
             cmd==WRITE? "WR": "RD", usedmaseg? "X": "", drive, cylinder, head, sector,
@@ -529,10 +529,11 @@ static int BFPROC do_readwrite(struct drive_infot *drivep, sector_t start, char 
                                 drive, cylinder, head, sector, segment, offset, drivep);
         if (error) {
             printk("bioshd(%x): cmd %d retry #%d CHS %d/%d/%d count %d\n",
-                drive, cmd, MAX_ERRS - errs + 1, cylinder, head, sector, this_pass);
+                drive, cmd, errs + 1, cylinder, head, sector, this_pass);
             bios_disk_reset(drive);
+            if (error == -1) errs = MAX_ERRS;   /* stop retries on CYL > 1023 */
         }
-    } while (error && --errs);      /* On error, retry up to MAX_ERRS times */
+    } while (error && ++errs < MAX_ERRS);       /* On error, retry up to MAX_ERRS times */
     last_drive = drivep;
 
     if (cmd == WRITE && drivep == cache_drive)

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -531,7 +531,7 @@ static int BFPROC do_readwrite(struct drive_infot *drivep, sector_t start, char 
             printk("bioshd(%x): cmd %d retry #%d CHS %d/%d/%d count %d\n",
                 drive, cmd, errs + 1, cylinder, head, sector, this_pass);
             bios_disk_reset(drive);
-            if (error == -1) errs = MAX_ERRS;   /* stop retries on CYL > 1023 */
+            if (error == -1) errs = MAX_ERRS;   /* no retries on cylinder > 1023 error */
         }
     } while (error && ++errs < MAX_ERRS);       /* On error, retry up to MAX_ERRS times */
     last_drive = drivep;

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -408,9 +408,15 @@ void GENPROC show_drive_info(struct drive_infot *drivep, const char *name, int d
                 unit++;
             }
             debug("DBG: Size = %lu (%X/%X)\n",size,*unit,unit[1]);
-            printk("%s%c: %4lu%c CHS %3u,%2d,%d%s",
+            printk("%s%c: %4lu%c CHS %3u,%2d,%d",
                 name, drive + (drivep->fdtype < 0? 'a' : '0'), (size/10), *unit,
-                drivep->cylinders, drivep->heads, drivep->sectors, eol);
+                drivep->cylinders, drivep->heads, drivep->sectors);
+#ifdef CONFIG_ARCH_IBMPC
+            /* IBM BIOS INT 13 can't use HD drives > 528MB, must use ATA/CF driver */
+            if (drivep->cylinders > 1023 && name[0] == 'h')
+                printk(" (CYL > 1023, must use /dev/cf%c)", drive+'a');
+#endif
+            printk("%s", eol);
         }
         drivep++;
     }

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -413,8 +413,8 @@ void GENPROC show_drive_info(struct drive_infot *drivep, const char *name, int d
                 drivep->cylinders, drivep->heads, drivep->sectors);
 #ifdef CONFIG_ARCH_IBMPC
             /* IBM BIOS INT 13 can't use HD drives > 528MB, must use ATA/CF driver */
-            if (drivep->cylinders > 1023 && name[0] == 'h')
-                printk(" (CYL > 1023, must use /dev/cf%c)", drive+'a');
+            if (drivep->cylinders > 1024 && name[0] == 'h')
+                printk(" (CYL > 1024, must use /dev/cf%c)", drive+'a');
 #endif
             printk("%s", eol);
         }

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -160,10 +160,11 @@ save_regs:
         call    syscall
         push    %ax             // syscall return value in ax
 
-#ifdef CONFIG_TRACE
+//#ifdef CONFIG_TRACE
         // strace.c must be compiled with tail optimization off to protect top of stack
+        // Now always checks for kernel stack overflow
         call    trace_end       // syscall return value is top of stack
-#endif
+//#endif
 
         cmpw    $0,bh_active    // Any active bottom halfs?
         je      1f              // No

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -176,24 +176,24 @@ void trace_begin(void)
         strace();
 #endif
 }
+#endif /* CONFIG_TRACE */
 
 /*
- * Called after syscall return
+ * Called after syscall return.
  * Must be compiled with -fno-optimize-siblings-calls (no tail call optimization)
  * in order to protect top of stack return value since called from _irqit.
  */
 void trace_end(unsigned int retval)
 {
-    int n;
-    static int max;
-
-    /* Check for kernel stack overflow */
+    /* Check if kernel stack has overflowed */
     if (current->kstack_magic != KSTACK_MAGIC) {
         printk("KSTACK(%P) KERNEL STACK OVERFLOW\n");
         do_exit(SIGSEGV);
     }
 
-    n = 0;
+#ifdef CONFIG_TRACE
+    int n = 0;
+    static int max;
 #if defined(CHECK_STRACE) || defined(CHECK_KSTACK)
     if (tracing & (TRACE_STRACE|TRACE_KSTACK)) {
         for (; n<KSTACK_BYTES/2; n++) {
@@ -214,6 +214,6 @@ void trace_end(unsigned int retval)
     if (tracing & TRACE_KSTACK)
         check_kstack(n);
 #endif
+#endif /* CONFIG_TRACE */
 }
 
-#endif /* CONFIG_TRACE */

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -188,7 +188,7 @@ void trace_end(unsigned int retval)
     /* Check if kernel stack has overflowed */
     if (current->kstack_magic != KSTACK_MAGIC) {
         printk("KSTACK(%P) KERNEL STACK OVERFLOW\n");
-        do_exit(SIGSEGV);
+        do_exit(SIGKILL);
     }
 
 #ifdef CONFIG_TRACE

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -10,9 +10,9 @@
 #define KSTACK_BYTES    740     /* Size of kernel stacks for PC-98 */
 #else
 #ifdef CONFIG_ASYNCIO
-#define KSTACK_BYTES    700     /* Size of kernel stacks w/async I/O */
+#define KSTACK_BYTES    730     /* Size of kernel stacks w/async I/O */
 #else
-#define KSTACK_BYTES    640     /* Size of kernel stacks w/o async I/O */
+#define KSTACK_BYTES    670     /* Size of kernel stacks w/o async I/O */
 #endif
 #endif
 

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -117,7 +117,7 @@ copy_bin_files()
 	cp /bin/umount	$MNT/bin
 	cp /bin/uname	$MNT/bin
 	else
-	cp -fR /bin $MNT/bin
+	cp -fvR /bin $MNT/bin
 	fi
 }
 


### PR DESCRIPTION
This PR fixes all the issues found and discussed in #2587.

When using the ELKS BIOS disk driver, the maximum number of cylinders that can be used for CHS addressing is 1024 (0-1023). Previously, no check was made for cylinder overflow/truncation when performing I/O to/from hard drives, and the cylinder number was truncated and I/O performed, silently causing filesystem or user data corruption.

The ATA/CF driver (/dev/cfa) uses LBA rather than CHS addressing, and must be used when accessing large SSD or hard drives.

This PR implements a warning a boot, `CYL > 1024, must use /dev/cfa`, letting the user know to use /dev/cfa rather than /dev/hda to eliminate otherwise possibly silent errors. Note that a large hard drive may be able to be booted from /dev/hda if /linux and programs run from /bin are all in the early portions (i.e. cylinder numbers < 1024) of the disk/SSD.

BIOS HD I/O past the 1024th cylinder (> 1023) now give I/O errors to stop any data corruption.

During the testing of the above, a problem which previously wasn't able to be duplicated was finally duplicated and found: during `sys -M /dev/hda1` execution, the `cp -R` command was crashing due to stack underflow and terminated. The real cause was finally found to be kernel stack overflow! What was happening is that the system was booted on a FAT floppy; the FAT filesystem is known to use a large amount of kernel stack. Then, the `sys` script executed `cp` which recursively copied files from one FAT filesystem to another, which overflowed the kernel stack of `cp`, going downwards through the task structure by 14 bytes and overwriting the t_begstack task structure member, which holds the stack base address. Then, during regular system call integrity checking in `check_ustack`, called before each syscall in \_irqit, the process SP appeared to be outside the stack base location and the process was terminated with a SIGSEGV.

After testing with CONFIG_TRACE on, the kernel stack was increased by 30 bytes (times 16 tasks = 480 byte extra permanent kernel heap usage), which should allow for enough stack to operate. @Mon0x4A, it would be nice if you could test this on your real hardware.

Finally, this PR implements a full-time "quick" kernel stack check after ever syscall, to catch any similar (future) kernel stack overflows immediately before returning from the syscall to user mode. This will make it easier to spot in the future, which will be solved by increasing kernel stack even more.

The `sys` script adds the verbose -v option to `cp` to see more easily what is being copied during system copying.