### PR TITLE
286pm ext buffers

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -931,6 +931,12 @@ arch_set_initseg:
 	jc	1f
 	mov	%ax,xms_kbytes
 1:
+#ifdef CONFIG_286_PMODE
+	// PM reaches extended memory (>1MB) through GDT descriptors, so A20 must be
+	// enabled or a >1MB physical access wraps back into low memory and corrupts it.
+	// The HMA path only enables A20 for hma=kernel; do it unconditionally for PM.
+	call	enable_a20_gate
+#endif
 #ifdef CONFIG_BOOTOPTS
 	call	bootopts	// load /bootopts into DEF_OPTSEG (0050:0000)
 	call    hmabootopts	// check /bootopts for hma=kernel

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -11,6 +11,8 @@
 #include <linuxmt/config.h>
 #include <linuxmt/types.h>
 #include <linuxmt/kernel.h>
+#include <linuxmt/memory.h>     /* setupw() -> SETUP_XMS_KBYTES */
+#include <arch/io.h>            /* inb/outb for the A20 gate */
 #include <arch/seg286.h>
 
 #ifdef CONFIG_286_PMODE
@@ -103,6 +105,21 @@ word_t desc_limit(unsigned int sel)         /* max valid byte offset in the segm
     return gdt[SEL_INDEX(sel)].limit;
 }
 
+/* Extended-memory (>1MB) bump allocator for the PM buffer cache.  A20 is enabled
+ * on the PM path (setup.S), so GDT descriptors reach physical addresses above 1MB.
+ * SETUP_XMS_KBYTES (INT 15h AH=88h at boot) is the extended-memory size in KB;
+ * hand out 1K-granular physical chunks starting just above 1MB. */
+static addr_t himem_next = 0x100000L;
+addr_t himem_alloc(unsigned int kbytes)     /* physical base >= 1MB, 0 = exhausted */
+{
+    addr_t base = himem_next;
+    addr_t need = (addr_t)kbytes << 10;
+    if ((base - 0x100000L) + need > ((addr_t)SETUP_XMS_KBYTES << 10))
+        return 0;                           /* not enough extended memory */
+    himem_next += need;
+    return base;
+}
+
 const void *gdt_table(void) { return gdt; }             /* for lgdt in boot asm */
 unsigned    gdt_limit(void) { return sizeof(gdt) - 1; }
 
@@ -144,6 +161,12 @@ void gdt_init(void)
     segext_t text_par   = BYTES_PARA(_endtext);
     /* fartext is loaded immediately after text (non-HMA boot). */
     addr_t   ftext_base = code_base + ((addr_t)text_par << 4);
