### PR TITLE
[kernel] Move PM IDT to real mode IVT location at 0:0

### DIFF
--- a/elks/arch/i86/lib/pmode.S
+++ b/elks/arch/i86/lib/pmode.S
@@ -51,29 +51,26 @@ pm_cs:
         ret                     // return (in PM) to gdt_init -> crt0 -> start_kernel
 
 // Exception/fault catch + reporter
-// gdt_init() points IDT 0..31 at pm_flt_base + vec*8 and 32..255 at pm_flt_other.
+// gdt_init() points IDT 0..31 at pm_fault_panic + vec*8 and the rest at pm_fault_panic2.
 // Each stub pushes its vector then jumps to the common reporter, which prints
-// "EXC=<num>-<errcode>-<IP>-<CS>-<FLAGS>-<rest of stack[0..4]>" on COM1 and halts.
+// "EXC=<vecnum>-<errcode>-<IP>-<CS>-<FLAGS>-<rest of stack[0..4]>" on COM1 and halts.
 // <num> is the exception number: #DF=08, #TS=0A, #NP=0B, #SS=0C, #GP=0D.
 // Faulting CS will be known selector number: CODE 0008, DATA 0010, FTEXT 0018.
 
         .balign 8
-        .global pm_flt_base
-pm_flt_base:
+        .global pm_fault_panic
+pm_fault_panic:
         .set    fltv, 0
-        .rept   32
+        .rept   32              // first 32 IDT entries report vector numbers 0..31
         pushw   $fltv
         jmp     pm_fault_common
-        .balign 8, 0x90         // each stub occupies an 8-byte slot
+        .balign 8, 0x90         // each entry occupies an 8-byte slot
         .set    fltv, fltv + 1
         .endr
-
-        .global pm_flt_other
-pm_flt_other:
-        pushw   $0x00FF         // use 00FF to mark vectors >= 32
+        pushw   $0x00FF         // remainder vectors >= 32 report vector 255
 pm_fault_common:
         cli
-        mov     %sp,%bp         // bp -> [vec][ERRCODE][IP][CS][FLAGS][...]
+        mov     %sp,%bp         // bp -> [vecnum][ERRCODE][IP][CS][FLAGS][...]
         mov     $0x0d,%al
         call    pm_putc_ser
         mov     $0x0a,%al

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -11,6 +11,7 @@
 #include <linuxmt/config.h>
 #include <linuxmt/types.h>
 #include <linuxmt/kernel.h>
+#include <linuxmt/memory.h>
 #include <linuxmt/limits.h>
 #include <arch/segment.h>
 #include <arch/seg286.h>
@@ -99,18 +100,16 @@ segext_t desc_limit(sel_t sel)         /* max valid byte offset in the segment *
     return gdt[SEL_INDEX(sel)].limit;
 }
 
-/* ---- Interrupt Descriptor Table (1032 bytes, in the kernel data segment) ---- */
-static struct idt_gate idt[MAX_IDT_ENTRIES];
-
-void idt_gate_set(int vect, unsigned int offset, sel_t selector, byte_t access)
+/* set an entry in the IDT; uses SEL_IDT which points to real mode IVT at 0:0 */
+void idt_gate_set(unsigned int vect, unsigned int offset, sel_t selector, byte_t access)
 {
-    struct idt_gate *g;
+    struct idt_gate __far *g;;
 
     if (vect >= MAX_IDT_ENTRIES) {
         printk("idt_gate_set: invalid vector %d\n", vect);
         return;
     }
-    g = &idt[vect];
+    g = _MK_FP(SEL_IDT, vect * sizeof(struct idt_gate));
     g->offset   = offset;
     g->selector = selector;
     g->zero     = 0;
@@ -159,6 +158,16 @@ void gdt_init(void)
      */
     desc_set(MK_SEL(GDT_KDATA_EXEC, SEL_GDT, SEL_RPL0), data_base, 0x1000, DESC_KCODE);
 
+    /* IDT replaces real mode IVT interrupt vector table + 8 bytes from 0:0 to 0:0407.
+     * NOTE: With the normal MAX_IDT_ENTRIES of 129 (required for syscall INT 0x80),
+     * the IDT which uses 8 bytes/entry will overwrite the first 1K IVT plus the
+     * first 8 bytes of the BIOS data area which starts at 0x40:0. The first 8
+     * bytes of the BDA contain the port addresses of COM1-COM4, which aren't used
+     * by ELKS setupb/setupw anyways.
+     */
+    desc_set(MK_SEL(GDT_IDT, SEL_GDT, SEL_RPL0), 0, BYTES_PARA(MAX_IDT_ENTRIES * 8),
+        DESC_KDATA);
+
     /* setupb/setupw setup.S data segment */
     desc_set(MK_SEL(GDT_SETUP, SEL_GDT, SEL_RPL0), SEG_SETUP_DATA << 4, BYTES_PARA(512),
         DESC_KDATA);
@@ -182,9 +191,9 @@ void gdt_init(void)
     idt_init();                 /* every vector -> fault-catch stub (until irq_init) */
 
     gdtr.limit = sizeof(gdt) - 1;
-    gdtr.base  = data_base + (unsigned)&gdt;    /* linear addr of GDT */
-    idtr.limit = sizeof(idt) - 1;
-    idtr.base  = data_base + (unsigned)&idt;    /* linear addr of IDT */
+    gdtr.base  = data_base + (unsigned)&gdt; /* linear address of GDT */
+    idtr.limit = MAX_IDT_ENTRIES * sizeof(struct idt_gate) - 1;
+    idtr.base  = 0;                         /* IDT replaces real mode IVT at 0:0 */
 
     enable_protected_mode(&gdtr, &idtr);    /* enter PM; returns here in protected mode */
 }

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -99,13 +99,18 @@ segext_t desc_limit(sel_t sel)         /* max valid byte offset in the segment *
     return gdt[SEL_INDEX(sel)].limit;
 }
 
-/* ---- Interrupt Descriptor Table (2 KB, in the kernel data segment) ---- */
-static struct idt_gate idt[256];
+/* ---- Interrupt Descriptor Table (1032 bytes, in the kernel data segment) ---- */
+static struct idt_gate idt[MAX_IDT_ENTRIES];
 
