### PR TITLE
[kernel] Get PM fartext kernel working

### DIFF
--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -14,9 +14,10 @@
 _start:
 
 /*
-! Setup.S already initialized DS and ES (but not SS)
+! Setup.S already initialized DS (but not SS)
 ! In addition, registers contain:
 !   BX, Text size
+!   ES, Far text segment
 !   DI  Far text size
 !   SI, Data size
 !   DX, BSS size
@@ -26,6 +27,10 @@ _start:
         mov     %si,_enddata
         add     %dx,%si
         mov     %si,_endbss
+        mov     %es,kernel_ftext
+
+        mov     %ds,%ax         // set ES = DS
+        mov     %ax,%es
 
 // Start cleaning BSS. Still using setup.S stack
 
@@ -115,6 +120,7 @@ early_putchar:
         .global _endftext
         .global _enddata
         .global _endbss
+        .global kernel_ftext
         .extern kernel_cs
         .extern kernel_ds
         .extern istack
@@ -129,6 +135,9 @@ _enddata:
         .word   0
 
 _endbss:
+        .word   0
+
+kernel_ftext:
         .word   0
 
         .bss

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -700,8 +700,9 @@ data_reloc:
 // Load registers as kernel expects
 
 	mov -22(%bp),%ax   // kernel .data segment
-	mov %ax,%es
 	mov %ax,%ds
+	mov -20(%bp),%ax   // kernel .fartext segment
+	mov %ax,%es
 	mov -2(%bp),%bx    // code size
 	mov -4(%bp),%si    // data size
 	mov -6(%bp),%dx    // bss size
@@ -715,10 +716,11 @@ data_reloc:
 	push %cx
 
 	.hex4sp	%ss,"\nDone SS:"
-	.hex4sp	%ds,"DS/ES:"
-	.hex4sp	%bx,".text size:"
-	.hex4sp	%di,".fartext size:"
-	.hex4sp	%si,".data size:"
+	.hex4sp	%ds,"DS:"
+	.hex4sp	%bx,".text sz:"
+	.hex4sp	%es,".ftext:"
+	.hex4sp	%di,".ftext sz:"
+	.hex4sp	%si,".data sz:"
 	.hex4sp	%ax,"\nJump CS:"
 	.hex4sp	%cx,"entry:"
 	.if debug_output

--- a/elks/arch/i86/lib/pmode.S
+++ b/elks/arch/i86/lib/pmode.S
@@ -15,6 +15,8 @@
  * installs the real IRQ/syscall handlers.  ftext has its own descriptor
  * and far-call selectors.
  */
+#include <arch/segment.h>
+
         .arch   i286, nojumps
         .code16
         .text
@@ -35,9 +37,9 @@ enable_protected_mode:
         or      $1,%ax          // set PE
         lmsw    %ax             // *** now in protected mode ***
 
-        ljmp    $0x08,$pm_cs    // load CS = kernel code selector, flush prefetch
+        ljmp    $SEL_KCODE,$pm_cs // load CS = kernel code selector, flush prefetch
 pm_cs:
-        mov     $0x10,%ax       // kernel data selector
+        mov     $SEL_KDATA,%ax  // kernel data selector
         mov     %ax,%ds
         mov     %ax,%es
         mov     %ax,%ss         // SS base = kernel_ds<<4 (same phys as real-mode SS)
@@ -48,13 +50,13 @@ pm_cs:
         pop     %bp
         ret                     // return (in PM) to gdt_init -> crt0 -> start_kernel
 
-// ---- exception/fault catch + reporter (phase 8 bring-up) ----
+// Exception/fault catch + reporter
 // gdt_init() points IDT 0..31 at pm_flt_base + vec*8 and 32..255 at pm_flt_other.
 // Each stub pushes its vector then jumps to the common reporter, which prints
-// "EXC=<vec>-<w0>-<w1>-<w2>-<w3>" (vector + top stack words) on COM1 and halts.
-// From <vec> = which exception; from the words = faulting CS:IP (CS is a known
-// selector 0008/0010/0018), shifted one word if an error code was pushed
-// (#DF=8 #TS=10 #NP=11 #SS=12 #GP=13).
+// "EXC=<num>-<errcode>-<IP>-<CS>-<FLAGS>-<rest of stack[0..4]>" on COM1 and halts.
+// <num> is the exception number: #DF=08, #TS=0A, #NP=0B, #SS=0C, #GP=0D.
+// Faulting CS will be known selector number: CODE 0008, DATA 0010, FTEXT 0018.
+
         .balign 8
         .global pm_flt_base
 pm_flt_base:
@@ -62,18 +64,16 @@ pm_flt_base:
         .rept   32
         pushw   $fltv
         jmp     pm_fault_common
-        .balign 8, 0x90                 // each stub occupies an 8-byte slot
+        .balign 8, 0x90         // each stub occupies an 8-byte slot
         .set    fltv, fltv + 1
         .endr
 
         .global pm_flt_other
 pm_flt_other:
