### PR TITLE
[kernel] Potential issue with idle task struct stack overwrite

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -134,17 +134,28 @@ static void FARPROC far_start_kernel(void)
     early_kernel_init();            /* read bootopts using kernel interrupt stack */
 
      /*
-      * Allocate the task array + smaller task struct for the idle task.
-      * The idle task struct has a smaller stack in t_kstack[] and no t_regs.
-      * This works because the idle task always runs at intr_count 1, so
-      * interrupts will always save registers onto istack, and never
-      * to the t_regs struct at the end of a normal task struct.
+      * Allocate the task array + a FULL task struct for the idle task.
+      *
+      * The idle task used to get a truncated struct (no t_regs, only
+      * IDLESTACK_BYTES of t_kstack) on the assumption that it always runs
+      * at intr_count 1 so interrupts save registers onto the istack.  That
+      * invariant is only self-establishing: kernel threads and idle run at
+      * intr_count 0 until the first interrupt whose was_trap path calls
+      * schedule() - a window that includes boot and the root-mount phase.
+      * A hardware interrupt over idle in that window takes the utask path,
+      * which saves the context into idle_task->t_regs and runs the whole
+      * handler with its stack descending through t_kstack - for the
+      * truncated struct both are PAST the allocation, silently overwriting
+      * the next heap block (measured: the system inode table's header and
+      * first ~7 inodes).  See Documentation/bugs/idle-truncated-tregs-
+      * interrupt.md.  A full struct makes those writes land in owned
+      * memory, at a one-time cost of
+      * (KSTACK_BYTES - IDLESTACK_BYTES + sizeof(struct pt_regs)) bytes.
       */
-     task = heap_alloc(max_tasks * sizeof(struct task_struct) +
-         TASK_KSTACK + IDLESTACK_BYTES, HEAP_TAG_TASK|HEAP_TAG_CLEAR);
+     task = heap_alloc((max_tasks + 1) * sizeof(struct task_struct),
+         HEAP_TAG_TASK|HEAP_TAG_CLEAR);
      if (!task) panic("No task mem");
-     idle_task = (struct task_struct *)
-         ((char *)task + max_tasks * sizeof(struct task_struct));
+     idle_task = task + max_tasks;
     setsp(&(task+1)->t_regs.ax);    /* change to a large temp stack (unused task #1) */
     debug("SP SWITCH\n");
 

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -16,7 +16,7 @@
 #include <arch/irq.h>
 
 struct task_struct *task;           /* dynamically allocated task array */
-struct task_struct *idle_task;      /* NOTE: valid only thru k_stack[IDLESTACK_BYTES/2] */
+struct task_struct *idle_task;      /* full struct; idle_loop uses only t_kstack[0..IDLESTACK_BYTES/2] */
 struct task_struct *current;
 struct task_struct *previous;
 int max_tasks = MAX_TASKS;


### PR DESCRIPTION
It seems that recent PM changes have more than one bug. These are latent, in the sense that accidental memory writes only cause crashes in certain circumstances. Here's one of them.
The proposed fix is AI-generated, so it's possibly wrong/misdirected. But the underlying issue is still worth looking into.

AI description below:

### Summary

`start_kernel()` allocates a truncated task struct for the idle task (no `t_regs`, only `IDLESTACK_BYTES` of `t_kstack`), justified by:

> This works because the idle task always runs at intr_count 1, so interrupts will always save registers onto istack, and never to the t_regs struct at the end of a normal task struct.

That invariant is only **self-establishing**, not guaranteed. `intr_count` starts at 0 and is only incremented by `_irqit` entries; kernel threads started by `kfork_proc()` and the idle loop itself run at count 0 until the first interrupt whose `was_trap` path calls `schedule()` "leaks" the count to 1. The window reliably includes early boot, `kernel_init()` device probing, and the whole root-mount phase (the mount kthread and idle alternate at count 0 while waiting on floppy I/O).

### Mechanism

A hardware interrupt over idle at `intr_count 0` takes the `utask` path (`cmpw $1,intr_count; jc utask`), which

1. saves the interrupted context into `current->t_regs` — for the truncated idle that is `KSTACK_BYTES − IDLESTACK_BYTES` bytes **past the end of the allocation** (540 with CONFIG_ASYNCIO), and
2. anchors SP at `&t_regs.ax` and runs the entire handler — `do_IRQ`, device handler, bottom halves, potentially `schedule()` — with its stack descending through the phantom `t_kstack`, all in the unowned heap block that follows.

### What actually gets overwritten (measured)

Dumped from a live ibmpc-pmode image at login via the QEMU gdbstub: the heap block following the idle struct is the **system inode table** (header tag `USED|CLEAR|HEAP_TAG_INODE`, size 7488 = `NR_INODE(96) × 78`). The unowned writes land on:

- the inode block's **heap header** (allocator list links + size — corrupting any later heap walk/free), and
- the **first ~7 in-use inodes** of the mounted root filesystem.

Which bytes are hit on a given boot depends only on interrupt timing and allocation order — mainline currently survives by that lottery. (Found the hard way: a task-struct experiment shifted the layout and the same mechanism produced deterministic buffer-head corruption and a NULLed `idle_task->next_run`, traced with memory watchpoints.)

### Fix

Allocate `(max_tasks + 1)` full structs and point `idle_task` at the last one, so the utask writes land in owned memory:

```c
task = heap_alloc((max_tasks + 1) * sizeof(struct task_struct),
    HEAP_TAG_TASK|HEAP_TAG_CLEAR);
idle_task = task + max_tasks;
```

One-time cost: `KSTACK_BYTES − IDLESTACK_BYTES + sizeof(struct pt_regs)` = **562 bytes** of kernel heap (CONFIG_ASYNCIO). `idle_loop()` behavior is unchanged — it still uses only the first `IDLESTACK_BYTES` of the stack.

Alternatives considered: routing idle interrupts to the istack unconditionally (needs restore-path changes), or forcing `intr_count = 1` at boot (breaks directfd, whose request continuation legitimately sleeps from a first-level handler). The full struct is the smallest change with no semantic consequences.

### Testing

- ibmpc-pmode config builds and boots to login (QEMU TCG; booting that config under hardware virtualization currently requires `xms=off` due to the separate, pre-existing PM+XMS issue).
- The gdbstub dump confirming the inode-table victim was taken on an unpatched image; with the patch, the same addresses fall inside idle's own `t_regs`/`t_kstack`.