-void idt_gate_set(int vect, word_t offset, sel_t selector, byte_t access)
+void idt_gate_set(int vect, unsigned int offset, sel_t selector, byte_t access)
 {
-    struct idt_gate *g = &idt[vect];
+    struct idt_gate *g;
 
+    if (vect >= MAX_IDT_ENTRIES) {
+        printk("idt_gate_set: invalid vector %d\n", vect);
+        return;
+    }
+    g = &idt[vect];
     g->offset   = offset;
     g->selector = selector;
     g->zero     = 0;
@@ -113,18 +118,18 @@ void idt_gate_set(int vect, word_t offset, sel_t selector, byte_t access)
     g->reserved = 0;
 }
 
-/* Point every vector at the fault-catch stub (in kernel code = SEL_KCODE) so an
- * exception between PM entry and irq_init() is reported, not a triple fault.
+/* Point IDT vectors at the fault-catch handler so an exception between
+ * PM entry and irq_init() is reported, not a triple fault.
  * irq_init() later overwrites the live IRQ/syscall/INT0/INT2 vectors.
  */
 static void idt_init(void)
 {
     int v;
 
-    for (v = 0; v < 32; v++)    /* per-vector stubs so the reporter knows the vector */
-        idt_gate_set(v, (word_t)(pm_flt_base + v*8), SEL_KCODE, GATE_INT286);
-    for (v = 32; v < 256; v++)
-        idt_gate_set(v, (word_t)pm_flt_other, SEL_KCODE, GATE_INT286);
+    for (v = 0; v < 32; v++)    /* per-vector entries so the reporter knows the vector */
+        idt_gate_set(v, (unsigned)pm_fault_panic + v*8, SEL_KCODE, GATE_INT286);
+    for (v = 32; v < MAX_IDT_ENTRIES; v++)
+        idt_gate_set(v, (unsigned)pm_fault_panic + 33*8, SEL_KCODE, GATE_INT286);
 }
 
 /* Called once from start_kernel: fill the kernel's own descriptors, build

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -25,7 +25,7 @@ int free_irq(int irq);
 
 /* irqtab.S */
 void _irqit (void);
