### PR TITLE
[kernel] Guard fast serial IRQ handler against spurious QEMU interrupts

### DIFF
--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -64,6 +64,11 @@ common_entry:
         mov     %cx,%bx                 // bx = sp = &ports[n]
         mov     (%bx),%si               // si = q = &sp->tty->inq
         mov     0x4(%bx),%dx            // dx = sp->io + UART_RX
+        add     $5,%dx                  // dx = sp->io + UART_LSR
+        in      (%dx),%al
+        sub     $5,%dx                  // dx = sp->io + UART_RX
+        test    $1,%al                  // data ready? QEMU may interrupt w/no data:
+        jz      4f                      // reading empty RX would queue a NUL as input
 0:      in      (%dx),%al               // do {
         mov     %al,%dl                 // dl = c = INB(sp->io+UART_RX)
         mov     (%si),%ax               // ax = q->len


### PR DESCRIPTION
Please find the AI-generated PR description below.
Human note: this was originally a part of 286 branch, that I think belongs in mainline if correct.
Apparently there are/were three code paths (rs_irq/rs_fast_com1/serfast.S)
The asm path (the only one live) is lacking the uart_rx guard present in serial-8250.c
This complicates kernel debugging over serial port in my 286 port.
Let me know if this needs a better fix or it's not supposed to be fixed at all for some reason.

## Problem

On QEMU, at a ttyS0 login shell, the next command typed after a pipeline
frequently vanishes — no output, no error, next prompt appears:

    # ls /etc | wc -l
         12
    # echo ONE          <- silently discarded
    # echo TWO
    TWO

Reproduced on a stock ibmpc-1440 kernel (unmodified master). It is a race,
so it may take 2-3 pipelines to show. Repro: change /etc/inittab default
runlevel to 3 (getty on ttyS0), boot
`qemu-system-i386 -m 4M -nographic -drive file=fd1440.img,format=raw,if=floppy -boot a`,
log in on serial, run a pipeline, then any command.

## Cause

serfast.S's rx loop is a do-while: it reads UART_RX *before* checking LSR
data-ready. QEMU generates spurious IRQ4s (the disabled C reference handler
rs_irq() in serial-8250.c guards this exact case, with the comment "QEMU may
interrupt w/no data"). On a spurious interrupt the handler reads the empty RX
register and queues the resulting 0x00 into the tty input queue. A kernel-side
trace of the shell's read(0) shows a lone NUL arriving before the next
command's characters — ash discards the poisoned line silently. Pipelines
trigger it reliably because the children's tty writes generate extra
interrupt traffic.

Real 8250 hardware presumably never raises IRQ4 without data, so this only
bites emulator users (untested on pcem/86Box/real hardware).

## Fix

Add the same data-ready check rs_irq() has to the asm handler entry: read
LSR, and skip the receive loop when DR is clear (5 instructions).

Verified on QEMU/KVM: with the guard, post-pipeline commands execute
normally on both a stock real-mode kernel and the 286-PM fork (#2718),
and the stdin trace shows no NUL injection.

---
Found while stress-testing the 286 protected-mode fork (#2718). Diagnosis
and patch were Claude-assisted, per the discussion there; the change mirrors
the existing C reference handler and I'm happy to rework it however you
prefer.
