### PR TITLE
[kernel] Update GDT and IDT structure members for 80386+ compatibility in PM kernel

### DIFF
--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -89,18 +89,16 @@ early_putchar:
 #elif defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_8018X)
 early_putchar:
 #ifdef CONFIG_286_PMODE
-        // protected mode: BIOS INT 10h is the #MF gate, not video -- write COM1
-        // via pm_putc_ser (lib/pm_enter.S), which takes the char in AL
         mov   %sp,%bx
-        mov   2(%bx),%al        // char (cdecl: [ret][char])
-        call  pm_putc_ser
+        mov   2(%bx),%al
+        call  pm_putc_ser               // write COM1, can't use BIOS INT 10h
         ret
 #else
         mov   %sp,%bx
         mov   2(%bx),%al
         mov   $0x0E,%ah
         mov   $0x0007,%bx
-        push  %bp               // some BIOS may destroy BP
+        push  %bp                       // some BIOS may destroy BP
         int   $0x10
         pop   %bp
         ret

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -97,7 +97,7 @@ static size_t kmem_read(struct inode *inode, struct file *filp, char *data, size
      * reading an argv string near the top of a process's stack) can overshoot
      * it and #GP.  Read only up to the limit.
      */
-    segext_t lim = desc_limit(sseg);        /* max valid byte offset */
+    unsigned int lim = desc_limit(sseg);    /* max valid byte offset (< 64K) */
     if (soff > lim)
         len = 0;
     else if (len - 1 > lim - soff) {

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -32,10 +32,11 @@ static byte_t seg_pm_access(word_t type)
     return ((type & SEG_FLAG_TYPE) == SEG_FLAG_CSEG) ? DESC_KCODE : DESC_KDATA;
 }
 
-/* allocate selector for passed segment_s structure, 0 = GDT full */
+/* allocate selector for passed segment_s structure, 0 = GDT full or limit exceeded */
 static int seg_pm_attach(segment_s *seg, word_t type)
 {
-    seg->base = desc_alloc(PARA_BYTES(seg->para), seg->size, seg_pm_access(type));
+    seg->base = desc_alloc(PARA_BYTES(seg->para), PARA_BYTES(seg->size),
+        seg_pm_access(type));
     return seg->base;
 }
 

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -107,7 +107,7 @@ addr_t desc_limit(sel_t sel)
  * After idt_init() sel_idt is updated to SEL_IDT for PM access to the IDT.
  */
 static seg_t sel_idt = 0;   /* init for real mode segment 0 */
-void idt_gate_set(unsigned int vect, unsigned int offset, sel_t selector, byte_t access)
+void idt_gate_set(unsigned int vect, unsigned int proc, sel_t selector, byte_t access)
 {
     struct idt_gate __far *g;
 
@@ -116,11 +116,11 @@ void idt_gate_set(unsigned int vect, unsigned int offset, sel_t selector, byte_t
         return;
     }
     g = _MK_FP(sel_idt, vect * sizeof(struct idt_gate));
-    g->offset   = offset;
+    g->offset   = proc;
     g->selector = selector;
-    g->zero     = 0;
+    g->wcount   = 0;            /* word count (=0 for 286 task and interrupt gates) */
     g->access   = access;
-    g->reserved = 0;
+    g->offset_hi= 0;            /* high 16 bits handler address (=0 for 286) */
 }
 
 /* Point IDT vectors at the fault-catch handler so an exception between

--- a/elks/arch/i86/mm/pm286.c
+++ b/elks/arch/i86/mm/pm286.c
@@ -1,12 +1,10 @@
 /*
- * 80286 protected-mode descriptor allocator -- the seg_alloc() backend
- * for CONFIG_286_PMODE.  See <arch/seg286.h> for the overall design.
+ * 80286/80386+ Protected-mode descriptor allocator.
  *
- * Real-mode builds do not compile this file; seg_alloc() returns paragraphs.
  * In PM, seg_alloc() reserves physical paragraphs from the existing arena as
- * usual, then calls desc_alloc(phys_base, paras, DESC_*) and stores the
- * returned SELECTOR in segment_s.base.  The far-memory primitives then load
- * that selector into a segment register and the 286 resolves it via the GDT.
+ * usual, then calls desc_alloc to allocate a selector, which is stored instead
+ * of the real mode segment in segment_s.base.  The far-memory primitives then load
+ * that selector into a segment register and the CPU resolves it via the GDT.
  */
 #include <linuxmt/config.h>
 #include <linuxmt/types.h>
@@ -17,57 +15,57 @@
 #include <arch/seg286.h>
 #include <arch/irq.h>
 
-/*
- * Config validation: protected mode cannot call the BIOS (real-mode IVT/
- * services are gone after PM entry), so any BIOS-backed driver selected in
- * .config would build fine and then fault at runtime with a raw EXC= dump.
- * Fail the compile instead, naming the required change.
- */
+/* Disallow certain configurations for protected mode builds */
 #if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD)
-#error 286 PM: BIOS disk (BFD/BHD, int 0x13) cannot work - disable both, use CONFIG_BLK_DEV_FD (directfd) with root=df0
+#error BIOS INT 13h fd/hd disallowed in PM build. Use CONFIG_BLK_DEV_FD with root=df0
 #endif
 #ifdef CONFIG_CONSOLE_BIOS
-#error 286 PM: BIOS console (int 0x10) cannot work - use CONFIG_CONSOLE_DIRECT or CONFIG_CONSOLE_SERIAL
+#error BIOS INT 10h console disallowed in PM build. Use CONFIG_CONSOLE_DIRECT or CONFIG_CONSOLE_SERIAL
 #endif
 #if defined(CONFIG_ARCH_IBMPC) && !defined(CONFIG_KEYBOARD_SCANCODE)
-#error 286 PM: without CONFIG_KEYBOARD_SCANCODE the IBMPC build links kbd-poll/conio-bios (int 0x16) - enable it
+#error BIOS INT 16h non-scancode keyboard disallowed in PM build. Use CONFIG_KEYBOARD_SCANCODE
 #endif
 
-/* The Global Descriptor Table (max 4 KB, in the kernel data segment).
- * GDT_KCODE/KDATA are the kernel's own segments; GDT_FIRST_DYN..end are
- * handed out by desc_alloc() for process/buffer segments.
- */
+/* Global Descriptor Table */
 static struct gdt_entry gdt[MAX_GDT_ENTRIES];
 
 /* round-robin hint for the next candidate free slot */
 static int next_dyn = GDT_FIRST_DYN;
 
-void desc_set(sel_t sel, addr_t base, segext_t paras, byte_t access)
+/* set GDT entry for passed selector */
+sel_t desc_set(sel_t sel, addr_t base, addr_t limit, byte_t access)
 {
     struct gdt_entry *d = &gdt[SEL_INDEX(sel)];
-    addr_t limit = PARA_BYTES(paras);
 
-    if (limit == 0 || limit > 0x10000L)     /* a 286 segment is <= 64 KB */
-        limit = 0x10000L;
-    d->limit    = (word_t)(limit - 1);      /* limit is bytes-1 */
-    d->base_lo  = (word_t)(base & 0xFFFF);
-    d->base_hi  = (byte_t)((base >> 16) & 0xFF);
-    d->access   = access;
-    d->reserved = 0;                        /* must be 0 on a 286 */
+    /* Allow selector limit of max 64K for now for automatic 80286 compatibility.
+     * User mode fmemalloc allocations are also limited to 64K max segments
+     * unless 32-bit instructions are used within the application.
+     */
+    if ((limit >> 16) > 1) {                /* limit size to 64K max for now */
+        printk("desc_set: %08lx limit > 64K\n", limit);
+        return 0;
+    }
+
+    d->limit_lo     = (word_t)limit - 1;    /* limit is bytes-1 */
+    d->base_lo      = base & 0xFFFF;
+    d->base_hi      = (base >> 16) & 0xFF;
+    d->access       = access;
+    d->fl_limit_hi  = 0;                    /* must be 0 on a 286 */
+    d->base_24      = 0;                    /* must be 0 on a 286 */
+    return sel;
 }
 
-/* change only the access byte (base/limit kept) -- exec flips its text seg
- * data(writable, to load) -> code(executable, to run)
- */
+/* Change access byte for passed selector */
 void desc_chaccess(sel_t sel, byte_t access)
 {
     gdt[SEL_INDEX(sel)].access = access;
 }
 
-/* find a free GDT slot, fill it, return its selector (0 = table full) */
-sel_t desc_alloc(addr_t base, segext_t paras, byte_t access)
+/* find a free GDT slot, fill it, return its selector (0 = table full or limit > 64K) */
+sel_t desc_alloc(addr_t base, addr_t limit, byte_t access)
 {
     int i, scanned;
+    sel_t sel = 0;
     flag_t flags;
 
     save_flags(flags);  /* may be called at interrupt time through xms_fmemcpy */
@@ -75,16 +73,14 @@ sel_t desc_alloc(addr_t base, segext_t paras, byte_t access)
     i = next_dyn;
     for (scanned = 0; scanned < MAX_GDT_ENTRIES - GDT_FIRST_DYN; scanned++) {
         if (gdt[i].access == 0) {
-            sel_t sel = MK_SEL(i, SEL_GDT, SEL_RPL0);
-            desc_set(sel, base, paras, access);
+            sel = desc_set(MK_SEL(i, SEL_GDT, SEL_RPL0), base, limit, access);
             next_dyn = (i + 1 < MAX_GDT_ENTRIES) ? i + 1 : GDT_FIRST_DYN;
-            restore_flags(flags);
-            return sel;
+            break;
         }
         if (++i >= MAX_GDT_ENTRIES) i = GDT_FIRST_DYN;
     }
     restore_flags(flags);
-    return 0;                                            /* GDT full */
+    return sel;
 }
 
 void desc_free(sel_t sel)
@@ -92,6 +88,7 @@ void desc_free(sel_t sel)
     gdt[SEL_INDEX(sel)].access = 0;                      /* clear Present */
 }
 
