### PR TITLE
[kernel] First step towards protected mode kernel for 286/386+ CPUs

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -160,7 +160,7 @@ static bool recover;            /* recovering from hang, awakened by watchdog ti
 static bool seek;               /* set if current op needs a track change (seek) */
 
 /* BIOS floppy motor timeout counter - FIXME leave this while BIOS driver present */
-static unsigned char __far *fl_timeout = (void __far *)0x440L;
+static unsigned char __far *fl_timeout = (void __far *)_MK_FP(BIOSSEG, 0x40);
 
 /* NOTE: current_DOR tells which motor(s) have been commanded to run,
  * 'running' tells which ones are actually running. The difference is subtle,
@@ -181,9 +181,6 @@ static unsigned char running;   /* keep track of motors already running */
  * ultra cheap floppies ;-)
  */
 #define MIN_ERRORS      0
-
-#define LINADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 4) + (unsigned)(offs)))
-#define XMSADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 0) + (unsigned)(offs)))
 
 /*
  * globals used by 'result()'
@@ -368,12 +365,12 @@ static void motor_on_callback(int nr)
 }
 
 static struct timer_list motor_on_timer[2] = {
-    {NULL, 0, 0, motor_on_callback},
-    {NULL, 0, 1, motor_on_callback}
+    {NULL, 0, (void *)0, motor_on_callback},
+    {NULL, 0, (void *)1, motor_on_callback}
 };
 static struct timer_list motor_off_timer[2] = {
-    {NULL, 0, 0, motor_off_callback},
-    {NULL, 0, 1, motor_off_callback}
+    {NULL, 0, (void *)0, motor_off_callback},
+    {NULL, 0, (void *)1, motor_off_callback}
 };
 static struct timer_list fd_timeout = {NULL, 0, 0, floppy_shutdown};
 
@@ -476,7 +473,7 @@ static void DFPROC setup_DMA(void)
     if (use_xms)
         use_bounce = 0;                 /* XMS buffers also always 1K aligned */
     else {
-        physaddr = (req->rq_seg << 4) + (unsigned int)req->rq_buffer;
+        physaddr = LINADDR(req->rq_seg, req->rq_buffer);
         use_bounce = (physaddr + count) < physaddr;
     }
     if (!use_cache) {                   /* use_cache overrides use_bounce */

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -92,7 +92,7 @@ static int NumConsoles;
  */
 static char UseRambuf;
 
-unsigned int VideoSeg = 0xb800;
+unsigned int VideoSeg = VIDEOSEG;
 int Current_VCminor;
 int kraw;
 
@@ -255,17 +255,17 @@ void INITPROC console_init(void)
     int output_type = OT_EGA;
     int avail_pages;
 
-    Width = peekb(0x4a, 0x40);  /* BIOS data segment */
+    Width = peekb(0x4a, BIOSSEG);  /* BIOS data segment */
     /* Trust this. Cga does not support peeking at 0x40:0x84. */
     Height = 25;
-    boot_crtc = peekw(0x63, 0x40);
-    PageSizeW = ((unsigned int)peekw(0x4C, 0x40) >> 1);
+    boot_crtc = peekw(0x63, BIOSSEG);
+    PageSizeW = ((unsigned int)peekw(0x4C, BIOSSEG) >> 1);
 
-    if (peekb(0x49, 0x40) == 7) {
+    if (peekb(0x49, BIOSSEG) == 7) {
         VideoSeg = 0xB000;
         output_type = OT_MDA;
     } else {
-        if (peekw(0xA8+2, 0x40) == 0)
+        if (peekw(0xA8+2, BIOSSEG) == 0)
             output_type = OT_CGA;
     }
     NumConsoles = MAX_CONSOLES;
@@ -309,8 +309,8 @@ void INITPROC console_init(void)
         C->cx = C->cy = 0;
         C->display = 0;
         if (!i) {
-            C->cx = peekb(0x50, 0x40);
-            C->cy = peekb(0x51, 0x40);
+            C->cx = peekb(0x50, BIOSSEG);
+            C->cy = peekb(0x51, BIOSSEG);
         }
         C->fsm = std_char;
 #if VC_USE_RAM_BUFFER
@@ -373,7 +373,7 @@ void INITPROC console_init(void)
     unsigned char cur_display = 0;
     unsigned char boot_type;
 
-    boot_crtc = peekw(0x63, 0x40);
+    boot_crtc = peekw(0x63, BIOSSEG);
     for (i = 0; i < N_DEVICETYPES; ++i) {
         if (crtc_params[i].crtc_base == boot_crtc)
             boot_type = i;
@@ -389,8 +389,8 @@ void INITPROC console_init(void)
             C->display = cur_display;
             if (!j) Visible[C->display] = C;
             if (!j && !i) {
-                C->cx = peekb(0x50, 0x40);
-                C->cy = peekb(0x51, 0x40);
+                C->cx = peekb(0x50, BIOSSEG);
+                C->cy = peekb(0x51, BIOSSEG);
             }
             C->fsm = std_char;
             C->vseg_offset = j * crtc_params[dev].page_words;

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -102,10 +102,10 @@ static int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg
         retword = max_tasks;
         break;
     case MEM_GETCS:
-        retword = kernel_cs;
+        retword = KERNEL_CS;
         break;
     case MEM_GETDS:
-        retword = kernel_ds;
+        retword = KERNEL_DS;
         break;
     case MEM_GETFARTEXT:
         retword = (unsigned)((long)buffer_init >> 16);

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -59,7 +59,7 @@ static void int_handler_add(int irq, int vect, int_proc proc)
     h = &trampoline[irq];
     h->call = 0x9A;         /* CALLF opcode */
     h->proc = (word_t)proc;
-    h->seg  = kernel_cs;    /* resident kernel code segment */
+    h->seg  = KERNEL_CS;    /* resident kernel code segment */
     h->irq  = irq;
     int_vector_set(vect, (word_t)h, kernel_ds);
 }

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -55,7 +55,7 @@ void INITPROC kfork_proc(void (*addr)())
     t = find_empty_process();
 
     /* t_regs values are nonexistent for idle task or handlers interrupting idle task */
-    t->t_regs.ds = t->t_regs.es = t->t_regs.ss = kernel_ds;
+    t->t_regs.ds = t->t_regs.es = t->t_regs.ss = KERNEL_DS;
     arch_build_stack(t, addr);
 }
 
@@ -174,7 +174,7 @@ void arch_build_stack(struct task_struct *t, void (*addr)())
         addr = ret_from_syscall;
     *tsp = (__u16)addr;                 /* Start execution address */
 #ifdef __ia16__
-    *(tsp-2) = kernel_ds;               /* Initial value for ES register */
+    *(tsp-2) = KERNEL_DS;               /* Initial value for ES register */
     t->t_ksp = (__u16)(tsp - 4);        /* Initial value for SP register */
 #else
     t->t_ksp = (__u16)(tsp - 3);        /* Initial value for SP register */

--- a/elks/arch/i86/lib/peekpoke.S
+++ b/elks/arch/i86/lib/peekpoke.S
@@ -4,7 +4,7 @@
 // assume DS=SS, save ES, for GCC-IA16
 
 // for SETUP_DATA segment
-#include <linuxmt/config.h>
+#include <arch/segment.h>
 
 #define ARG0	2
 #define ARG1	4

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -360,7 +360,7 @@ int sys_fmemalloc(int paras, unsigned short *pseg)
     }
     debug_brk("(%P)FMEMALLOC %ld\n", (unsigned long)paras << 4);
     seg->pid = current->pid;
