### PR TITLE
[kernel] Implement 286 protected-mode kernel (CONFIG_286_PMODE)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Kernel config files are parsed by shell/awk build tooling that anchors on
+# LF; keep them LF in the working tree even when core.autocrlf is set (Windows).
+*.config text eol=lf

--- a/PMODE-TODO.md
+++ b/PMODE-TODO.md
@@ -1,0 +1,84 @@
+# 286 protected-mode port — backlog
+
+Status: full multi-user works on QEMU/KVM — boot → directfd DMA → FAT root →
+init → /etc/rc.sys → getty → login → shell; meminfo/ps/uptime/uname/df/date
+work. Proven on both the full (far-text) config and a trimmed 55K
+single-segment (far-text-off) kernel. All userland currently runs at ring 0.
+
+## Bugs / broken
+
+- ~~Shell pipes wedge the shell~~ FIXED upstream (PR #2719, merged): not
+  pipes at all — serfast.S read UART_RX before checking LSR_DR, so QEMU's
+  spurious serial IRQs queued a NUL into the tty input, and ash silently
+  discarded the poisoned next command line. Entry guard added, matching the
+  C handler. Confirmed on stock real-mode ELKS (not a PM-port artifact);
+  the fix now arrives via upstream master.
+- ~~telnetd faults EXC=0005 at startup~~ RESOLVED: another fragmentation-era
+  phantom — the pty driver needed no PM fix at all. With CONFIG_PSEUDO_TTY
+  enabled, **telnet login into 286 PM works end-to-end** (client → QEMU
+  hostfwd → ne2k → ktcp → telnetd → pty → login → shell) on the small
+  single-segment kernel (text 60624). The original roadmap goal is complete.
+
+## Degraded / deferred
+
+- **ps COMMAND column: blank or kernel-string garbage.** Cmdline reads pack
+  another process's SS as (seg<<4)+off — not invertible with selectors. The
+  kmem_read bounds check (16ad9d65) rejects positions outside the
+  (KERNEL_DS<<4)+64K window, but with KERNEL_DS=0x10 the window starts at
+  linear 0x100, so many selector-packed positions land INSIDE it and read
+  valid-but-wrong kernel data — pty-session processes' SPs collide, so ps
+  prints kernel rodata strings as COMMAND (cosmetic; system unaffected).
+  Real fix: selector-aware /dev/kmem protocol (e.g. ioctl taking selector +
+  offset) + rebuilt ps — blocked on userland rebuilds.
+- ~~Userland cannot be rebuilt~~ FIXED: `make -C libc all && make -C libc
+  install DESTDIR=/usr` installs elkslibc into the PPA toolchain
+  (/usr/ia16-elf/lib/elkslibc) and provides the runtime specs that
+  `-melks-libc` needs; apps then build normally (verified: ps links and
+  runs). Unblocks: /proc-based ps rewrite, test programs, kmem protocol
+  work.
+- **procfs (CONFIG_PROC_FS) prototype landed** (41725883): /proc/uptime +
+  /proc/pid/{stat,cmd}, automounted, ~2.5K text, correct command names in
+  PM via kernel-side selector reads. Next: rewrite ps to read /proc
+  (kills the kmem COMMAND garbage + the struct-version coupling), then
+  the upstream design issue (user is raising it).
+- **Medium-model user executables** (FTEXT != 0): need CONFIG_EXEC_MMODEL +
+  selector-aware relocate() + a per-process second code descriptor. No known
+  binary on the image needs it; telnet path is all small-model.
+- **/bootopts not found** on hand-built images unless the file sits in the
+  first 8 root directory entries (setup.S scans only those). mkimg.sh omits
+  /bootopts; defaults work. Robust fix: read /bootopts post-root-mount.
+
+## Design debt
+
+- **Ring 3 / protection.** Everything runs at DPL0, so PM currently adds no
+  memory protection. Needs DESC_U* descriptors, a TSS for the ring3→ring0
+  stack switch, and _irqit/restore_regs rework for the hardware ring switch.
+- **Extended memory (>1MB).** XMS group is disabled; kernel uses only the
+  639K conventional pool (it is tight: kstack bump once OOM'd buffer_init).
+  On 286, >1MB access in PM is natural via descriptors — a PM-native buffer
+  cache above 1MB would relieve the main pool.
+- **#ifdef reduction / upstream convergence** (ghaerr, issue #2718): replace
+  raw CONFIG_286_PMODE ifdefs with mainline-friendly abstractions in the
+  KERNEL_DS/BIOSSEG/VIDEOSEG style. Done so far: KERNEL_CS/KERNEL_DS in
+  mem.c. Audit remaining ifdef sites.
+- **.farinit.init reclaim in small model:** INITPROC is empty with far text
+  off, so boot-only code stays resident (~7K). Could add a dedicated near
+  .text.init section + linker brackets + seg_add, same as far text does.
+
+## Tooling / process
+
+- **mkimg.sh lives only inside the `elks` container** (/work/mkimg.sh):
+  fresh-image build + hard fail if /linux is fragmented. Consider committing
+  it to the repo and re-deploying on container rebuild.
+  Never quick-update ::/linux in a populated image — the FAT boot sector
+  loads consecutive sectors from the first cluster only; a fragmented kernel
+  boots with a silently corrupted .data tail (cost a full day to diagnose).
+- **Testing breadth:** only QEMU/KVM so far. pcem/86Box (real 286 timing) and
+  real hardware untested. ghaerr tests with pcem; slow boot reported.
+
+## Someday / vision
+
+- sbase userland + C99 compiler work on a 286 Unix (the original motivation —
+  8086 segmentation memory limits make this impossible without PM).
+- Upstream-visible fork maintenance: keep rebasing on mainline ELKS, publish
+  images, find users (per the issue #2718 discussion).

--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -48,6 +48,9 @@ _start:
         mov     %ax,%ss         // SS=ES=DS
         mov     $istack,%sp
 
+#ifdef CONFIG_286_PMODE
+        call    gdt_init        // build GDT and enter protected mode (no return to real mode)
+#endif
         call    start_kernel    // no return
 
 #if defined(CONFIG_ARCH_SWAN)
@@ -83,6 +86,14 @@ early_putchar:
         ret
 #elif defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_8018X)
 early_putchar:
+#ifdef CONFIG_286_PMODE
+        // protected mode: BIOS INT 10h is the #MF gate, not video -- write COM1
+        // via pm_putc_ser (lib/pm_enter.S), which takes the char in AL
+        mov   %sp,%bx
+        mov   2(%bx),%al        // char (cdecl: [ret][char])
+        call  pm_putc_ser
+        ret
+#else
         mov   %sp,%bx
         mov   2(%bx),%al
         mov   $0x0E,%ah
@@ -91,6 +102,7 @@ early_putchar:
         int   $0x10
         pop   %bp
         ret
+#endif
 #endif
 
 //      Segment beginnings

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -755,6 +755,24 @@ relocat:
 
 	mov -22(%bp),%ax   // kernel .data segment
 3:
+#ifdef CONFIG_286_PMODE
+	// PM: the branches above computed a real-mode paragraph; replace it with the
+	// matching GDT selector (KCODE/KFTEXT/KDATA) so the kernel's far refs resolve
+	// in protected mode.  %si still points at the relocation record (symndx at 4).
+	mov 4(%si),%ax            // r_symndx
+	cmp $-2,%ax               // S_TEXT
+	jne pmrel_1
+	mov $0x08,%ax             // -> SEL_KCODE
+	jmp pmrel_done
+pmrel_1:
+	cmp $-5,%ax               // S_FTEXT
+	jne pmrel_2
+	mov $0x18,%ax             // -> SEL_KFTEXT
+	jmp pmrel_done
+pmrel_2:
+	mov $0x10,%ax             // S_DATA -> SEL_KDATA
+pmrel_done:
+#endif
 	mov %ax,%es:(%di)
 
 	.if debug_loader

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -96,6 +96,7 @@
 #include <arch/io.h>
 #include <arch/irq.h>
 #include <arch/segment.h>
+#include <arch/seg286.h>
 #include <arch/ports.h>
 
 #define MAJOR_NR        FLOPPY_MAJOR
@@ -1453,7 +1454,9 @@ static void DFPROC floppy_deregister(void)
     outb(0x0c, FD_DOR);         /* all motors off, enable IRQ and DMA */
     clr_irq();
     free_irq(FLOPPY_IRQ);
+#ifndef CONFIG_286_PMODE    /* PM: IRQ via IDT; don't touch the real-mode IVT at seg 0 */
     *(__u32 __far *)FLOPPY_VEC = old_floppy_vec;
+#endif
     enable_irq(FLOPPY_IRQ);
     set_irq();
 }
@@ -1504,7 +1507,9 @@ static int DFPROC floppy_register(void)
     current_DOR = 0x0c;
     outb(0x0c, FD_DOR);         /* all motors off, enable IRQ and DMA */
 
+#ifndef CONFIG_286_PMODE    /* PM: floppy IRQ via IDT; real-mode IVT (seg 0) unusable, stays 0 */
     old_floppy_vec = *((__u32 __far *)FLOPPY_VEC);
+#endif
     err = request_irq(FLOPPY_IRQ, floppy_interrupt, INT_GENERIC);
     if (err) {
         printk("df: IRQ %d busy\n", FLOPPY_IRQ);

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -28,6 +28,9 @@
 
 #include <arch/io.h>
 #include <arch/segment.h>
+#ifdef CONFIG_286_PMODE
+#include <arch/seg286.h>
+#endif
 
 #define DEV_MEM_MINOR           1       /* unused */
 #define DEV_KMEM_MINOR          2
@@ -67,35 +70,37 @@ static size_t zero_read(struct inode *inode, struct file *filp, char *data, size
 
 /*
  * /dev/kmem code
+ *
+ * f_pos carries a seg:off far pointer -- segment in the high word, offset in the
+ * low word -- rather than a linear (seg<<4)+off address, so the segment reaches
+ * the kernel intact.  fmemcpyb reads it as a GDT selector in 286 protected mode
+ * and as a paragraph in real mode, so both kernel data (KERNEL_DS:off) and
+ * another process's memory (SS:off, e.g. ps reading argv) are reachable through
+ * one path in both models.  Userland (ps/meminfo) packs the matching layout.
  */
-#ifdef CONFIG_286_PMODE
-/* Userland seeks to LINEARADDRESS(off, seg) = (seg << 4) + off, where seg came
- * from MEM_GETDS -- in PM that is the KERNEL_DS selector, so the packing is not
- * a physical address and (pos >> 4) does not reconstruct a loadable segment.
- * Undo the known composition instead: strip the (KERNEL_DS << 4) bias and access
- * the kernel data segment via its selector. Reads composed with other segment
- * values (e.g. a process's SS from its task struct) are not supported in PM. */
-#define KMEM_SEG(pos)   KERNEL_DS
-#define KMEM_OFF(pos)   ((segext_t)((pos) - ((unsigned long)KERNEL_DS << 4)))
-/* only positions inside that window decode to real kernel data; anything else
- * (e.g. ps packing another process's SS) would silently read the wrong bytes */
-#define KMEM_VALID(pos, len) \
-    ((pos) >= ((unsigned long)KERNEL_DS << 4) && \
-     (pos) - ((unsigned long)KERNEL_DS << 4) + (len) <= 0x10000UL)
-#else
-#define KMEM_SEG(pos)   ((seg_t)((unsigned long)(pos) >> 4))
-#define KMEM_OFF(pos)   ((segext_t)((pos) & 0x0F))
-#define KMEM_VALID(pos, len)    1
-#endif
+#define KMEM_SEG(pos)   ((seg_t)((unsigned long)(pos) >> 16))
+#define KMEM_OFF(pos)   ((segext_t)((unsigned long)(pos) & 0xFFFF))
 
 static size_t kmem_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     seg_t sseg = KMEM_SEG(filp->f_pos);
     segext_t soff = KMEM_OFF(filp->f_pos);
+    size_t nread = len;
 
-    if (!KMEM_VALID(filp->f_pos, (unsigned long)len))
-        return -EFAULT;
-    fmemcpyb((byte_t *)data, current->t_regs.ds, (byte_t *)soff, sseg, (word_t) len);
+#ifdef CONFIG_286_PMODE
+    /* PM segments have a hard descriptor limit; a fixed-size reader (e.g. ps
+     * reading an argv string near the top of a process's stack) can overshoot
+     * it and #GP.  Read only up to the limit and zero-fill the rest, so a caller
+     * that needs an exact-size read still gets a NUL-terminated buffer. */
+    word_t lim = desc_limit(sseg);              /* max valid byte offset */
+    if (soff > lim || (word_t)(len - 1) > (word_t)(lim - soff)) {
+        word_t avail = (soff > lim) ? 0 : (word_t)(lim - soff + 1);
+        fmemsetb((char *)data + avail, current->t_regs.ds, 0, (word_t)(len - avail));
+        nread = avail;
+    }
+#endif
+    if (nread)
+        fmemcpyb((byte_t *)data, current->t_regs.ds, (byte_t *)soff, sseg, (word_t)nread);
     filp->f_pos += len;
     return len;
 }
@@ -105,8 +110,6 @@ static size_t kmem_write(struct inode *inode, struct file *filp, char *data, siz
     seg_t dseg = KMEM_SEG(filp->f_pos);
     segext_t doff = KMEM_OFF(filp->f_pos);
 
-    if (!KMEM_VALID(filp->f_pos, (unsigned long)len))
-        return -EFAULT;
     /* FIXME: very dangerous! */
     fmemcpyb((byte_t *)doff, dseg, (byte_t *)data, current->t_regs.ds, (word_t) len);
     filp->f_pos += len;

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -68,11 +68,33 @@ static size_t zero_read(struct inode *inode, struct file *filp, char *data, size
 /*
  * /dev/kmem code
  */
+#ifdef CONFIG_286_PMODE
+/* Userland seeks to LINEARADDRESS(off, seg) = (seg << 4) + off, where seg came
+ * from MEM_GETDS -- in PM that is the KERNEL_DS selector, so the packing is not
+ * a physical address and (pos >> 4) does not reconstruct a loadable segment.
+ * Undo the known composition instead: strip the (KERNEL_DS << 4) bias and access
+ * the kernel data segment via its selector. Reads composed with other segment
+ * values (e.g. a process's SS from its task struct) are not supported in PM. */
+#define KMEM_SEG(pos)   KERNEL_DS
+#define KMEM_OFF(pos)   ((segext_t)((pos) - ((unsigned long)KERNEL_DS << 4)))
+/* only positions inside that window decode to real kernel data; anything else
+ * (e.g. ps packing another process's SS) would silently read the wrong bytes */
+#define KMEM_VALID(pos, len) \
+    ((pos) >= ((unsigned long)KERNEL_DS << 4) && \
+     (pos) - ((unsigned long)KERNEL_DS << 4) + (len) <= 0x10000UL)
+#else
+#define KMEM_SEG(pos)   ((seg_t)((unsigned long)(pos) >> 4))
+#define KMEM_OFF(pos)   ((segext_t)((pos) & 0x0F))
+#define KMEM_VALID(pos, len)    1
+#endif
+
 static size_t kmem_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
-    seg_t sseg = (unsigned long)filp->f_pos >> 4;
-    segext_t soff = filp->f_pos & 0x0F;
+    seg_t sseg = KMEM_SEG(filp->f_pos);
+    segext_t soff = KMEM_OFF(filp->f_pos);
 
+    if (!KMEM_VALID(filp->f_pos, (unsigned long)len))
+        return -EFAULT;
     fmemcpyb((byte_t *)data, current->t_regs.ds, (byte_t *)soff, sseg, (word_t) len);
     filp->f_pos += len;
     return len;
@@ -80,9 +102,11 @@ static size_t kmem_read(struct inode *inode, struct file *filp, char *data, size
 
 static size_t kmem_write(struct inode *inode, struct file *filp, char *data, size_t len)
 {
-    seg_t dseg = (unsigned long)filp->f_pos >> 4;
-    segext_t doff = filp->f_pos & 0x0F;
+    seg_t dseg = KMEM_SEG(filp->f_pos);
+    segext_t doff = KMEM_OFF(filp->f_pos);
 
+    if (!KMEM_VALID(filp->f_pos, (unsigned long)len))
+        return -EFAULT;
     /* FIXME: very dangerous! */
     fmemcpyb((byte_t *)doff, dseg, (byte_t *)data, current->t_regs.ds, (word_t) len);
     filp->f_pos += len;

--- a/elks/arch/i86/drivers/char/serfast.S
+++ b/elks/arch/i86/drivers/char/serfast.S
@@ -55,7 +55,12 @@ common_entry:
         // Recover kernel data segment
         // Was pushed by the CALLF of the dynamic handler
         mov     %sp,%bx
+#ifdef CONFIG_286_PMODE
+        mov     $0x10, %ax              // SEL_KDATA (writable); CALLF-saved CS is read-only SEL_KDATA_EXEC
+        mov     %ax, %ds
+#else
         mov     %ss:12(%bx),%ds
+#endif
 
         // translated C routine above
         // NOTE: uses hard-coded offsets from struct serial_info, tty and ch_queue

--- a/elks/arch/i86/kernel/irq-8259.c
+++ b/elks/arch/i86/kernel/irq-8259.c
@@ -22,6 +22,20 @@
 
 void initialize_irq(void)
 {
+#ifdef CONFIG_286_PMODE
+    /* In protected mode the BIOS-programmed PIC (IRQ0-7 -> INT 0x08-0x0F) collides
+     * with the CPU exception vectors.  Reprogram the 8259s: IRQ0-15 -> INT 0x20-0x2F. */
+    outb(0x11, PIC1_CMD);       /* ICW1: cascade, edge-triggered, ICW4 to follow */
+    outb(0x11, PIC2_CMD);
+    outb(0x20, PIC1_DATA);      /* ICW2: master vector base = 0x20 */
+    outb(0x28, PIC2_DATA);      /* ICW2: slave  vector base = 0x28 */
+    outb(0x04, PIC1_DATA);      /* ICW3: slave is attached to master IRQ2 */
+    outb(0x02, PIC2_DATA);      /* ICW3: slave cascade identity = 2 */
+    outb(0x01, PIC1_DATA);      /* ICW4: 8086/88 mode */
+    outb(0x01, PIC2_DATA);
+    outb(0xFB, PIC1_DATA);      /* mask all master IRQs except IRQ2 (cascade) */
+    outb(0xFF, PIC2_DATA);      /* mask all slave IRQs; enable_irq() unmasks on request */
+#endif
 #if NOTNEEDED   /* not needed on IBM PC as BIOS initializes IRQ 2 */
     if (sys_caps & CAP_IRQ2MAP9) {      /* PC/AT or greater */
         save_flags(flags);
@@ -61,7 +75,10 @@ int remap_irq(int irq)
 
 int irq_vector (int irq)
 {
-#ifdef CONFIG_ARCH_PC98
+#ifdef CONFIG_286_PMODE
+        // PM: PIC remapped above the CPU exceptions -> IRQ 0-15 = INT 0x20-0x2F
+        return irq + 0x20;
+#elif defined(CONFIG_ARCH_PC98)
         // IRQ 0-7  are mapped to vectors INT 08h-0Fh
         // IRQ 8-15 are mapped to vectors INT 10h-17h
 

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -26,6 +26,7 @@
 #include <arch/irq.h>
 #include <arch/ports.h>
 #include <arch/segment.h>
+#include <arch/seg286.h>
 
 /*
  * Irq index numbers >= 16 are used for hardware exceptions or syscall.
@@ -61,7 +62,12 @@ static void int_handler_add(int irq, int vect, int_proc proc)
     h->proc = (word_t)proc;
     h->seg  = KERNEL_CS;    /* resident kernel code segment */
     h->irq  = irq;
+#ifdef CONFIG_286_PMODE
+    /* IDT gate runs the trampoline via the data-as-code alias (trampoline[] is data) */
+    idt_gate_set(vect, (word_t)h, SEL_KDATA_EXEC, GATE_INT286);
+#else
     int_vector_set(vect, (word_t)h, kernel_ds);
+#endif
 }
 
 /* request an IRQ from 0 to 15 */
@@ -153,7 +159,9 @@ void INITPROC irq_init(void)
 #else /* normal IRQ 0 timer */
     initialize_irq();           /* IRQ and/or PIC initialization */
     disable_timer_tick();       /* not needed on IBM PC as IRQ 0 vector untouched */
-    save_timer_irq();           /* save original BIOS IRQ 0 vector */
+#ifndef CONFIG_286_PMODE
+    save_timer_irq();           /* save BIOS IRQ 0 vector (reads IVT via ES=0; PM uses IDT) */
+#endif
 
     /* Connect timer interrupt handler to hardware IRQ 0 */
     if (request_irq(TIMER_IRQ, timer_tick, INT_GENERIC))

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -5,7 +5,11 @@
 #include <arch/ports.h>
 #include <arch/irq.h>
 
+#ifdef CONFIG_286_PMODE
+        .arch   i286, nojumps   // PM build: 286 superset (push imm); 8086 code unaffected
+#else
         .arch   i8086, nojumps
+#endif
         .code16
         .text
 
@@ -69,7 +73,12 @@ _irqit:
 //      TODO: BP is better for stack work
 //
         mov     %sp,%si
+#ifdef CONFIG_286_PMODE
+        push    $0x10           // PM: SEL_KDATA (trampoline return-CS is the code alias, not usable as DS)
+        pop     %ds
+#else
         mov     %ss:8(%si),%ds
+#endif
 //
 //      Determine which stack to use
 //
@@ -120,6 +129,10 @@ save_regs:
         pop     8(%si)          // DS
         pop     %di             // Return offset is actually a pointer to the IRQ number
         pop     %ds             // Return segment of the dynamic handler = kernel DS
+#ifdef CONFIG_286_PMODE
+        push    $0x10           // PM: force DS = SEL_KDATA (popped return-CS is the code alias)
+        pop     %ds
+#endif
         push    %bp             // BP
         mov     %sp,10(%si)     // SP
         mov     %ss,12(%si)     // SS
@@ -212,7 +225,7 @@ doirq:
         jz      was_trap
 #endif
 
-#if defined(CONFIG_BLK_DEV_BFD) && !defined(CONFIG_ARCH_PC98)
+#if defined(CONFIG_BLK_DEV_BFD) && !defined(CONFIG_ARCH_PC98) && !defined(CONFIG_286_PMODE)
         or      %ax,%ax         // Is int #0?
         jnz     do_eoi
 //

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -10,6 +10,7 @@
 #include <linuxmt/init.h>
 
 #include <arch/segment.h>
+#include <arch/seg286.h>
 
 static char *args[] = {
 (char *)0x01,   /* 0 argc     */

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -48,6 +48,10 @@ else
 SRCS1 += bios13-ibm.S bios15-ibm.S unreal.S loadall.S
 endif
 
+ifeq ($(CONFIG_286_PMODE), y)
+SRCS1 += pm_enter.S             # 286 PM mode-switch + fault stubs (near text)
+endif
+
 OBJS1 = $(SRCS1:.S=.o)
 
 # Non-precompiled assembly

--- a/elks/arch/i86/lib/pm_enter.S
+++ b/elks/arch/i86/lib/pm_enter.S
@@ -1,0 +1,172 @@
+#include <linuxmt/config.h>
+/*
+ * 80286 real -> protected mode switch.  (phase 4 of the 286 HAL)
+ *
+ * Called once from crt0.S (CONFIG_286_PMODE) after kernel_cs/kernel_ds are
+ * saved and the temporary stack is set, just before start_kernel.  The GDT
+ * has already been filled by gdt_init() (pm286.c), which passes the lgdt/lidt
+ * operands.  Kernel selectors (see <arch/seg286.h>):
+ *     0x08 = GDT[1] kernel code, base = kernel_cs << 4
+ *     0x10 = GDT[2] kernel data, base = kernel_ds << 4
+ * Both bases equal the kernel's real-mode segments, so the same offsets resolve
+ * to the same physical addresses across the switch (CS:IP and SS:SP stay valid).
+ *
+ * NOTE: enters PM with interrupts OFF.  gdt_init() has filled the IDT (phase 5a):
+ * every vector points at pm_fault_stub (report on COM1 + halt) until irq_init()
+ * installs the real IRQ/syscall handlers (phase 5b).  ftext has its own descriptor
+ * and far-call selectors (phase 4b).
+ */
+#ifdef CONFIG_286_PMODE
+        .arch   i286, nojumps
+        .code16
+        .text
+        .global pm_switch
+
+// void pm_switch(struct dtr *gdtr, struct dtr *idtr);   /* near cdecl */
+pm_switch:
+        push    %bp
+        mov     %sp,%bp
+        cli                     // no interrupts during the transition
+
+        mov     4(%bp),%bx      // bx -> gdtr { word limit; long base }
+        lgdt    (%bx)
+        mov     6(%bp),%bx      // bx -> idtr (empty for now)
+        lidt    (%bx)
+
+        smsw    %ax             // 286: enter PM via LMSW (no mov-to-CR0)
+        or      $1,%ax          // set PE
+        lmsw    %ax             // *** now in protected mode ***
+
+        ljmp    $0x08,$pm_cs    // load CS = kernel code selector, flush prefetch
+pm_cs:
+        mov     $0x10,%ax       // kernel data selector
+        mov     %ax,%ds
+        mov     %ax,%es
+        mov     %ax,%ss         // SS base = kernel_ds<<4 (same phys as real-mode SS)
+
+        mov     $'P',%al        // bring-up: signal successful PM entry on COM1
+        call    pm_putc_ser
+
+        pop     %bp
+        ret                     // return (in PM) to gdt_init -> crt0 -> start_kernel
+
+// ---- exception/fault catch + reporter (phase 8 bring-up) ----
+// gdt_init() points IDT 0..31 at pm_flt_base + vec*8 and 32..255 at pm_flt_other.
+// Each stub pushes its vector then jumps to the common reporter, which prints
+// "EXC=<vec>-<w0>-<w1>-<w2>-<w3>" (vector + top stack words) on COM1 and halts.
+// From <vec> = which exception; from the words = faulting CS:IP (CS is a known
+// selector 0008/0010/0018), shifted one word if an error code was pushed
+// (#DF=8 #TS=10 #NP=11 #SS=12 #GP=13).
+        .balign 8
+        .global pm_flt_base
+pm_flt_base:
+        .set    fltv, 0
+        .rept   32
+        pushw   $fltv
+        jmp     pm_fault_common
+        .balign 8, 0x90                 // each stub occupies an 8-byte slot
+        .set    fltv, fltv + 1
+        .endr
+
+        .global pm_flt_other
+pm_flt_other:
+        pushw   $0x00FF                 // marker: vector >= 32 (shouldn't fire pre-irq_init)
+        jmp     pm_fault_common
+
+pm_fault_common:
+        cli
+        mov     %sp,%bp                 // bp -> [vec][..][IP][CS][FLAGS] (SS-relative)
+        mov     $0x0d,%al
+        call    pm_putc_ser
+        mov     $0x0a,%al
+        call    pm_putc_ser
+        mov     $'E',%al
+        call    pm_putc_ser
+        mov     $'X',%al
+        call    pm_putc_ser
+        mov     $'C',%al
+        call    pm_putc_ser
+        mov     $'=',%al
+        call    pm_putc_ser
+        movw    (%bp),%ax               // vector
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    2(%bp),%ax
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    4(%bp),%ax
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    6(%bp),%ax
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    8(%bp),%ax
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    10(%bp),%ax     // (for fmemcpyb: caller return address)
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    12(%bp),%ax
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    14(%bp),%ax
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    16(%bp),%ax
+        call    pm_puthex
+        mov     $'-',%al
+        call    pm_putc_ser
+        movw    18(%bp),%ax
+        call    pm_puthex
+        mov     $0x0d,%al
+        call    pm_putc_ser
+        mov     $0x0a,%al
+        call    pm_putc_ser
+9:      hlt
+        jmp     9b
+
+// AX -> 4 hex digits on COM1 (high nibble first)
+pm_puthex:
+        push    %cx
+        push    %bx
+        mov     %ax,%bx
+        mov     $4,%cx
+1:      rol     $4,%bx
+        mov     %bx,%ax
+        and     $0x0f,%ax
+        cmp     $10,%ax
+        jb      2f
+        add     $7,%ax
+2:      add     $0x30,%ax
+        call    pm_putc_ser
+        loop    1b
+        pop     %bx
+        pop     %cx
+        ret
+
+// AL = char -> COM1 THR (0x3F8), polled.  PM ring0 port I/O; clobbers nothing.
+// Also called from crt0.S early_putchar in PM.
+        .global pm_putc_ser
+pm_putc_ser:
+        push    %ax
+        push    %dx
+        mov     %al,%ah
+8:      mov     $0x3FD,%dx      // LSR
+        inb     %dx,%al
+        test    $0x20,%al       // THR empty?
+        jz      8b
+        mov     $0x3F8,%dx      // THR
+        mov     %ah,%al
+        outb    %al,%dx
+        pop     %dx
+        pop     %ax
+        ret
+#endif

--- a/elks/arch/i86/mm/Makefile
+++ b/elks/arch/i86/mm/Makefile
@@ -37,6 +37,10 @@ include $(BASEDIR)/Makefile-rules
 
 OBJS  = malloc.o user.o memcpyfs.o xms.o
 
+ifeq ($(CONFIG_286_PMODE), y)
+OBJS += pm286.o
+endif
+
 #########################################################################
 # Commands.
 

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -12,6 +12,33 @@
 #include <linuxmt/heap.h>
 
 #include <arch/segment.h>
+#include <arch/seg286.h>
+
+#ifdef CONFIG_286_PMODE
+/* 286 protected mode (ghaerr's convention): the arena manages the physical
+ * paragraph in segment_s.para (BASE() macro); every USED segment also gets a
+ * GDT descriptor whose selector becomes segment_s.base -- the value the kernel
+ * hands out externally via ->base and loads into a segment register. */
+static byte_t seg_pm_access(word_t type)
+{
+    /* ring-0 user (phase 6): DPL0 code/data selectors.  Running user code at DPL3
+     * (DESC_UCODE/UDATA) gives real protection but needs a TSS for the ring3->ring0
+     * interrupt stack switch -- deferred to the protection phase. */
+    return ((type & SEG_FLAG_TYPE) == SEG_FLAG_CSEG) ? DESC_KCODE : DESC_KDATA;
+}
+static int seg_pm_attach(segment_s *seg, word_t type)
+{
+    seg->base = desc_alloc(PARA_BYTES(seg->para), seg->size, seg_pm_access(type));
+    return seg->base ? 0 : -1;      /* selector 0 => GDT full */
+}
+static void seg_pm_detach(segment_s *seg)
+{
+    if (seg->base) { desc_free(seg->base); seg->base = 0; }
+}
+#else
+#define seg_pm_attach(seg, type)    0
+#define seg_pm_detach(seg)          ((void)0)
+#endif
 
 #ifdef CONFIG_286_PMODE
 /* PM must use additional 'para' member seperately from
@@ -137,6 +164,10 @@ segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
     seg->size = size;
     seg->flags = SEG_FLAG_USED | type;
     seg->ref_count = 1;
+    if (seg_pm_attach(seg, type)) {     /* PM: attach descriptor */
+        heap_free(seg);
+        return 0;
+    }
     return seg;
 }
 
@@ -151,6 +182,10 @@ segment_s * seg_alloc (segext_t size, word_t type)
     seg = seg_free_get (size, type);
     if (seg && (type & SEG_FLAG_ALIGN1K))
         BASE(seg) += ((~BASE(seg) + 1) & ((1024 >> 4) - 1));
+    if (seg && seg_pm_attach(seg, type)) {  /* PM: attach descriptor (no-op in real mode) */
+        seg_free(seg);
+        seg = 0;
+    }
     return seg;
 }
 
@@ -159,6 +194,7 @@ segment_s * seg_alloc (segext_t size, word_t type)
 
 void seg_free (segment_s * seg)
 {
+    seg_pm_detach(seg);     /* PM: release GDT descriptor (no-op in real mode) */
 #ifdef CONFIG_ROMFS_FS
     // Handle segments created outside of the memory allocator
     // (via seg_alloc_fixed).
@@ -232,8 +268,10 @@ void seg_put (segment_s * seg)
 segment_s * seg_dup (segment_s * src)
 {
     segment_s * dst = seg_free_get (src->size, src->flags);
-    if (dst)
+    if (dst) {
+        if (seg_pm_attach(dst, src->flags)) { seg_free(dst); return 0; }
         fmemcpyw(0, dst->base, 0, src->base, src->size << 3);
+    }
     return dst;
 }
 

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -1,0 +1,175 @@
+/*
+ * 80286 protected-mode descriptor allocator -- the seg_alloc() backend
+ * for CONFIG_286_PMODE.  See <arch/seg286.h> for the overall design.
+ *
+ * Real-mode builds do not compile this file; seg_alloc() returns paragraphs.
+ * In PM, seg_alloc() reserves physical paragraphs from the existing arena as
+ * usual, then calls desc_alloc(phys_base, paras, DESC_*) and stores the
+ * returned SELECTOR in segment_s.base.  The far-memory primitives then load
+ * that selector into a segment register and the 286 resolves it via the GDT.
+ */
+#include <linuxmt/config.h>
+#include <linuxmt/types.h>
+#include <linuxmt/kernel.h>
+#include <arch/seg286.h>
+
+#ifdef CONFIG_286_PMODE
+
+/*
+ * Config validation: protected mode cannot call the BIOS (real-mode IVT/
+ * services are gone after PM entry), so any BIOS-backed driver selected in
+ * .config would build fine and then fault at runtime with a raw EXC= dump.
+ * Fail the compile instead, naming the required change.
+ */
+#if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD)
+#error 286 PM: BIOS disk (BFD/BHD, int 0x13) cannot work - disable both, use CONFIG_BLK_DEV_FD (directfd) with root=df0
+#endif
+#ifdef CONFIG_CONSOLE_BIOS
+#error 286 PM: BIOS console (int 0x10) cannot work - use CONFIG_CONSOLE_DIRECT or CONFIG_CONSOLE_SERIAL
+#endif
+#if defined(CONFIG_ARCH_IBMPC) && !defined(CONFIG_KEYBOARD_SCANCODE)
+#error 286 PM: without CONFIG_KEYBOARD_SCANCODE the IBMPC build links kbd-poll/conio-bios (int 0x16) - enable it
+#endif
+#if defined(CONFIG_FS_XMS) || defined(CONFIG_FS_XMS_BUFFER) || defined(CONFIG_FS_XMS_RAMDISK)
+#error 286 PM: XMS/unreal-mode paths are not ported - disable the CONFIG_FS_XMS* group
+#endif
+
+/* The Global Descriptor Table (4 KB, in the kernel data segment).
+ * GDT_KCODE/KDATA are the kernel's own segments; GDT_FIRST_DYN..end are
+ * handed out by desc_alloc() for process/buffer segments. */
+static gdt_entry_t gdt[GDT_ENTRIES];
+
+/* round-robin hint for the next candidate free slot */
+static unsigned int next_dyn = GDT_FIRST_DYN;
+
+/* lgdt/lidt operand: 16-bit limit + linear base (286 uses low 24 bits) */
+struct dtr { word_t limit; addr_t base; };
+
+extern word_t kernel_cs, kernel_ds;     /* saved by crt0.S */
+extern word_t _endtext, _endftext;      /* kernel .text / .fartext byte sizes (crt0.S) */
+void pm_switch(struct dtr *gdtr, struct dtr *idtr);     /* arch/i86/lib/pm_enter.S */
+
+void desc_set(unsigned int sel, addr_t base, segext_t paras, byte_t access)
+{
+    gdt_entry_t *d = &gdt[SEL_INDEX(sel)];
+    addr_t limit = PARA_BYTES(paras);
+
+    if (limit == 0 || limit > 0x10000L)     /* a 286 segment is <= 64 KB */
+        limit = 0x10000L;
+    d->limit    = (word_t)(limit - 1);      /* limit is bytes-1 */
+    d->base_lo  = (word_t)(base & 0xFFFF);
+    d->base_hi  = (byte_t)((base >> 16) & 0xFF);
+    d->access   = access;
+    d->reserved = 0;                        /* must be 0 on a 286 */
+}
+
+/* change only the access byte (base/limit kept) -- exec flips its text seg
+ * data(writable, to load) -> code(executable, to run) */
+void desc_chaccess(unsigned int sel, byte_t access)
+{
+    gdt[SEL_INDEX(sel)].access = access;
+}
+
+/* find a free GDT slot, fill it, return its selector (0 = table full) */
+unsigned int desc_alloc(addr_t base, segext_t paras, byte_t access)
+{
+    unsigned int i = next_dyn, scanned;
+
+    for (scanned = 0; scanned < GDT_ENTRIES - GDT_FIRST_DYN; scanned++) {
+        if (!(gdt[i].access & DESC_PRESENT)) {          /* P=0 => free */
+            unsigned int sel = MK_SEL(i, SEL_GDT, SEL_RPL0);
+            desc_set(sel, base, paras, access);
+            next_dyn = (i + 1 < GDT_ENTRIES) ? i + 1 : GDT_FIRST_DYN;
+            return sel;
+        }
+        if (++i >= GDT_ENTRIES) i = GDT_FIRST_DYN;
+    }
+    return 0;                                            /* GDT full */
+}
+
+void desc_free(unsigned int sel)
+{
+    gdt[SEL_INDEX(sel)].access = 0;                      /* clear Present */
+}
+
+addr_t desc_base(unsigned int sel)
+{
+    gdt_entry_t *d = &gdt[SEL_INDEX(sel)];
+    return ((addr_t)d->base_hi << 16) | d->base_lo;
+}
+
+const void *gdt_table(void) { return gdt; }             /* for lgdt in boot asm */
+unsigned    gdt_limit(void) { return sizeof(gdt) - 1; }
+
+/* ---- Interrupt Descriptor Table (2 KB, in the kernel data segment) ---- */
+static idt_gate_t idt[256];
+extern char pm_flt_base[];              /* arch/i86/boot/pm_enter.S: 32 stubs, 8 bytes each */
+extern void pm_flt_other(void);         /* generic stub for vectors >= 32 */
+
+void idt_gate_set(unsigned int vect, word_t offset, word_t selector, byte_t access)
+{
+    idt_gate_t *g = &idt[vect];
+    g->offset   = offset;
+    g->selector = selector;
+    g->zero     = 0;
+    g->access   = access;
+    g->reserved = 0;
+}
+
+/* Point every vector at the fault-catch stub (in kernel code = SEL_KCODE) so an
+ * exception between PM entry and irq_init() is reported, not a triple fault.
+ * irq_init() later overwrites the live IRQ/syscall/INT0/INT2 vectors (phase 5b). */
+void idt_init(void)
+{
+    unsigned int v;
+    for (v = 0; v < 32; v++)            /* per-vector stubs so the reporter knows the vector */
+        idt_gate_set(v, (word_t)(pm_flt_base + v*8), SEL_KCODE, GATE_INT286);
+    for (v = 32; v < 256; v++)
+        idt_gate_set(v, (word_t)pm_flt_other, SEL_KCODE, GATE_INT286);
+}
+
+/* called once from crt0.S just before start_kernel: fill the kernel's own
+ * descriptors, build the GDTR/IDTR, then switch to protected mode.  Does not
+ * return to real mode. */
+void gdt_init(void)
+{
+    static struct dtr gdtr, idtr;
+    addr_t   code_base  = (addr_t)kernel_cs << 4;
+    addr_t   data_base  = (addr_t)kernel_ds << 4;
+    segext_t text_par   = BYTES_PARA(_endtext);
+    /* fartext is loaded immediately after text (non-HMA boot). */
+    addr_t   ftext_base = code_base + ((addr_t)text_par << 4);
+
+    /* phase 4b: separate descriptors for near text, far text and data.
+     * setup.S has patched the kernel's far-call/far-data segments to these
+     * selectors (SEL_KCODE/SEL_KFTEXT/SEL_KDATA) instead of paragraphs. */
+    desc_set(MK_SEL(GDT_NULL,   SEL_GDT, SEL_RPL0), 0,          0,                     0);
+    desc_set(MK_SEL(GDT_KCODE,  SEL_GDT, SEL_RPL0), code_base,  text_par,              DESC_KCODE);
+    desc_set(MK_SEL(GDT_KDATA,  SEL_GDT, SEL_RPL0), data_base,  0x1000,                DESC_KDATA);
+    desc_set(MK_SEL(GDT_KFTEXT, SEL_GDT, SEL_RPL0), ftext_base, BYTES_PARA(_endftext), DESC_KCODE);
+    /* same base/limit as KDATA but executable+readable: IRQ trampolines are built
+     * in the kernel data segment, and an IDT gate needs an executable selector. */
+    desc_set(MK_SEL(GDT_KDATA_EXEC, SEL_GDT, SEL_RPL0), data_base, 0x1000, DESC_KCODE);
+    /* boot setup data lives at the SEG_SETUP_DATA paragraph; setupb/setupw read it via
+     * SEL_SETUP in PM (a raw paragraph can't be loaded into a segment register). */
+    desc_set(MK_SEL(GDT_SETUP, SEL_GDT, SEL_RPL0), (addr_t)SEG_SETUP_DATA << 4, BYTES_PARA(512), DESC_KDATA);
+    /* boot options (/bootopts) area, copied once into the kernel during init */
+    desc_set(MK_SEL(GDT_OPTSEG, SEL_GDT, SEL_RPL0), (addr_t)DEF_OPTSEG << 4, 0x40, DESC_KDATA);
+    /* BIOS data area (real-mode seg 0x40, physical 0x400, 256 bytes) -- read by drivers */
+    desc_set(MK_SEL(GDT_BIOSDATA, SEL_GDT, SEL_RPL0), (addr_t)SEG_BIOSDATA << 4, BYTES_PARA(256), DESC_KDATA);
+    /* text video memory (real-mode seg 0xb800, physical 0xB8000) -- direct console */
+    desc_set(MK_SEL(GDT_VIDEO, SEL_GDT, SEL_RPL0), (addr_t)SEG_VIDEO << 4, 0x1000, DESC_KDATA);
+    /* directfd DMA/track buffer; base=SEG_TRACK<<4 (physical paragraph), far-mem copies in PM */
+    desc_set(MK_SEL(GDT_TRACK, SEL_GDT, SEL_RPL0), (addr_t)SEG_TRACK << 4, 0x200, DESC_KDATA);
+
+    idt_init();                 /* every vector -> fault-catch stub (until irq_init) */
+
+    gdtr.limit = (word_t)(sizeof(gdt) - 1);
+    gdtr.base  = data_base + (addr_t)(unsigned)&gdt;        /* linear addr of GDT */
+    idtr.limit = (word_t)(sizeof(idt) - 1);
+    idtr.base  = data_base + (addr_t)(unsigned)&idt;        /* linear addr of IDT */
+
+    pm_switch(&gdtr, &idtr);    /* enter PM; returns here in protected mode */
+}
+
+#endif /* CONFIG_286_PMODE */

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -98,6 +98,11 @@ addr_t desc_base(unsigned int sel)
     return ((addr_t)d->base_hi << 16) | d->base_lo;
 }
 
+word_t desc_limit(unsigned int sel)         /* max valid byte offset in the segment */
+{
+    return gdt[SEL_INDEX(sel)].limit;
+}
+
 const void *gdt_table(void) { return gdt; }             /* for lgdt in boot asm */
 unsigned    gdt_limit(void) { return sizeof(gdt) - 1; }
 

--- a/elks/config.in
+++ b/elks/config.in
@@ -19,6 +19,7 @@ mainmenu_option next_comment
 
 		bool 'Compaq DeskPro Hardware (fast mode)' CONFIG_HW_COMPAQFAST n
 		bool 'MK-88 Hardware (IRQ 3 keyboard)' CONFIG_HW_MK88 n
+		bool 'i286 protected mode (experimental)' CONFIG_286_PMODE n
 
 		comment 'Devices'
 

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -46,6 +46,7 @@
 #include <linuxmt/debug.h>
 #include <linuxmt/memory.h>
 #include <arch/segment.h>
+#include <arch/seg286.h>
 #pragma GCC diagnostic ignored "-Wunused-label"
 
 /* for relocation debugging change to printk */
@@ -385,6 +386,10 @@ static int FARPROC execve_aout(struct inode *inode, struct file *filp,
             paras, bytes);
         seg_code = seg_alloc(paras, SEG_FLAG_CSEG);
         if (!seg_code) goto error_exec3;
+#ifdef CONFIG_286_PMODE
+        /* text seg is a code selector (not writable in PM); make it writable to load */
+        desc_chaccess(seg_code->base, DESC_KDATA);
+#endif
         currentp->t_regs.ds = seg_code->base;
         retval = filp->f_op->read(inode, filp, 0, bytes);
         if (retval != bytes) {
@@ -497,6 +502,10 @@ static int FARPROC execve_aout(struct inode *inode, struct file *filp,
     currentp->t_begstack = (currentp->t_endseg - slen) & ~1; /* force even SP and argv */
     fmemcpyb((char *)currentp->t_begstack, seg_data->base, sptr, ds, slen);
 
+#ifdef CONFIG_286_PMODE
+    /* text fully loaded; restore executable access so seg_code can be used as CS */
+    desc_chaccess(seg_code->base, DESC_KCODE);
+#endif
     finalize_exec(inode, seg_code, seg_data, (word_t)mh.entry, 0);
     return 0;           /* success */
 

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -119,6 +119,9 @@ void   desc_free(unsigned int sel);
 /* recover the physical base behind a selector (for DMA, exec relocation, etc.) */
 addr_t desc_base(unsigned int sel);
 
+/* max valid byte offset in a selector's segment (its descriptor limit) */
+word_t desc_limit(unsigned int sel);
+
 /* IDT: zero the table + point every vector at the fault-catch stub (called from
  * gdt_init before entering PM); install one gate (used by the IRQ/syscall path). */
 void idt_init(void);

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -1,0 +1,129 @@
+#ifndef __ARCH_SEG286_H
+#define __ARCH_SEG286_H
+/*
+ * 80286 protected-mode segment HAL for ELKS        (gated by CONFIG_286_PMODE)
+ *
+ * Design
+ * ------
+ * The kernel's segment abstraction is ALREADY the HAL boundary:
+ *   - upper kernel (fs/, kernel/, net/) only ever holds an opaque seg_t and
+ *     passes it to the far-memory primitives (peekb/peekw/pokeb/pokew,
+ *     fmemcpyb/w, fmemsetb/w, fmemcmpb/w) and to seg_alloc()/segment_s.base.
+ *   - those primitives do "mov es,seg ; ... es:[off]". That instruction works
+ *     in BOTH real mode (es = paragraph, phys = es*16+off) AND protected mode
+ *     (es = selector, phys = descriptor[es].base + off) -- the CPU resolves it
+ *     per current mode. So the far-mem asm needs NO change.
+ *
+ * Therefore the 286-PM port is confined to three things, all below the HAL line:
+ *   1. seg_t now carries a SELECTOR (not a paragraph). segment_s.base = selector;
+ *      the physical base lives in the descriptor (desc_base() recovers it).
+ *   2. seg_alloc()/seg_free() allocate physical paragraphs as today, then also
+ *      allocate/free a GDT (or per-process LDT) descriptor and return its
+ *      selector in segment_s.base.  (arch/i86/mm/pm286.c)
+ *   3. boot sets up the GDT/IDT and enters protected mode; exec() loads
+ *      selectors into CS/DS/SS instead of paragraphs (it already goes through
+ *      seg_alloc + segment_s.base, so the change is small).
+ *
+ * Real-mode build (CONFIG_286_PMODE off) is unaffected: seg_t stays a paragraph
+ * and none of this header's code is compiled.
+ */
+
+#include <linuxmt/types.h>
+
+/* ---- 80286 segment descriptor: 8 bytes; high word MUST be 0 on a 286 ----
+ * (on a 386 the reserved word holds limit[16:19]+flags+base[24:31]; writing 0
+ *  there yields 286-equivalent semantics, so this layout is forward-compatible) */
+struct gdt_entry {
+    word_t  limit;          /* segment limit in bytes-1  (0..0xFFFF => <=64K)   */
+    word_t  base_lo;        /* physical base bits 0..15                          */
+    byte_t  base_hi;        /* physical base bits 16..23 (24-bit base => 16 MB)  */
+    byte_t  access;         /* P | DPL | S | type | A  (see DESC_* below)        */
+    word_t  reserved;       /* 0 on 286                                          */
+};
+typedef struct gdt_entry gdt_entry_t;
+
+/* access byte: bit7=Present 6-5=DPL 4=S(1=code/data) 3=E 2=C/ED 1=R/W 0=Accessed */
+#define DESC_PRESENT 0x80   /* P bit (set in every DESC_* below); 0 => free slot */
+#define DESC_KCODE  0x9A    /* present, DPL0, code, readable        */
+#define DESC_KDATA  0x92    /* present, DPL0, data, writable        */
+#define DESC_UCODE  0xFA    /* present, DPL3, code, readable        */
+#define DESC_UDATA  0xF2    /* present, DPL3, data, writable        */
+
+/* ---- 80286 interrupt/trap gate: 8 bytes (high word 0 on a 286) ---- */
+struct idt_gate {
+    word_t  offset;         /* handler offset within `selector`             */
+    word_t  selector;       /* code (or data-as-code) selector of handler   */
+    byte_t  zero;           /* always 0                                     */
+    byte_t  access;         /* P | DPL | gate type (GATE_* below)           */
+    word_t  reserved;       /* 0 on a 286                                   */
+};
+typedef struct idt_gate idt_gate_t;
+#define GATE_INT286   0x86  /* present, DPL0, 286 interrupt gate (clears IF) */
+#define GATE_TRAP286  0x87  /* present, DPL0, 286 trap gate (leaves IF)      */
+
+/* selector = (index << 3) | TI | RPL */
+#define SEL_RPL0    0x00
+#define SEL_RPL3    0x03
+#define SEL_GDT     0x00
+#define SEL_LDT     0x04
+#define MK_SEL(index, ti, rpl)  (((unsigned)(index) << 3) | (ti) | (rpl))
+#define SEL_INDEX(sel)          ((unsigned)(sel) >> 3)
+
+/* fixed GDT layout (kernel-private selectors) */
+#define GDT_NULL        0   /* required null descriptor          */
+#define GDT_KCODE       1   /* kernel CS  (near .text)           */
+#define GDT_KDATA       2   /* kernel DS = SS                    */
+#define GDT_KFTEXT      3   /* kernel far text (.fartext, medium model) */
+#define GDT_KDATA_EXEC  4   /* kernel data aliased as readable CODE (IRQ trampolines) */
+#define GDT_SETUP       5   /* boot setup-data area (REL_INITSEG, read by setupb/setupw) */
+#define GDT_OPTSEG      6   /* boot options area (DEF_OPTSEG, /bootopts read once at init) */
+#define GDT_BIOSDATA    7   /* BIOS data area (segment 0x40, base 0x400) */
+#define GDT_VIDEO       8   /* CGA/EGA/VGA text video memory (0xB8000) */
+#define GDT_TRACK       9   /* directfd DMA/track buffer (TRACKSEG) for far-mem copies in PM */
+#define GDT_FIRST_DYN   10  /* first dynamically-allocated selector */
+
+/* fixed kernel selectors (index<<3, GDT, RPL0) -- must match setup.S patches */
+#define SEL_KCODE       0x08
+#define SEL_KDATA       0x10
+#define SEL_KFTEXT      0x18
+#define SEL_SETUP       0x28    /* GDT[5]: base = REL_INITSEG<<4, for setupb/setupw in PM */
+#define SEL_OPTSEG      0x30    /* GDT[6]: base = DEF_OPTSEG<<4, for the /bootopts copy in PM */
+#define SEL_BIOSDATA    0x38    /* GDT[7]: base = 0x400, BIOS data area (seg 0x40) reads in PM */
+#define SEL_VIDEO       0x40    /* GDT[8]: base = 0xB8000, text video memory (VideoSeg) in PM */
+#define SEL_TRACK       0x48    /* GDT[9]: base = TRACKSEG<<4, directfd DMA/track buffer in PM */
+#define SEL_KDATA_EXEC  0x20    /* GDT[4]: same base as KDATA, but executable+readable;
+                                 * IDT gates point here so the CPU can run the trampolines
+                                 * that int_handler_add() builds in the kernel data segment */
+#define GDT_ENTRIES     512 /* 512 * 8 = 4 KB GDT                 */
+
+/* paragraph (16-byte) helpers shared with the real-mode arena allocator */
+#define PARA_BYTES(paras)   ((addr_t)(paras) << 4)
+#define BYTES_PARA(bytes)   (((bytes) + 15) >> 4)
+
+#ifdef CONFIG_286_PMODE
+
+/* ---- HAL hooks (implemented in arch/i86/mm/pm286.c and arch/i86/boot) ---- */
+
+/* boot: build GDT[GDT_KCODE/KDATA], load GDTR+IDTR, set CR0.PE, far-jump to PM */
+void gdt_init(void);
+
+/* allocate a descriptor for [base, base+paras*16) with `access`; returns a
+ * selector (0 on table-full). seg_alloc() calls this after reserving physram. */
+unsigned int desc_alloc(addr_t base, segext_t paras, byte_t access);
+
+/* rewrite / free an existing selector's descriptor */
+void   desc_set(unsigned int sel, addr_t base, segext_t paras, byte_t access);
+void   desc_chaccess(unsigned int sel, byte_t access);
+void   desc_free(unsigned int sel);
+
+/* recover the physical base behind a selector (for DMA, exec relocation, etc.) */
+addr_t desc_base(unsigned int sel);
+
+/* IDT: zero the table + point every vector at the fault-catch stub (called from
+ * gdt_init before entering PM); install one gate (used by the IRQ/syscall path). */
+void idt_init(void);
+void idt_gate_set(unsigned int vect, word_t offset, word_t selector, byte_t access);
+
+#endif /* CONFIG_286_PMODE */
+
+#endif /* __ARCH_SEG286_H */

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -35,10 +35,6 @@
 
 #else /* real mode */
 
-/* use real mode segment values (these may move to config.h) */
-#define SEG_BIOSDATA    0x0040          /* BIOS data */
-#define SEG_VIDEO       0xB800          /* text video RAM */
-
 /* macros map to segment values */
 #define KERNEL_CS       kernel_cs       /* real mode kernel near code segment */
 #define KERNEL_DS       kernel_ds       /* real mode kernel data segment */
@@ -54,11 +50,28 @@
 
 #ifndef __ASSEMBLER__
 #include <linuxmt/types.h>
+#include <linuxmt/config.h>
 
 extern seg_t kernel_cs, kernel_ds;
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
 extern short endistack[], istack[];
 extern unsigned int heapsize;
+#endif
+
+/* Segment VALUE for the kernel's own data when loaded into a segment register or
+ * handed to the far-memory primitives: a selector in protected mode, the real-mode
+ * paragraph otherwise.  (0x10 == SEL_KDATA in <arch/seg286.h>; written as a literal
+ * so this header stays usable from .S.)  NOT for physical math -- use kernel_ds<<4. */
+#ifdef CONFIG_286_PMODE
+#define KERNEL_CS  0x08     /* SEL_KCODE */
+#define KERNEL_DS  0x10
+#define BIOSSEG    0x38     /* SEL_BIOSDATA: BIOS data area (real-mode seg 0x40) */
+#define VIDEOSEG   0x40     /* SEL_VIDEO: text video memory (real-mode seg 0xb800) */
+#else
+#define KERNEL_CS  kernel_cs
+#define KERNEL_DS  kernel_ds
+#define BIOSSEG    0x40
+#define VIDEOSEG   0xb800
 #endif
 
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -203,6 +203,11 @@
 #define DMASEGEND       (DMASEG+(DMASEGSZ>>4))
 #endif
 
+/* physical paragraph addresses of fixed low-memory areas (moved here from
+ * arch/segment.h per its note); used as gdt_init descriptor bases in PM */
+#define SEG_BIOSDATA    0x0040          /* BIOS data area (real-mode seg 0x40) */
+#define SEG_VIDEO       0xB800          /* text video RAM (real-mode seg 0xB800) */
+
 /* Define segment locations of low memory, must not overlap */
 
 #ifdef CONFIG_ROMCODE

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -18,6 +18,7 @@
 #include <linuxmt/timer.h>
 #include <linuxmt/debug.h>
 #include <arch/segment.h>
+#include <arch/seg286.h>
 #include <arch/ports.h>
 #include <arch/irq.h>
 #include <arch/io.h>
@@ -263,6 +264,13 @@ static void INITPROC kernel_init(void)
 #ifdef CONFIG_FARTEXT_KERNEL
     /* add .farinit.init section to main memory free list */
     seg_t     init_seg = ((unsigned long)(void __far *)__start_fartext_init) >> 16;
+#ifdef CONFIG_286_PMODE
+    /* PM: a far pointer's segment is a SELECTOR, not a paragraph. Convert it to
+     * the physical base paragraph; otherwise seg_add() frees a bogus low region
+     * into the main pool that overlaps reserved low memory, and whatever program
+     * later loads there (e.g. /bin/init) corrupts the kernel. */
+    init_seg = (seg_t)(desc_base(init_seg) >> 4);
+#endif
     seg_t s = init_seg + (((word_t)(void *)__start_fartext_init + 15) >> 4);
     seg_t e = init_seg + (((word_t)(void *)  __end_fartext_init + 15) >> 4);
     debug("init: seg %04x to %04x size %04x (%d)\n", s, e, (e - s) << 4, (e - s) << 4);
@@ -528,7 +536,11 @@ static int INITPROC parse_options(void)
     char *next;
 
     /* copy /bootopts loaded by boot loader at 0050:0000*/
-    fmemcpyb(opts.options, KERNEL_DS, 0, DEF_OPTSEG, sizeof(opts.options));
+#ifdef CONFIG_286_PMODE
+    fmemcpyb(opts.options, KERNEL_DS, 0, SEL_OPTSEG, sizeof(opts.options)); /* PM: KERNEL_DS dest, SEL_OPTSEG src */
+#else
+    fmemcpyb(opts.options, kernel_ds, 0, DEF_OPTSEG, sizeof(opts.options));
+#endif
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
     /* check file starts with ##, one or two sectors, max 1023 bytes or 511 one sector */

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -21,7 +21,9 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 
-#define LINEARADDRESS(off, seg)     ((off_t) (((off_t)seg << 4) + off))
+/* seg:off far-pointer layout: keeps the segment intact for the kernel (GDT
+ * selector in 286 PM, paragraph in real mode).  Pairs with kmem_read/write. */
+#define LINEARADDRESS(off, seg)     ((off_t)(((off_t)(word_t)(seg) << 16) | (word_t)(off)))
 
 int aflag;      /* show application memory*/
 int fflag;      /* show free memory*/

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -34,7 +34,10 @@
 #include <paths.h>
 #include <libgen.h>
 
-#define LINEARADDRESS(off, seg)     ((off_t) (((off_t)seg << 4) + off))
+/* seg:off far-pointer layout (segment high word, offset low word): keeps the
+ * segment intact for the kernel, which reads it as a GDT selector in 286 PM and
+ * a paragraph in real mode.  Pairs with the seg:off decode in kmem_read/write. */
+#define LINEARADDRESS(off, seg)     ((off_t)(((off_t)(word_t)(seg) << 16) | (word_t)(off)))
 #define MK_FP(seg,off) ((void __far *)((((unsigned long)(seg))<<16) | ((unsigned)(off))))
 
 static int maxtasks;
@@ -108,7 +111,7 @@ char *dev_name(unsigned int minor)
 
 char *tty_name(int fd, unsigned int off, unsigned int seg)
 {
-    off_t addr = ((off_t)seg << 4) + off;
+    off_t addr = LINEARADDRESS(off, seg);
     struct tty tty;
 
     if (off == 0)

--- a/ibmpc-286pm-small.config
+++ b/ibmpc-286pm-small.config
@@ -1,0 +1,185 @@
+#
+# Automatically generated make config: don't edit
+#
+
+#
+# Kernel & Hardware
+#
+
+#
+# Just accept the defaults unless you know what you are doing
+#
+
+#
+# System
+#
+CONFIG_ARCH_IBMPC=y
+# CONFIG_ARCH_8018X is not set
+# CONFIG_ARCH_NECV25 is not set
+# CONFIG_ARCH_PC98 is not set
+# CONFIG_ARCH_SWAN is not set
+# CONFIG_ARCH_SOLO86 is not set
+
+#
+# Platform
+#
+# CONFIG_HW_COMPAQFAST is not set
+# CONFIG_HW_MK88 is not set
+CONFIG_286_PMODE=y
+
+#
+# Devices
+#
+CONFIG_HW_SERIAL_FIFO=y
+
+#
+# Kernel settings
+#
+CONFIG_BOOTOPTS=y
+CONFIG_ASYNCIO=y
+# CONFIG_AUDIO is not set
+CONFIG_CPU_USAGE=y
+# CONFIG_TIME_RTC_LOCALTIME is not set
+# CONFIG_TRACE is not set
+# CONFIG_TIMER_INT0F is not set
+# CONFIG_TIMER_INT1C is not set
+# CONFIG_ROMCODE is not set
+# CONFIG_FARTEXT_KERNEL is not set
+
+#
+# Networking Support
+#
+CONFIG_SOCKET=y
+CONFIG_INET=y
+CONFIG_UNIX=n
+
+#
+# Filesystem Support
+#
+# CONFIG_MINIX_FS is not set
+# CONFIG_ROMFS_FS is not set
+CONFIG_FS_FAT=y
+
+#
+# Filesystem settings
+#
+# CONFIG_FS_EXTERNAL_BUFFER is not set
+# CONFIG_FS_XMS is not set
+
+#
+# Executable file formats
+#
+CONFIG_EXEC_COMPRESS=y
+# CONFIG_EXEC_OS2 is not set
+CONFIG_EXEC_MMODEL=y
+
+#
+# Drivers
+#
+
+#
+# Block device drivers
+#
+# CONFIG_BLK_DEV_BFD is not set
+CONFIG_BLK_DEV_FD=y
+CONFIG_TRACK_CACHE=y
+# CONFIG_BLK_DEV_BFD_HARD is not set
+# CONFIG_BLK_DEV_BHD is not set
+# CONFIG_IDE_PROBE is not set
+CONFIG_ASYNCIO=y
+
+#
+# Additional block devices
+#
+# CONFIG_BLK_DEV_RAM is not set
+CONFIG_BLK_DEV_SSD_NONE=y
+# CONFIG_BLK_DEV_SSD_TEST is not set
+# CONFIG_BLK_DEV_SSD_SD is not set
+# CONFIG_BLK_DEV_ATA_CF is not set
+
+#
+# Block device options
+#
+# CONFIG_BLK_DEV_CHAR is not set
+
+#
+# Character device drivers
+#
+CONFIG_CONSOLE_DIRECT=y
+# CONFIG_CONSOLE_BIOS is not set
+# CONFIG_CONSOLE_8018X is not set
+# CONFIG_CONSOLE_NECV25 is not set
+# CONFIG_CONSOLE_HEADLESS is not set
+CONFIG_KEYBOARD_SCANCODE=y
+# CONFIG_CONSOLE_DUAL is not set
+CONFIG_CONSOLE_SERIAL=y
+CONFIG_CONSOLE_MAX=3
+# CONFIG_EMUL_ANSI is not set
+# CONFIG_KEYMAP_BE is not set
+# CONFIG_KEYMAP_DE is not set
+# CONFIG_KEYMAP_DV is not set
+# CONFIG_KEYMAP_ES is not set
+# CONFIG_KEYMAP_FR is not set
+# CONFIG_KEYMAP_IT is not set
+# CONFIG_KEYMAP_SE is not set
+# CONFIG_KEYMAP_UK is not set
+CONFIG_KEYMAP_US=y
+
+#
+# Other character devices
+#
+CONFIG_CHAR_DEV_RS=y
+# CONFIG_CHAR_DEV_LP is not set
+CONFIG_CHAR_DEV_MEM=y
+CONFIG_PSEUDO_TTY=y
+
+#
+# Network device drivers
+#
+CONFIG_ETH=y
+CONFIG_ETH_NE2K=y
+# CONFIG_ETH_WD is not set
+# CONFIG_ETH_EL3 is not set
+
+#
+# Userland
+#
+CONFIG_APPS_BY_IMAGESZ=y
+
+#
+# Select Applications by Image Size
+#
+# CONFIG_APPS_HD is not set
+# CONFIG_APPS_2880K is not set
+CONFIG_APPS_1440K=y
+# CONFIG_APPS_1232K is not set
+# CONFIG_APPS_1200K is not set
+# CONFIG_APPS_720K is not set
+# CONFIG_APPS_360K is not set
+
+#
+# System startup
+#
+# CONFIG_SYS_DEFSHELL_SASH is not set
+# CONFIG_SYS_NO_BININIT is not set
+
+#
+# Target image
+#
+CONFIG_IMG_FAT=y
+# CONFIG_IMG_ROM is not set
+# CONFIG_IMG_FD2880 is not set
+CONFIG_IMG_FD1440=y
+# CONFIG_IMG_FD1232 is not set
+# CONFIG_IMG_FD1200 is not set
+# CONFIG_IMG_FD720 is not set
+# CONFIG_IMG_FD360 is not set
+# CONFIG_IMG_HD is not set
+CONFIG_IMG_DEV=y
+CONFIG_IMG_BOOT=y
+CONFIG_APPS_COMPRESS=y
+
+#
+# Binary Images
+#
+# CONFIG_IMG_EXTRA_IMAGES is not set

--- a/mkimg.sh
+++ b/mkimg.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Build a fresh ELKS boot image with a guaranteed-contiguous /linux.
+# Usage: mkimg.sh [kernel-file] [image-name] [runlevel]
+# Fails (exit 1) if /linux ends up fragmented -- the FAT boot sector loads
+# consecutive sectors from the first cluster only, so a fragmented kernel
+# silently boots with a corrupted .data tail (cost us a full day to find).
+set -e
+KERNEL=${1:-linux-small}
+IMG=${2:-small.img}
+RUNLEVEL=${3:-3}
+cd /work
+export MTOOLS_SKIP_CHECK=1
+
+cp fd1440-fat.img "$IMG"
+rm -rf /tmp/root; mkdir /tmp/root
+mcopy -s -i fd1440-fat.img ::/bin ::/etc ::/lib ::/sbin ::/root ::/home ::/mnt ::/var ::/tmp /tmp/root/ 2>/dev/null || true
+sed -i "s/^id:1:initdefault:/id:$RUNLEVEL:initdefault:/" /tmp/root/etc/inittab
+
+# empty the image but keep its boot sector, then /linux FIRST (contiguous)
+mdeltree -i "$IMG" ::/dev ::/bin ::/etc ::/home ::/lib ::/mnt ::/root ::/tmp ::/var ::/sbin 2>/dev/null || true
+mattrib -i "$IMG" -r -s -h ::/linux 2>/dev/null || true
+mdel -i "$IMG" ::/linux 2>/dev/null || true
+mdel -i "$IMG" ::/bootopts 2>/dev/null || true
+mcopy -i "$IMG" "$KERNEL" ::/linux
+mmd -i "$IMG" ::/dev
+mmd -i "$IMG" ::/proc
+mcopy -s -i "$IMG" /tmp/root/* ::/
+
+CHAIN=$(mshowfat -i "$IMG" ::/linux)
+echo "CHAIN: $CHAIN"
+EXTENTS=$(echo "$CHAIN" | tr -cd "<" | wc -c)
+if [ "$EXTENTS" -ne 1 ]; then
+    echo "FATAL: /linux is FRAGMENTED ($EXTENTS extents) - boot would load garbage as kernel data"
+    exit 1
+fi
+echo "IMAGE OK: $IMG /linux contiguous"


### PR DESCRIPTION
@ghaerr Here's the requested PR per your comment in the fork
TBH I'd prefer to fix the kmem issue first in the branch but happy either way.

AI description below:

Builds on the pmode refactor (#2721, now in master). Adds a 286 protected-mode HAL: the kernel runs in 16-bit PM with a GDT/IDT, segments become GDT selectors, and the memory manager hands out descriptors — while the mainline real-mode path is untouched (everything behind `CONFIG_286_PMODE`, off by default).

Submitting the whole POC here per @ghaerr's request, for landing in master as a shared base.

**Status:** boots to a shell in 286 PM on QEMU/KVM — boot → directfd DMA → FAT root → init → getty → login → shell. Multi-user works including telnet login (ne2k → ktcp → telnetd → pty). Verified on both the full config and a trimmed ~60K single-segment kernel. All userland runs at ring 0 for now.

**What's here**
- **Mode bring-up:** `pm286.c` (GDT/IDT, real→PM switch), `pm_enter.S`, `seg286.h`.
- **Segment abstraction:** `segment.h`/`config.h` — `SEL_*`/`SEG_*`; `KERNEL_CS/DS`, `LINADDR`, `TRACKSEG` resolve to selectors in PM and paragraphs in real mode, so most code stays ifdef-free.
- **Memory manager:** `malloc.c` — `seg_pm_attach`/`detach` allocate a GDT descriptor per segment (`seg->base` = selector, `seg->para` = physical); no-ops in real mode.
- **IRQ:** `irq.c` (IDT gates via the data-as-code alias), `irq-8259.c`, `irqtab.S`.
- **Drivers/boot:** `directfd.c` (DMA via `desc_base`/selectors), `crt0.S`/`setup.S`, `exec.c`, `process.c`, `main.c`.
- **Build:** `ibmpc-286pm-small.config`, Makefile hooks, `.gitattributes`.

**Known / deferred (per discussion)**
- `/dev/kmem` PM decode (`mem.c`) is a partial bias-strip for ps/meminfo's task-table reads; the argv/`COMMAND` case isn't invertible with selectors. Left in for now — glad to drop it, since you noted you may leave it out until the selector-aware protocol lands.
- `mkimg.sh` included per your note; a test-harness convenience (injects a fresh kernel into a prebuilt image), not needed for from-scratch builds.
- procfs / ps rewrite deferred (agreed — after 0.9.2 if at all).
- Backlog in `PMODE-TODO.md` (ring 3, >1MB/XMS, INITPROC-in-small-model, ifdef audit).

Rebases cleanly on master — picked up your `ecdf027d` malloc fix; our matching external-selector edits folded into it.