+/* return selector physical base address (< 16M) */
 addr_t desc_base(sel_t sel)
 {
     struct gdt_entry *d = &gdt[SEL_INDEX(sel)];
@@ -99,9 +96,10 @@ addr_t desc_base(sel_t sel)
     return ((addr_t)d->base_hi << 16) | d->base_lo;
 }
 
-segext_t desc_limit(sel_t sel)         /* max valid byte offset in the segment */
+/* return selector limit (< 64K). FIXME: will need 16M limit for 386 PM/fmemalloc */
+addr_t desc_limit(sel_t sel)
 {
-    return gdt[SEL_INDEX(sel)].limit;
+    return gdt[SEL_INDEX(sel)].limit_lo;
 }
 
 
@@ -144,9 +142,7 @@ static void idt_init(void)
  */
 void gdt_init(void)
 {
-    addr_t   code_base  = (addr_t)kernel_cs << 4;
     addr_t   data_base  = (addr_t)kernel_ds << 4;
-    segext_t text_para  = BYTES_PARA((unsigned)_endtext);
     static struct dtr gdtr, idtr;
 
     /* enable A20 while still in real mode (calls BIOS) */
@@ -158,17 +154,21 @@ void gdt_init(void)
      * selectors (SEL_KCODE/SEL_KFTEXT/SEL_KDATA) instead of paragraphs.
      */
     desc_set(MK_SEL(GDT_NULL,   SEL_GDT, SEL_RPL0), 0,          0,         0);
-    desc_set(MK_SEL(GDT_KCODE,  SEL_GDT, SEL_RPL0), code_base,  text_para, DESC_KCODE);
-    desc_set(MK_SEL(GDT_KDATA,  SEL_GDT, SEL_RPL0), data_base,  0x1000,    DESC_KDATA);
+
+    desc_set(MK_SEL(GDT_KCODE,  SEL_GDT, SEL_RPL0),
+        (addr_t)kernel_cs << 4, (unsigned)_endtext, DESC_KCODE);
+
+    desc_set(MK_SEL(GDT_KDATA,  SEL_GDT, SEL_RPL0), data_base, 65536L, DESC_KDATA);
+
     if (kernel_ftext) {
-        desc_set(MK_SEL(GDT_KFTEXT, SEL_GDT, SEL_RPL0), (addr_t)kernel_ftext << 4,
-                                          BYTES_PARA((unsigned)_endftext), DESC_KCODE);
+        desc_set(MK_SEL(GDT_KFTEXT, SEL_GDT, SEL_RPL0),
+            (addr_t)kernel_ftext << 4, (unsigned)_endftext, DESC_KCODE);
     }
 
     /* KCODE same base/limit as KDATA but executable+readable. IRQ trampolines are
      * built in the kernel data segment, and an IDT gate needs an executable selector.
      */
-    desc_set(MK_SEL(GDT_KDATA_EXEC, SEL_GDT, SEL_RPL0), data_base, 0x1000, DESC_KCODE);
+    desc_set(MK_SEL(GDT_KDATA_EXEC, SEL_GDT, SEL_RPL0), data_base, 65536L, DESC_KCODE);
 
     /* IDT replaces real mode IVT interrupt vector table + 8 bytes from 0:0 to 0:0407.
      * NOTE: With the normal MAX_IDT_ENTRIES of 129 (required for syscall INT 0x80),
@@ -177,32 +177,28 @@ void gdt_init(void)
      * bytes of the BDA contain the port addresses of COM1-COM4, which aren't used
      * by ELKS setupb/setupw anyways.
      */
-    desc_set(MK_SEL(GDT_IDT, SEL_GDT, SEL_RPL0), 0, BYTES_PARA(MAX_IDT_ENTRIES * 8),
-        DESC_KDATA);
+    desc_set(MK_SEL(GDT_IDT, SEL_GDT, SEL_RPL0), 0, MAX_IDT_ENTRIES * 8, DESC_KDATA);
 
     /* setupb/setupw setup.S data segment */
-    desc_set(MK_SEL(GDT_SETUP, SEL_GDT, SEL_RPL0), SEG_INITSEG << 4, BYTES_PARA(512),
-        DESC_KDATA);
+    desc_set(MK_SEL(GDT_SETUP, SEL_GDT, SEL_RPL0), SEG_INITSEG << 4, 512, DESC_KDATA);
 
     /* boot options (/bootopts) segment */
-    desc_set(MK_SEL(GDT_OPTSEG, SEL_GDT, SEL_RPL0), SEG_OPTSEG << 4, BYTES_PARA(1024),
-        DESC_KDATA);
+    desc_set(MK_SEL(GDT_OPTSEG, SEL_GDT, SEL_RPL0), SEG_OPTSEG << 4, 1024, DESC_KDATA);
 
     /* BIOS data area */
     desc_set(MK_SEL(GDT_BIOSDATA, SEL_GDT, SEL_RPL0), SEG_BIOSDATA << 4, BYTES_PARA(256),
         DESC_KDATA);
 
     /* text video memory */
-    desc_set(MK_SEL(GDT_VIDEO, SEL_GDT, SEL_RPL0), (addr_t)SEG_VIDEO << 4, 0x1000,
+    desc_set(MK_SEL(GDT_VIDEO, SEL_GDT, SEL_RPL0), (addr_t)SEG_VIDEO << 4, 32768L,
         DESC_KDATA);
 
     /* direct floppy DMA track buffer */
-    desc_set(MK_SEL(GDT_TRACKBUF, SEL_GDT, SEL_RPL0), SEG_TRACK << 4,
-        BYTES_PARA(TRACKSEGSZ), DESC_KDATA);
+    desc_set(MK_SEL(GDT_TRACKBUF, SEL_GDT, SEL_RPL0), SEG_TRACK << 4, TRACKSEGSZ,
+        DESC_KDATA);
 
     /* ATA/CF DMA sector buffer */
-    desc_set(MK_SEL(GDT_DMABUF, SEL_GDT, SEL_RPL0), SEG_DMASEG << 4, BYTES_PARA(512),
-        DESC_KDATA);
+    desc_set(MK_SEL(GDT_DMABUF, SEL_GDT, SEL_RPL0), SEG_DMASEG << 4, 512, DESC_KDATA);
 
     /* initialize IVT using real mode sel_idt segment 0 to fault-catch stubs */
     idt_init();

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -132,11 +132,11 @@ void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
         dst_seg, dst_off, src_seg, src_off, count);
 
     if (src_seg >> 16) {
-        sel_src = desc_alloc(src_seg, 0x40, DESC_KDATA);
+        sel_src = desc_alloc(src_seg, count, DESC_KDATA);
         src_seg = sel_src;
     }
     if (dst_seg >> 16) {
-        sel_dst = desc_alloc(dst_seg, 0x40, DESC_KDATA);
+        sel_dst = desc_alloc(dst_seg, count, DESC_KDATA);
         dst_seg = sel_dst;
     }
 	fmemcpyw(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
@@ -154,11 +154,11 @@ void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
         dst_seg, dst_off, src_seg, src_off, count);
 
     if (src_seg >> 16) {
-        sel_src = desc_alloc(src_seg, 0x40, DESC_KDATA);
+        sel_src = desc_alloc(src_seg, count, DESC_KDATA);
         src_seg = sel_src;
     }
     if (dst_seg >> 16) {
-        sel_dst = desc_alloc(dst_seg, 0x40, DESC_KDATA);
+        sel_dst = desc_alloc(dst_seg, count, DESC_KDATA);
         dst_seg = sel_dst;
     }
 	fmemcpyb(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
@@ -174,7 +174,7 @@ void xms_fmemset(void *dst_off, ramdesc_t dst_seg, size_t count)
     debug("xms_fmemset(%08lx:%04x count %u\n", dst_seg, dst_off, count);
 
     if (dst_seg >> 16) {
-        sel_dst = desc_alloc(dst_seg, 0x40, DESC_KDATA);
+        sel_dst = desc_alloc(dst_seg, count, DESC_KDATA);
         dst_seg = sel_dst;
     }
 	fmemsetb(dst_off, (seg_t)dst_seg, 0, count);

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -144,7 +144,8 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
             /* Fallback for xms=off EXT buffers requires one selector per buffer.
              * seg is already PM selector of max 64K array of 1K buffers.
              */
-            ebh->b_L2seg = desc_alloc(desc_base((seg_t)seg) + offset, 0x40, DESC_KDATA);
+            ebh->b_L2seg = desc_alloc(desc_base((seg_t)seg) + offset,
+                BLOCK_SIZE, DESC_KDATA);
         }
 #else
         size_t offset = xmsenabled?  ((n & 63) << BLOCK_SIZE_BITS) :

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -4,40 +4,39 @@
 #include <linuxmt/types.h>
 
 /*
- * 80286 protected-mode segment HAL for ELKS        (gated by CONFIG_286_PMODE)
+ * 80286/80386+ Protected-mode segment HAL for ELKS
  *
  * Design
  * ------
  * The kernel's segment abstraction is already the HAL boundary:
  *   - upper kernel (fs/, kernel/, net/) only ever holds an opaque seg_t and
  *     passes it to the far-memory primitives (peekb/peekw/pokeb/pokew,
- *     fmemcpyb/w, fmemsetb/w, fmemcmpb/w) and to seg_alloc()/segment_s.base.
+ *     fmemcpyb/w, fmemsetb/w, fmemcmpb/w) and to seg_alloc/segment_s.base.
  *   - those primitives do "mov es,seg ; ... es:[off]". That instruction works
  *     in both real mode (es = paragraph, phys = es*16+off) and protected mode
  *     (es = selector, phys = descriptor[es].base + off) -- the CPU resolves it
- *     per current mode. So the far-mem asm needs NO change.
+ *     per current mode. So the far-mem asm needs no change.
  *
- * Therefore the 286-PM port is confined to three things, all below the HAL line:
- *   1. seg_t now carries a selector (not a paragraph). segment_s.base = selector;
- *      the physical base lives in the descriptor (desc_base() recovers it).
+ * Therefore the PM port is confined to three things, all below the HAL line:
+ *   1. seg_t now carries a selector (not a segment). segment_s.base = selector;
+ *      the physical base lives in the descriptor.
  *   2. seg_alloc()/seg_free() allocate physical paragraphs, then also
  *      allocate/free a GDT descriptor and return its selector in segment_s.base.
  *   3. boot sets up the GDT/IDT and enters protected mode; exec() loads
- *      selectors into CS/DS/SS instead of paragraphs.
+ *      selectors into CS/DS/SS instead of segments.
  *
- * Real-mode build (CONFIG_286_PMODE off) is unaffected: seg_t stays a paragraph.
- * and none of the protected mode routines are linked into the kernel.
+ * Real-mode build is unaffected: seg_t stays a paragraph, and none of the
+ * protected mode routines are linked into the kernel.
  */
 
-/* ---- 80286 segment descriptor: 8 bytes; high word MUST be 0 on a 286 ----
- * (on a 386 the reserved word holds limit[16:19]+flags+base[24:31]; writing 0
- *  there yields 286-equivalent semantics, so this layout is forward-compatible) */
+/* 80286/80386+ segment descriptor */
 struct gdt_entry {
-    word_t  limit;          /* segment limit in bytes-1  (0..0xFFFF => <=64K)   */
-    word_t  base_lo;        /* physical base bits 0..15                          */
-    byte_t  base_hi;        /* physical base bits 16..23 (24-bit base => 16 MB)  */
-    byte_t  access;         /* P | DPL | S | type | A  (see DESC_* below)        */
-    word_t  reserved;       /* 0 on 286                                          */
+    word_t  limit_lo;       /* segment limit bits 15:0 in bytes - 1             */
+    word_t  base_lo;        /* physical base bits 15:0                          */
+    byte_t  base_hi;        /* physical base bits 23:16 (24-bit base = 16 MB)   */
+    byte_t  access;         /* P | DPL | S | type | A  (see DESC_* below)       */
+    byte_t  fl_limit_hi;    /* flags[7:4], limit[3:0] bits 19:16 (0 on 286)     */
+    byte_t  base_24;        /* physical base bits 31:24 (0 on 286)              */
 };
 
 /* access byte: bit7=Present 6-5=DPL 4=S(1=code/data) 3=E 2=C/ED 1=R/W 0=Accessed */
@@ -93,10 +92,10 @@ void enable_protected_mode(struct dtr *gdtr, struct dtr *idtr);
 /* allocate a descriptor for [base, base+paras*16) with `access`; returns a
  * selector (0 on table-full). seg_alloc() calls this after reserving physram.
  */
-sel_t  desc_alloc(addr_t base, segext_t paras, byte_t access);
+sel_t  desc_alloc(addr_t base, addr_t limit, byte_t access);
 
 /* rewrite / free an existing selector's descriptor */
-void   desc_set(sel_t sel, addr_t base, segext_t paras, byte_t access);
+sel_t  desc_set(sel_t sel, addr_t base, addr_t limit, byte_t access);
 void   desc_chaccess(sel_t sel, byte_t access);
 void   desc_free(sel_t sel);
 
@@ -104,7 +103,7 @@ void   desc_free(sel_t sel);
 addr_t desc_base(sel_t sel);
 
 /* max valid byte offset in a selector's segment (its descriptor limit) */
-segext_t desc_limit(sel_t sel); /* FIXME: will need 16M limit for 386 PM/fmemalloc */
+addr_t desc_limit(sel_t sel);
 
 /* install an interrupt gate (used by the IRQ/syscall path). */
 void idt_gate_set(unsigned int vect, unsigned int offset, sel_t selector, byte_t access);

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -46,22 +46,22 @@ struct gdt_entry {
 #define DESC_UCODE  0xFA    /* present, DPL3, code, readable        */
 #define DESC_UDATA  0xF2    /* present, DPL3, data, writable        */
 
-/* ---- 80286 interrupt/trap gate: 8 bytes (high word 0 on a 286) ---- */
+/* 80286/80386+ interrupt/trap gate */
 struct idt_gate {
-    word_t  offset;         /* handler offset within `selector`             */
-    word_t  selector;       /* code (or data-as-code) selector of handler   */
-    byte_t  zero;           /* always 0                                     */
-    byte_t  access;         /* P | DPL | gate type (GATE_* below)           */
-    word_t  reserved;       /* 0 on a 286                                   */
+    word_t  offset;         /* handler address bits 15:0                        */
+    word_t  selector;       /* code (or data-as-code) selector of handler       */
+    byte_t  wcount;         /* word count (=0 for 80286 interrupt/trap gates)   */
+    byte_t  access;         /* P | DPL | gate type (GATE_* below)               */
+    word_t  offset_hi;      /* handler address bits 23:16 (=0 for 80286)        */
 };
 
 #define GATE_INT286   0x86  /* present, DPL0, 286 interrupt gate (clears IF) */
 #define GATE_TRAP286  0x87  /* present, DPL0, 286 trap gate (leaves IF)      */
 
-/* lgdt/lidt operand: 16-bit limit + linear physical base (286 uses low 24 bits) */
+/* descriptor table register operand for LGDT and LIDT instructions */
 struct dtr {
-    word_t limit;
-    addr_t base;
+    word_t limit;           /* size of table - 1 */
+    addr_t base;            /* 24-bit linear physical base address from real mode */
 };
 
 /* selector = (index << 3) | TI | RPL */
@@ -106,6 +106,6 @@ addr_t desc_base(sel_t sel);
 addr_t desc_limit(sel_t sel);
 
 /* install an interrupt gate (used by the IRQ/syscall path). */
-void idt_gate_set(unsigned int vect, unsigned int offset, sel_t selector, byte_t access);
+void idt_gate_set(unsigned int vect, unsigned int proc, sel_t selector, byte_t access);
 
 #endif /* __ARCH_SEG286_H */


### PR DESCRIPTION
`desc_alloc` and `desc_set` now passed 32-bit limits for future compatibility with 80386 CPUs, but still limited to 64K max segment sizes for automatic compatibility with 80286 CPUs. There remain potential issues with user mode use of `fmemalloc` for allocations > 64K.

Descriptor limits are now passed in bytes rather than than paragraphs for code simplicity as well as byte-accurate segment sizes, rather than previous silent extension to paragraph boundaries.