-        pushw   $0x00FF                 // marker: vector >= 32 (shouldn't fire pre-irq_init)
-        jmp     pm_fault_common
-
+        pushw   $0x00FF         // use 00FF to mark vectors >= 32
 pm_fault_common:
         cli
-        mov     %sp,%bp                 // bp -> [vec][..][IP][CS][FLAGS] (SS-relative)
+        mov     %sp,%bp         // bp -> [vec][ERRCODE][IP][CS][FLAGS][...]
         mov     $0x0d,%al
         call    pm_putc_ser
         mov     $0x0a,%al
@@ -86,43 +86,43 @@ pm_fault_common:
         call    pm_putc_ser
         mov     $'=',%al
         call    pm_putc_ser
-        movw    (%bp),%ax               // vector
+        movw    (%bp),%ax       // vector
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    2(%bp),%ax
+        movw    2(%bp),%ax      // errcode
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    4(%bp),%ax
+        movw    4(%bp),%ax      // IP
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    6(%bp),%ax
+        movw    6(%bp),%ax      // CS
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    8(%bp),%ax
+        movw    8(%bp),%ax      // FLAGS
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    10(%bp),%ax     // (for fmemcpyb: caller return address)
+        movw    10(%bp),%ax     // stack 0
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    12(%bp),%ax
+        movw    12(%bp),%ax     // stack 1
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    14(%bp),%ax
+        movw    14(%bp),%ax     // stack 2
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    16(%bp),%ax
+        movw    16(%bp),%ax     // stack 3
         call    pm_puthex
         mov     $'-',%al
         call    pm_putc_ser
-        movw    18(%bp),%ax
+        movw    18(%bp),%ax     // stack 4
         call    pm_puthex
         mov     $0x0d,%al
         call    pm_putc_ser

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -135,7 +135,7 @@ void gdt_init(void)
     addr_t   code_base  = (addr_t)kernel_cs << 4;
     addr_t   data_base  = (addr_t)kernel_ds << 4;
     segext_t text_para  = BYTES_PARA((unsigned)_endtext);
-    addr_t   ftext_base = code_base + ((addr_t)text_para << 4); /* fartext after text */
+    addr_t   ftext_base = code_base + PARA_BYTES(text_para); /* HMA fartext after text */
     static struct dtr gdtr, idtr;
 
     /* separate descriptors for near text, far text and data.

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -135,7 +135,6 @@ void gdt_init(void)
     addr_t   code_base  = (addr_t)kernel_cs << 4;
     addr_t   data_base  = (addr_t)kernel_ds << 4;
     segext_t text_para  = BYTES_PARA((unsigned)_endtext);
-    addr_t   ftext_base = code_base + PARA_BYTES(text_para); /* HMA fartext after text */
     static struct dtr gdtr, idtr;
 
     /* separate descriptors for near text, far text and data.
@@ -145,8 +144,10 @@ void gdt_init(void)
     desc_set(MK_SEL(GDT_NULL,   SEL_GDT, SEL_RPL0), 0,          0,         0);
     desc_set(MK_SEL(GDT_KCODE,  SEL_GDT, SEL_RPL0), code_base,  text_para, DESC_KCODE);
     desc_set(MK_SEL(GDT_KDATA,  SEL_GDT, SEL_RPL0), data_base,  0x1000,    DESC_KDATA);
-    desc_set(MK_SEL(GDT_KFTEXT, SEL_GDT, SEL_RPL0), ftext_base,
+    if (kernel_ftext) {
+        desc_set(MK_SEL(GDT_KFTEXT, SEL_GDT, SEL_RPL0), (addr_t)kernel_ftext << 4,
                                           BYTES_PARA((unsigned)_endftext), DESC_KCODE);
+    }
 
     /* KCODE same base/limit as KDATA but executable+readable. IRQ trampolines are
      * built in the kernel data segment, and an IDT gate needs an executable selector.

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -1,16 +1,14 @@
 #ifndef __ARCH_8086_SEGMENT_H
 #define __ARCH_8086_SEGMENT_H
 
+/*
+ * Configured values for various fixed segment addresses and selectors.
+ */
 #include <linuxmt/config.h>
 
 /* paragraph (16-byte) helpers shared with the real-mode arena allocator */
 #define PARA_BYTES(paras)   ((addr_t)(paras) << 4)
 #define BYTES_PARA(bytes)   (((bytes) + 15) >> 4)
-
-/*
- * Protected mode selector vs real mode segment definitions and macros
- */
-#ifdef CONFIG_286_PMODE
 
 /* fixed GDT indices (kernel-private selectors) */
 #define GDT_NULL        0   /* required null descriptor          */
@@ -37,6 +35,11 @@
 #define SEL_TRACK       0x48
 
 #define GDT_ENTRIES     512 /* 512 * 8 = 4 KB GDT                 */