-    put_user(BASE(seg), pseg);
+    put_user(seg->base, pseg);
     return 0;
 }
 
@@ -372,7 +372,7 @@ int sys_fmemfree(unsigned short segment)
     for (n = _seg_all.next; n != &_seg_all; ) {
         segment_s * seg = structof (n, segment_s, all);
 
-        if (BASE(seg) == segment) {
+        if (seg->base == segment) {
             if (seg->pid == current->pid) {
                 seg_free(seg);
                 return 0;
@@ -411,7 +411,7 @@ int seg_verify_area(pid_t pid, seg_t base, segoff_t offset)
     for (n = _seg_all.next; n != &_seg_all; ) {
         segment_s * seg = structof (n, segment_s, all);
 
-        if (seg->pid == pid && BASE(seg) == base)
+        if (seg->pid == pid && seg->base == base)
             return offset <= (seg->size << 4);
         n = seg->all.next;
     }

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -13,6 +13,16 @@
 
 #include <arch/segment.h>
 
+#ifdef CONFIG_286_PMODE
+/* PM must use additional 'para' member seperately from
+ * 'base' selector value to track main memory physical address.
+ * Real mode just uses single 'base' member as segment address.
+ */
+#define BASE(seg)   ((seg)->para)   /* use base paragraph address in protected mode */
+#else
+#define BASE(seg)   ((seg)->base)   /* use segment address in real mode */
+#endif
+
 // Minimal segment size to be useful
 // (= size of the smallest allocation)
 
@@ -41,7 +51,7 @@ static segment_s * seg_split (segment_s * s1, segext_t size0)
         if (!s2)
             return 0;   // heap_alloc gives heap full message
 
-        s2->base = s1->base + size0;
+        BASE(s2) = BASE(s1) + size0;
         s2->size = size2;
         s2->flags = SEG_FLAG_FREE;
         s2->ref_count = 0;
@@ -75,7 +85,7 @@ static segment_s * seg_free_get (segext_t size0, word_t type)
         segext_t size1 = seg->size;
 
         if (type & SEG_FLAG_ALIGN1K)
-            size00 = size0 + ((~seg->base + 1) & ((1024 >> 4) - 1));
+            size00 = size0 + ((~BASE(seg) + 1) & ((1024 >> 4) - 1));
         if ((seg->flags == SEG_FLAG_FREE) && (size1 >= size00) && (size1 < best_size)) {
             best_seg  = seg;
             best_size = size1;
@@ -123,7 +133,7 @@ segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
     if (!seg)
         return seg;
 
-    seg->base = base;
+    BASE(seg) = base;
     seg->size = size;
     seg->flags = SEG_FLAG_USED | type;
     seg->ref_count = 1;
@@ -140,7 +150,7 @@ segment_s * seg_alloc (segext_t size, word_t type)
 
     seg = seg_free_get (size, type);
     if (seg && (type & SEG_FLAG_ALIGN1K))
-        seg->base += ((~seg->base + 1) & ((1024 >> 4) - 1));
+        BASE(seg) += ((~BASE(seg) + 1) & ((1024 >> 4) - 1));
     return seg;
 }
 
@@ -171,7 +181,7 @@ void seg_free (segment_s * seg)
     list_s * p = seg->all.prev;
     if (&_seg_all != p) {
         segment_s * prev = structof (p, segment_s, all);
-        if ((prev->flags == SEG_FLAG_FREE) && (prev->base + prev->size == seg->base)) {
+        if ((prev->flags == SEG_FLAG_FREE) && (BASE(prev) + prev->size == BASE(seg))) {
             list_remove (&(prev->free));
             seg_merge (prev, seg);
             i = _seg_free.prev;
@@ -184,7 +194,7 @@ void seg_free (segment_s * seg)
     list_s * n = seg->all.next;
     if (n != &_seg_all) {
         segment_s * next = structof (n, segment_s, all);
-        if ((next->flags == SEG_FLAG_FREE) && (seg->base + seg->size == next->base)) {
+        if ((next->flags == SEG_FLAG_FREE) && (BASE(seg) + seg->size == BASE(next))) {
             list_remove (&(next->free));
             seg_merge (seg, next);
             i = _seg_free.prev;
@@ -241,7 +251,7 @@ void mm_get_usage (struct mem_usage *mu)
         segment_s * seg = structof (n, segment_s, all);
 
         /*if (used) printk ("seg %X: size %u used %u count %u\n",
-            seg->base, seg->size, seg->flags, seg->ref_count);*/
+            BASE(seg), seg->size, seg->flags, seg->ref_count);*/
 
         if (seg->flags == SEG_FLAG_FREE)
             free += seg->size;
@@ -350,7 +360,7 @@ int sys_fmemalloc(int paras, unsigned short *pseg)
     }
     debug_brk("(%P)FMEMALLOC %ld\n", (unsigned long)paras << 4);
     seg->pid = current->pid;
-    put_user(seg->base, pseg);
+    put_user(BASE(seg), pseg);
     return 0;
 }
 
@@ -362,7 +372,7 @@ int sys_fmemfree(unsigned short segment)
     for (n = _seg_all.next; n != &_seg_all; ) {
         segment_s * seg = structof (n, segment_s, all);
 
-        if (seg->base == segment) {
+        if (BASE(seg) == segment) {
             if (seg->pid == current->pid) {
                 seg_free(seg);
                 return 0;
@@ -401,7 +411,7 @@ int seg_verify_area(pid_t pid, seg_t base, segoff_t offset)
     for (n = _seg_all.next; n != &_seg_all; ) {
         segment_s * seg = structof (n, segment_s, all);
 
-        if (seg->pid == pid && seg->base == base)
+        if (seg->pid == pid && BASE(seg) == base)
             return offset <= (seg->size << 4);
         n = seg->all.next;
     }
@@ -412,7 +422,7 @@ void INITPROC seg_add(seg_t start, seg_t end)
 {
     segment_s * seg = (segment_s *) heap_alloc (sizeof (segment_s), HEAP_TAG_SEG);
     if(seg) {
-        seg->base = start;
+        BASE(seg) = start;
         seg->size = end - start;
         seg->flags = SEG_FLAG_FREE;
         seg->ref_count = 0;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -256,7 +256,7 @@ int INITPROC buffer_init(void)
     } while (bufs_to_alloc > 0);
 #else
     /* no EXT or XMS buffers, internal L1 only */
-    add_buffers(nr_map_bufs, L1buf, kernel_ds);
+    add_buffers(nr_map_bufs, L1buf, KERNEL_DS);
 #endif
     return 0;
 }
@@ -720,7 +720,7 @@ void map_buffer(struct buffer_head *bh)
     L1map[i] = bh;
     bh->b_data = L1buf + (i << BLOCK_SIZE_BITS);
     if (ebh->b_uptodate)
-        xms_fmemcpyw(bh->b_data, kernel_ds, 0, ebh->b_L2seg, BLOCK_SIZE/2);
+        xms_fmemcpyw(bh->b_data, KERNEL_DS, 0, ebh->b_L2seg, BLOCK_SIZE/2);
     map_count++;
     debug_map("MAP:   L%02d block %ld\n", i+1, ebh->b_blocknr);
   end_map_buffer:
@@ -768,7 +768,7 @@ void brelseL1_index(int i, int copyout)
     if (ebh->b_mapcount || ebh->b_locked)
         return;
     if (copyout && ebh->b_uptodate && bh->b_data) {
-        xms_fmemcpyw(0, ebh->b_L2seg, bh->b_data, kernel_ds, BLOCK_SIZE/2);
+        xms_fmemcpyw(0, ebh->b_L2seg, bh->b_data, KERNEL_DS, BLOCK_SIZE/2);
         unmap_count++;
     }
     bh->b_data = 0;
@@ -791,6 +791,6 @@ void brelseL1(struct buffer_head *bh, int copyout)
 
 ramdesc_t buffer_seg(struct buffer_head *bh)
 {
-    return (bh->b_data? kernel_ds: EBH(bh)->b_L2seg);
+    return (bh->b_data? KERNEL_DS: EBH(bh)->b_L2seg);
 }
 #endif /* CONFIG_FS_EXTERNAL_BUFFER | CONFIG_FS_XMS_BUFFER*/

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -85,7 +85,7 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
 
     /* Read the header */
     ds = current->t_regs.ds;
-    current->t_regs.ds = kernel_ds;
+    current->t_regs.ds = KERNEL_DS;
     retval = filp->f_op->read(inode, filp, (char *)&magic, sizeof(magic));
     current->t_regs.ds = ds;
     if (retval != sizeof(magic)) goto error_exec2_5;
@@ -146,7 +146,7 @@ static int FARPROC relocate(seg_t place_base, unsigned long rsize, segment_s *se
 
     if ((int)rsize % sizeof(struct minix_reloc))
         return -EINVAL;
-    current->t_regs.ds = kernel_ds;
+    current->t_regs.ds = KERNEL_DS;
     debug_reloc("EXEC: applying %04lx bytes of relocations to segment %x\n",
            (unsigned long)rsize, place_base);
     while (rsize >= sizeof(struct minix_reloc)) {
@@ -207,7 +207,7 @@ static int FARPROC execve_aout(struct inode *inode, struct file *filp,
 #endif
 
     /* (Re)read the header */
-    current->t_regs.ds = kernel_ds;
+    current->t_regs.ds = KERNEL_DS;
     filp->f_pos = 0;
     retval = filp->f_op->read(inode, filp, (char *) &mh, sizeof(mh));
 
@@ -614,7 +614,7 @@ static int FARPROC execve_os2(struct inode *inode, struct file *filp,
     static struct ne_reloc reloc;
 
     /* read MZ header, then OS/2 header */
-    current->t_regs.ds = kernel_ds;
+    current->t_regs.ds = KERNEL_DS;
     filp->f_pos = 0;
     retval = filp->f_op->read(inode, filp, (char *)&doshdr, sizeof(doshdr));
     if (retval != sizeof(doshdr)) goto errout;
@@ -714,7 +714,7 @@ static int FARPROC execve_os2(struct inode *inode, struct file *filp,
         retval = filp->f_op->read(inode, filp, 0, segp->size);
         if (retval != segp->size) goto errout2;
 
-        current->t_regs.ds = kernel_ds;
+        current->t_regs.ds = KERNEL_DS;
         if (segp->flags & NESEG_RELOCINFO) {
             retval = filp->f_op->read(inode, filp, (char *)&reloc_num, sizeof(reloc_num));
             if (retval != sizeof(reloc_num)) goto errout2;

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -1,11 +1,64 @@
 #ifndef __ARCH_8086_SEGMENT_H
 #define __ARCH_8086_SEGMENT_H
 
+#include <linuxmt/config.h>
+
+/*
+ * Protected mode selector vs segment macros
+ */
+#ifdef CONFIG_286_PMODE
+/* (fixed) protected mode selector values defined in seg286.h */
+//#include <arch/seg286.h>      // add this and remove SEL_ below when arch/seg286.h present
+#define SEL_KCODE       0x08
+#define SEL_KDATA       0x10
+#define SEL_KFTEXT      0x18
+#define SEL_SETUP       0x28    /* GDT[5]: base = REL_INITSEG<<4, for setupb/setupw in PM */
+#define SEL_OPTSEG      0x30    /* GDT[6]: base = DEF_OPTSEG<<4, for the /bootopts copy in PM */
+#define SEL_BIOSDATA    0x38    /* GDT[7]: base = 0x400, BIOS data area (seg 0x40) reads in PM */
+#define SEL_VIDEO       0x40    /* GDT[8]: base = 0xB8000, text video memory (VideoSeg) in PM */
+#define SEL_TRACK       0x48    /* GDT[9]: base = TRACKSEG<<4, directfd DMA/track buffer in PM */
+#define SEL_KDATA_EXEC  0x20    /* GDT[4]: same base as KDATA, but executable+readable;
+                                 * IDT gates point here so the CPU can run the trampolines
+                                 * that int_handler_add() builds in the kernel data segment */
+
+/* macros map to selector values */
+#define KERNEL_CS       SEL_KCODE       /* kernel near code selector */
+#define KERNEL_DS       SEL_KDATA       /* kernel data selector */
+#define BIOSSEG         SEL_BIOSDATA    /* BIOS data */
+#define VIDEOSEG        SEL_VIDEO       /* text video RAM */
+#define TRACKSEG        SEL_TRACK       /* direct floppy track cache */
+#define SETUP_DATA      SEL_SETUP       /* setupb/setupw data segment */
+
+/* address conversion macros used in directfd.c */
+#define LINADDR(seg, offs) (desc_base(seg) + (unsigned long)(unsigned)(offs))
+#define XMSADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 0) + (unsigned)(offs)))
+
+#else /* real mode */
+
+/* use real mode segment values (these may move to config.h) */
+#define SEG_BIOSDATA    0x0040          /* BIOS data */
+#define SEG_VIDEO       0xB800          /* text video RAM */
+
+/* macros map to segment values */
+#define KERNEL_CS       kernel_cs       /* real mode kernel near code segment */
+#define KERNEL_DS       kernel_ds       /* real mode kernel data segment */
+#define BIOSSEG         SEG_BIOSDATA    /* BIOS data */
+#define VIDEOSEG        SEG_VIDEO       /* text video RAM */
+#define TRACKSEG        SEG_TRACK       /* direct floppy track cache */
+#define SETUP_DATA      SEG_SETUP_DATA  /* setupb/setupw data segment */
+
+/* address conversion macros used in directfd.c */
+#define LINADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 4) + (unsigned)(offs)))
+#define XMSADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 0) + (unsigned)(offs)))
+#endif
+
+#ifndef __ASSEMBLER__
 #include <linuxmt/types.h>
 
 extern seg_t kernel_cs, kernel_ds;
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
 extern short endistack[], istack[];
 extern unsigned int heapsize;
+#endif
 
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -197,7 +197,7 @@
 #  define TRACKSEGSZ    0           /* no TRACKSEG buffer */
 #  endif
 #endif
-#define TRACKSEG        (DMASEG+(DMASEGSZ>>4))
+#define SEG_TRACK       (DMASEG+(DMASEGSZ>>4))
 #define DMASEGEND       (DMASEG+(DMASEGSZ>>4)+(TRACKSEGSZ>>4))
 #else
 #define DMASEGEND       (DMASEG+(DMASEGSZ>>4))
@@ -219,7 +219,7 @@
 #define REL_INITSEG     0x90        /* 0x200 bytes setup data */
 #define DMASEG          0xB0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
-#define SETUP_DATA      REL_INITSEG
+#define SEG_SETUP_DATA  REL_INITSEG
 #endif
 
 #ifdef CONFIG_ARCH_PC98
@@ -229,7 +229,7 @@
 #define REL_INITSEG     0xA0        /* 0x200 bytes setup data */
 #define DMASEG          0xC0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
-#define SETUP_DATA      REL_INITSEG
+#define SEG_SETUP_DATA  REL_INITSEG
 #endif
 
 #endif /* !CONFIG_ROMCODE */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -208,7 +208,7 @@
 #ifdef CONFIG_ROMCODE
 #define DMASEG          0x80        /* start of floppy sector buffer */
 #define KERNEL_DATA     DMASEGEND   /* kernel data segment */
-#define SETUP_DATA      CONFIG_ROM_SETUP_DATA
+#define SEG_SETUP_DATA  CONFIG_ROM_SETUP_DATA
 
 #else /* !CONFIG_ROMCODE */
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -450,7 +450,7 @@ ramdesc_t buffer_seg(struct buffer_head *bh);
 #define unmap_brelse(bh) brelse(bh)
 #define brelseL1_index(i,copyout)
 #define brelseL1(bh,copyout)
-#define buffer_seg(bh)   (kernel_ds)
+#define buffer_seg(bh)   (KERNEL_DS)
 #endif
 
 extern size_t block_read(struct inode *,struct file *,char *,size_t);

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -3,15 +3,20 @@
 
 #include <linuxmt/types.h>
 #include <linuxmt/list.h>
+#include <linuxmt/config.h>
 
+/* main memory management */
 struct segment {
 	list_s    all;
 	list_s    free;
-	seg_t     base;
-	segext_t  size;
+	seg_t     base;             /* segment or selector value of main memory */
+	segext_t  size;             /* size in bytes */
 	byte_t    flags;
 	byte_t    ref_count;
 	word_t    pid;
+#ifdef CONFIG_286_PMODE
+	seg_t     phys;             /* physical segment value of memory (=base in real mode) */
+#endif
 };
 
 typedef struct segment segment_s;

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -10,7 +10,7 @@ struct segment {
 	list_s    all;
 	list_s    free;
 	seg_t     base;             /* segment or selector used to access memory */
-	segext_t  size;             /* size in bytes */
+	segext_t  size;             /* size in paragraphs */
 	byte_t    flags;
 	byte_t    ref_count;
 	word_t    pid;

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -9,13 +9,13 @@
 struct segment {
 	list_s    all;
 	list_s    free;
-	seg_t     base;             /* segment or selector value of main memory */
+	seg_t     base;             /* segment or selector used to access memory */
 	segext_t  size;             /* size in bytes */
 	byte_t    flags;
 	byte_t    ref_count;
 	word_t    pid;
 #ifdef CONFIG_286_PMODE
-	seg_t     phys;             /* physical segment value of memory (=base in real mode) */
+	seg_t     para;             /* paragraph address of memory (=base in real mode) */
 #endif
 };
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -528,7 +528,7 @@ static int INITPROC parse_options(void)
     char *next;
 
     /* copy /bootopts loaded by boot loader at 0050:0000*/
-    fmemcpyb(opts.options, kernel_ds, 0, DEF_OPTSEG, sizeof(opts.options));
+    fmemcpyb(opts.options, KERNEL_DS, 0, DEF_OPTSEG, sizeof(opts.options));
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
     /* check file starts with ##, one or two sectors, max 1023 bytes or 511 one sector */

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -268,7 +268,7 @@ static void vprintk(const char *fmt, va_list p)
                 kputs(root_dev_name(va_arg(p, unsigned int))+8); /* skip ROOTDEV= */
                 break;
             case 's':
-                n = kernel_ds;
+                n = KERNEL_DS;
             str:
                 str = va_arg(p, char *);
                 while ((zero = peekb((word_t)str++, n))) {


### PR DESCRIPTION
Hello @duzenko,

This is the first step of modifications required towards implementing a proof of concept of a protected mode kernel, originally discussed in #2718, #2720 and https://github.com/duzenko/elks/pull/1.

Please check to see if you can get rebase your code at https://github.com/duzenko/elks/pull/1 around this PR's branch. We can then proceed to either committing this or adding more changes in order to keep your initial PM port with smaller step-wise changes.

These changes should reduce the number of ifdefs in your port by quite a bit.

~Note: I've added the `phys` member to `struct segment` in an effort to restructure your port's requirement of using SEG_HANDLE(seg) rather than my preferred method of keeping the use of seg->base in the kernel, except for malloc.c. I would like to ensure this can be done, if possible, before committing this PR, and I can then include those memory management routine changes required from your repo to this PR.~
I've pushed another commit to allow using seg->base externally as selector value. This uses a new `struct segment` member named 'para' which is the paragraph address of physical main memory (=base in real mode).

Note also that arch/segment.h can now be included in ASM .S files so SEL_KDATA etc can be used directly in segment.h, rather than hard-coded constants matching the seg286.h header file. Adding `#ifndef __ASSEMBLER__` to seg286.h around the C code will allow it to be included in arch/segment.h and also then included in ASM files.

Thank you!