+
+    /* Enable the A20 gate (fast A20 via port 0x92) so GDT descriptors can address
+     * physical memory above 1MB -- required for the extended-memory buffer cache.
+     * Done here in real mode just before the PM switch; setup.S's enable_a20_gate
+     * proved unreliable.  Preserve bit0 (port 0x92 bit0 = fast CPU reset). */
+    outb((inb(0x92) | 0x02) & ~0x01, 0x92);
 
     /* phase 4b: separate descriptors for near text, far text and data.
      * setup.S has patched the kernel's far-call/far-data segments to these

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -122,7 +122,7 @@ static void FARPROC put_last_lru(struct buffer_head *bh)
     }
 }
 
-static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
+static void INITPROC add_buffers(int nbufs, char *buf, addr_t seg)
 {
     struct buffer_head *bh;
     int n = 0;
@@ -140,11 +140,11 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
 
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
 #ifdef CONFIG_286_PMODE
-        /* PM: 'seg' is a GDT selector and can't be paragraph-offset like a real-mode
-         * segment.  Give each L2 buffer its own descriptor based at the chunk's
-         * physical address + n*BLOCK_SIZE, so it is reachable at selector:0 (matching
-         * the "no offset to buffer" design).  ext only -- PM has no XMS. */
-        ebh->b_L2seg = desc_alloc(desc_base(seg) + ((addr_t)(n & 63) << BLOCK_SIZE_BITS),
+        /* PM: 'seg' is the chunk's PHYSICAL base in extended memory (himem_alloc,
+         * >1MB).  Give each L2 buffer its own descriptor based at physical +
+         * n*BLOCK_SIZE, so it is reachable at selector:0 (matching the "no offset
+         * to buffer" design).  ext only -- PM has no XMS. */
+        ebh->b_L2seg = desc_alloc((addr_t)seg + ((addr_t)(n & 63) << BLOCK_SIZE_BITS),
                                   BYTES_PARA(BLOCK_SIZE), DESC_KDATA);
 #else
         /* segment adjusted to require no offset to buffer */
@@ -262,10 +262,20 @@ int INITPROC buffer_init(void)
         } else
 #endif
         {
+#ifdef CONFIG_286_PMODE
+            /* PM: put the L2 pool in extended memory (>1MB) so it does not consume
+             * the scarce conventional pool.  add_buffers gives each buffer its own
+             * descriptor based within this himem chunk (BLOCK_SIZE == 1K, so nbufs
+             * buffers == nbufs KB). */
+            addr_t himem = himem_alloc(nbufs);
+            if (!himem) return 2;
+            add_buffers(nbufs, 0, himem);
+#else
             segment_s *extseg = seg_alloc (nbufs << (BLOCK_SIZE_BITS - 4),
                 SEG_FLAG_EXTBUF|SEG_FLAG_ALIGN1K);
             if (!extseg) return 2;
             add_buffers(nbufs, 0, extseg->base);
+#endif
         }
     } while (bufs_to_alloc > 0);
 #else

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -8,6 +8,9 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/heap.h>
 #include <linuxmt/errno.h>
+#ifdef CONFIG_286_PMODE
+#include <arch/seg286.h>        /* desc_alloc/desc_base: per-buffer descriptors for PM ext L2 */
+#endif
 #include <linuxmt/trace.h>
 #include <linuxmt/debug.h>
 
@@ -123,7 +126,9 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
 {
     struct buffer_head *bh;
     int n = 0;
+#ifndef CONFIG_286_PMODE
     size_t offset;
+#endif
 
     for (bh = bh_next; n < nbufs; n++, bh = ++bh_next) {
         ext_buffer_head *ebh = EBH(bh);
@@ -134,10 +139,19 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
         }
 
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
+#ifdef CONFIG_286_PMODE
+        /* PM: 'seg' is a GDT selector and can't be paragraph-offset like a real-mode
+         * segment.  Give each L2 buffer its own descriptor based at the chunk's
+         * physical address + n*BLOCK_SIZE, so it is reachable at selector:0 (matching
+         * the "no offset to buffer" design).  ext only -- PM has no XMS. */
+        ebh->b_L2seg = desc_alloc(desc_base(seg) + ((addr_t)(n & 63) << BLOCK_SIZE_BITS),
+                                  BYTES_PARA(BLOCK_SIZE), DESC_KDATA);
+#else
         /* segment adjusted to require no offset to buffer */
         offset = xmsenabled?  ((n & 63) << BLOCK_SIZE_BITS) :
                               ((n & 63) << (BLOCK_SIZE_BITS - 4));
         ebh->b_L2seg = seg + offset;
+#endif
 #else
         bh->b_data = buf;
         buf += BLOCK_SIZE;

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -122,6 +122,10 @@ addr_t desc_base(unsigned int sel);
 /* max valid byte offset in a selector's segment (its descriptor limit) */
 word_t desc_limit(unsigned int sel);
 
+/* bump-allocate a physical chunk of 'kbytes' from extended memory above 1MB
+ * (returns the physical base, 0 if exhausted) -- backing store for the PM L2 cache */
+addr_t himem_alloc(unsigned int kbytes);
+
 /* IDT: zero the table + point every vector at the fault-catch stub (called from
  * gdt_init before entering PM); install one gate (used by the IRQ/syscall path). */
 void idt_init(void);


### PR DESCRIPTION
This closes one of the protected mode gaps - EXT buffer.
Two commits: one fixes it in the conventional memory and the other moves it to high memory.
Can be split in two PRs or used for research of alternative solution.
No hurry to review.