### PR TITLE
[kernel] Fix BIOSDATA descriptor limit (bytes, not paragraphs) — PM t…

### DIFF
--- a/elks/arch/i86/mm/pmode.c
+++ b/elks/arch/i86/mm/pmode.c
@@ -161,8 +161,15 @@ void gdt_init(void)
     desc_set(MK_SEL(GDT_KCODE,  SEL_GDT, SEL_RPL0),
         (addr_t)kernel_cs << 4, (unsigned)_endtext, DESC_KCODE);
 
+    /* Full 64K limit: gdt_init runs before setup_arch() computes membase,
+     * so (membase - kernel_ds) << 4 here would be garbage (membase still 0),
+     * truncating the limit and #GP-faulting the first heap access above it
+     * on hardware that enforces limits (VT-x/KVM; QEMU TCG doesn't check).
+     * setup_arch() extends the kernel data segment to a maximum of 64K for
+     * the near heap anyway, matching the KDATA_EXEC alias below.
+     */
     desc_set(MK_SEL(GDT_KDATA,  SEL_GDT, SEL_RPL0),
-        data_base, (membase - kernel_ds) << 4, DESC_KDATA);
+        data_base, 65536L, DESC_KDATA);
 
     if (kernel_ftext) {
         desc_set(MK_SEL(GDT_KFTEXT, SEL_GDT, SEL_RPL0),

--- a/elks/arch/i86/mm/pmode.c
+++ b/elks/arch/i86/mm/pmode.c
@@ -190,7 +190,7 @@ void gdt_init(void)
     desc_set(MK_SEL(GDT_OPTSEG, SEL_GDT, SEL_RPL0), SEG_OPTSEG << 4, 1024, DESC_KDATA);
 
     /* BIOS data area */
-    desc_set(MK_SEL(GDT_BIOSDATA, SEL_GDT, SEL_RPL0), SEG_BIOSDATA << 4, BYTES_PARA(256),
+    desc_set(MK_SEL(GDT_BIOSDATA, SEL_GDT, SEL_RPL0), SEG_BIOSDATA << 4, 256,
         DESC_KDATA);
 
     /* text video memory */


### PR DESCRIPTION
…riple-faults under VT-x

Human note: supposed to fix https://github.com/ghaerr/elks/issues/2734

AI description below:

> Summary
> 
> The protected-mode kernel triple-faults during early boot under hardware virtualization (VirtualBox / QEMU-KVM / VT-x), while booting normally under QEMU-TCG. Root cause is a one-line unit mismatch: a GDT descriptor is given a limit in paragraphs where bytes are now expected.
> 
> Root cause
> 
> Commit d6e480de ("Prepare for > 64K future selector limits") changed desc_set() to take a byte limit instead of a paragraph count, and updated the callers accordingly — except GDT_BIOSDATA in gdt_init(), which still wraps its size in BYTES_PARA(256):
> 
> desc_set(MK_SEL(GDT_BIOSDATA, ...), SEG_BIOSDATA << 4, BYTES_PARA(256), DESC_KDATA);
> 
> BYTES_PARA(256) evaluates to 256 >> 4 = 16, so the BIOS Data Area segment gets a 16-byte limit instead of 256.
> 
> console_init() reads the 80-column word at BDA offset 0x40:0x4A via peekb(0x4A, GDT_BIOSDATA). Offset 0x4A (74) is past the 16-byte limit:
> 
> - On hardware VT-x, the segment limit is enforced → #GP → the kernel triple-faults right after ttyS0 ..., before the PC/AT class cpu banner.
> - On QEMU TCG, segment limits aren't checked, so the read silently returns the correct byte and the kernel boots — which is why this only manifests on hardware-virtualized targets.
> 
> Fix
> 
> Pass the limit in bytes, consistent with the other descriptors updated in d6e480de:
> 
> desc_set(MK_SEL(GDT_BIOSDATA, ...), SEG_BIOSDATA << 4, 256, DESC_KDATA);
> 
> How it was found
> 
> git bisect between a5b7da49 (good) and 2c8c71a9 (bad), boot-testing each step in a VirtualBox VM on VT-x → first-bad-commit d6e480de. Fault frame decoded to peekb called from console_init with selector GDT_BIOSDATA, offset 0x4A.
> 
> Testing
> 
> - Before: current master → VirtualBox Guru Meditation (VINF_EM_TRIPLE_FAULT) / KVM triple fault; TCG boots.
> - After: boots to login on VirtualBox VT-x (mounts root, runs /etc/rc.sys); TCG unaffected.
> - GDT_BIOSDATA was the only remaining BYTES_PARA()-wrapped descriptor limit in gdt_init().