-void int_vector_set (int vect, word_t proc, word_t seg);
+void int_vector_set(unsigned int vect, word_t proc, seg_t seg);
 void idle_halt(void);
 
 void div0_handler(int irq, struct pt_regs *regs);

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -75,6 +75,13 @@ struct dtr {
 
 /* ---- HAL hooks (implemented in pm286.c and pmode.S) ---- */
 
+/* The ELKS PM Interupt Descriptor Table uses the same physical memory as
+ * the real mode Interrupt Vector Table, except that the IDT uses 8 bytes/entry
+ * whereas the IVT uses just 4. Thus, only the first 128 entries will fit into
+ * the original IVT locations before extending into the BIOS Data Area starting
+ * at physical address 0x400.
+ * NOTE: MAX_IDT_ENTRIES > 128 uses 8 bytes of the BDA per additional entry!
+ */
 #define MAX_IDT_ENTRIES 129     /* 0..NR_IRQS required, needs 129 for 0x80 syscall */
 
 void gdt_init(void);            /* build fixed GDT selector enries */
@@ -100,6 +107,6 @@ addr_t desc_base(sel_t sel);
 segext_t desc_limit(sel_t sel); /* FIXME: will need 16M limit for 386 PM/fmemalloc */
 
 /* install an interrupt gate (used by the IRQ/syscall path). */
-void idt_gate_set(int vect, unsigned int offset, sel_t selector, byte_t access);
+void idt_gate_set(unsigned int vect, unsigned int offset, sel_t selector, byte_t access);
 
 #endif /* __ARCH_SEG286_H */

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -73,18 +73,20 @@ struct dtr {
 #define MK_SEL(index, ti, rpl)  (((unsigned)(index) << 3) | (ti) | (rpl))
 #define SEL_INDEX(sel)          ((unsigned)(sel) >> 3)
 
-/* ---- HAL hooks (implemented in pm286.c and pm_enter.S) ---- */
+/* ---- HAL hooks (implemented in pm286.c and pmode.S) ---- */
 
-extern char pm_flt_base[];       /* pm_enter.S: 32 stubs, 8 bytes each */
-void pm_flt_other(void);         /* generic stub for vectors >= 32 */
+#define MAX_IDT_ENTRIES 129     /* 0..NR_IRQS required, needs 129 for 0x80 syscall */
+
+void gdt_init(void);            /* build fixed GDT selector enries */
+void pm_fault_panic(void);      /* PM exception handler: display info and halt */
+
+/* load GDTR and IDTR, set PM via SMSW/LMSW, reload CS */
 void enable_protected_mode(struct dtr *gdtr, struct dtr *idtr);
 
-/* boot: build GDT[GDT_KCODE/KDATA], load GDTR+IDTR, set CR0.PE, far-jump to PM */
-void gdt_init(void);
-
 /* allocate a descriptor for [base, base+paras*16) with `access`; returns a
- * selector (0 on table-full). seg_alloc() calls this after reserving physram. */
-sel_t desc_alloc(addr_t base, segext_t paras, byte_t access);
+ * selector (0 on table-full). seg_alloc() calls this after reserving physram.
+ */
+sel_t  desc_alloc(addr_t base, segext_t paras, byte_t access);
 
 /* rewrite / free an existing selector's descriptor */
 void   desc_set(sel_t sel, addr_t base, segext_t paras, byte_t access);
@@ -98,6 +100,6 @@ addr_t desc_base(sel_t sel);
 segext_t desc_limit(sel_t sel); /* FIXME: will need 16M limit for 386 PM/fmemalloc */
 
 /* install an interrupt gate (used by the IRQ/syscall path). */
-void idt_gate_set(int vect, word_t offset, sel_t selector, byte_t access);
+void idt_gate_set(int vect, unsigned int offset, sel_t selector, byte_t access);
 
 #endif /* __ARCH_SEG286_H */

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -21,7 +21,8 @@
 #define GDT_BIOSDATA    7   /* BIOS data area (segment 0x40) */
 #define GDT_VIDEO       8   /* CGA/EGA/VGA text video memory (segment 0xB800) */
 #define GDT_TRACK       9   /* directfd DMA/track buffer (TRACKSEG) */
-#define GDT_FIRST_DYN   10  /* first dynamically-allocated selector */
+#define GDT_IDT         10  /* IDT table access at physical address 0:0 */
+#define GDT_FIRST_DYN   11  /* first dynamically-allocated selector */
 
 /* fixed kernel selectors (index<<3, GDT, RPL0) -- must match above order */
 #define SEL_KCODE       0x08
@@ -33,8 +34,7 @@
 #define SEL_BIOSDATA    0x38
 #define SEL_VIDEO       0x40
 #define SEL_TRACK       0x48
-
-#define GDT_ENTRIES     512 /* 512 * 8 = 4 KB GDT                 */
+#define SEL_IDT         0x50
 
 /*
  * Protected mode selector vs real mode segment definitions and macros


### PR DESCRIPTION
Moves the protected mode Interrupt Descriptor Table location to replace the real mode Interrupt Vector Table location, saving 2K bytes of kernel data segment space. The IDT requires 129 entries, since ELKS uses INT 0x80 (=128) for the syscall interrupt.

The table size is also reduced to 129 entries from 256, which requires 1032 bytes of RAM at 0:0. This overwrites the first 8 bytes of the BIOS Data Area which contain the port addresses of COM1-COM4 to no effect, since ELKS doesn't use the BDA for COM port address initialization.

The PM exception fault handler was cleaned up and renamed pm_fault_panic, which better describes its current operation of  displaying the faulting vector number, CS/IP/FLAGS and halting.