+
+/*
+ * Protected mode selector vs real mode segment definitions and macros
+ */
+#ifdef CONFIG_286_PMODE
 
 /* macros map to selector values */
 #define KERNEL_CS       SEL_KCODE       /* kernel near code selector */

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -73,7 +73,7 @@
 #ifndef __ASSEMBLER__
 #include <linuxmt/types.h>
 
-extern seg_t kernel_cs, kernel_ds;
+extern seg_t kernel_cs, kernel_ds, kernel_ftext;
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
 extern short endistack[], istack[];
 extern unsigned int heapsize;

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -44,7 +44,7 @@ struct netif_parms netif_parms[MAX_ETHS] = {
     { WD_IRQ, WD_PORT, WD_RAM, WD_FLAGS },
     { EL3_IRQ, EL3_PORT, 0, EL3_FLAGS },
 };
-seg_t kernel_cs, kernel_ds;
+seg_t kernel_cs, kernel_ds;     /* always segment values even in PM */
 int root_mountflags;
 int tracing;
 int nr_ext_bufs, nr_xms_bufs, nr_map_bufs;
@@ -113,9 +113,10 @@ void start_kernel(void)
 {
     //tracing = TRACE_KSTACK | TRACE_ISTACK;
 #ifdef CONFIG_286_PMODE
-    /* Build GDT and enter protected mode (no return to real mode).
-     * Must be called before any FAR/INITPROC procedures as setup.S
-     * loader relocated far segment values to selectors.
+    /* Build GDT and enter protected mode before calling far_start_kernel,
+     * as the setup.S kernel loader already relocated all .fartext CS segment
+     * references to SEL_KFTEXT selectors. The system never returns to real
+     * mode and BIOS services can no longer be called.
      */
     gdt_init();
 #endif
@@ -296,7 +297,7 @@ static void INITPROC kernel_banner(seg_t init, seg_t extra)
            (unsigned)_endbss - (unsigned)_enddata, heapsize);
     printk("Kernel text %x ", kernel_cs);
 #ifdef CONFIG_FARTEXT_KERNEL
-    printk("ftext %x init %x ", (unsigned)((long)kernel_init >> 16), init);
+    printk("ftext %x init %x ", kernel_ftext, init);
 #endif
     printk("data %x end %x top %x %u+%u+%uK free\n",
            kernel_ds, membase, memend, (int) ((memend - membase) >> 6),

--- a/ibmpc-pmode.config
+++ b/ibmpc-pmode.config
@@ -95,7 +95,7 @@ CONFIG_ASYNCIO=y
 CONFIG_BLK_DEV_SSD_NONE=y
 # CONFIG_BLK_DEV_SSD_TEST is not set
 # CONFIG_BLK_DEV_SSD_SD is not set
-# CONFIG_BLK_DEV_ATA_CF is not set
+CONFIG_BLK_DEV_ATA_CF=y
 
 #
 # Block device options

--- a/ibmpc-pmode.config
+++ b/ibmpc-pmode.config
@@ -44,7 +44,7 @@ CONFIG_CPU_USAGE=y
 # CONFIG_TIMER_INT0F is not set
 # CONFIG_TIMER_INT1C is not set
 # CONFIG_ROMCODE is not set
-# CONFIG_FARTEXT_KERNEL is not set
+CONFIG_FARTEXT_KERNEL=y
 
 #
 # Networking Support
@@ -56,7 +56,7 @@ CONFIG_UNIX=n
 #
 # Filesystem Support
 #
-# CONFIG_MINIX_FS is not set
+CONFIG_MINIX_FS=y
 # CONFIG_ROMFS_FS is not set
 CONFIG_FS_FAT=y
 
@@ -166,6 +166,7 @@ CONFIG_APPS_1440K=y
 #
 # Target image
 #
+# CONFIG_IMG_MINIX is not set
 CONFIG_IMG_FAT=y
 # CONFIG_IMG_ROM is not set
 # CONFIG_IMG_FD2880 is not set


### PR DESCRIPTION
Adds CONFIG_FARTEXT_KERNEL support in protected mode to allow creating larger kernels. The small model kernel was almost completely out of space.

The PM kernel can now boot with the kernel loaded normally or in HMA (/bootopts hma=kernel).

This PR renames the test PM kernel configuration file from ibmpc-286-pm-small.config to ibmpc-pmode.config and adds MINIX filesystem support and compact flash/hard drive support through the ATA/CF direct driver. 

The PM exception reporting code was slightly cleaned up, since getting this working generated a few PM exceptions. The reporting routine will be rewritten in C in the future.

The standard `qemu.sh` script works now for running the PM kernel. Since the direct console is configured, it is no longer required to reconfigure the system to boot into run level 3, and login: now appears on the direct console display, although all boot messages are currently still rerouted to the serial port. This will likely be changed shortly, as a CONFIG_CONSOLE_SERIAL can be configured to do the same thing. Likewise, the `mkimg.sh` temporary shell script will also be removed shortly as no longer required.