### PR TITLE
CI: boot-smoke-test ELKS under qemu-kvm (hardware VT-x)

### DIFF
--- a/.github/workflows/kvm-boot-test.yml
+++ b/.github/workflows/kvm-boot-test.yml
@@ -1,0 +1,114 @@
+name: kvm-boot-test
+
+# Boot-smoke-tests ELKS under qemu-kvm (hardware VT-x via the runner's
+# nested virtualization).  Unlike QEMU TCG, KVM enforces segment descriptor
+# limits and faults exactly like real silicon - the bug class behind
+# PR #2735 (GDT_BIOSDATA / GDT_KDATA limits) is invisible on TCG and only
+# manifests here.  Pass = serial console reaches "login:"; fail = kernel
+# panic or boot timeout.
+
+on:
+  push:
+    paths:
+      - '**'
+      - '!.github/workflows/cross.yml'
+      - '!tools/*'
+  pull_request:
+
+jobs:
+  boot:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - ibmpc-1440.config    # real-mode baseline
+          - ibmpc-pmode.config   # 286 protected mode - the VT-x-sensitive build
+
+    # ibmpc-pmode currently fails at root mount under hardware
+    # virtualization with XMS enabled (pre-existing issue, invisible on
+    # TCG).  Report it as a warning, not a red X, until that is fixed -
+    # then remove this to make the job gating.
+    continue-on-error: ${{ matrix.config == 'ibmpc-pmode.config' }}
+
+    env:
+      MAKEFLAGS: "-j$(nproc)"
+
+    steps:
+      - name: setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --fix-missing texinfo libncurses5-dev libelf-dev ncompress qemu-system-x86
+
+      # GitHub-hosted Linux runners expose /dev/kvm; grant access to the runner user
+      - name: enable KVM
+        run: |
+          echo "--- CPU virt flags ---"
+          grep -cE '(vmx|svm)' /proc/cpuinfo || true
+          echo "--- kvm modules ---"
+          lsmod | grep -i kvm || true
+          sudo modprobe kvm_intel 2>/dev/null || sudo modprobe kvm_amd 2>/dev/null || true
+          echo "--- /dev/kvm before ---"
+          ls -la /dev/kvm || true
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm || true
+          [ -e /dev/kvm ] && sudo chmod 666 /dev/kvm
+          echo "--- /dev/kvm after ---"
+          ls -la /dev/kvm
+          test -w /dev/kvm && echo "KVM available"
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      # same cached cross toolchain as main.yml
+      - name: cache cross toolchain
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: cross
+          key: cross-${{ hashFiles('tools/*') }}-${{ runner.os }}
+
+      - name: build cross toolchain
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p cross
+          tools/build.sh
+
+      - name: build ELKS (${{ matrix.config }})
+        run: |
+          . ./env.sh
+          cp ${{ matrix.config }} .config
+          ( cd elks/arch/i86/drivers/char/KeyMaps && ./mkcfg )   # generate keymaps.h
+          # serial getty so the boot outcome is observable on COM1
+          # ("3" = multi-user runlevel with getty on ttyS0)
+          sed -i 's|^#console=ttyS0,19200 3|console=ttyS0,19200 3|' \
+            elkscmd/rootfs_template/bootopts
+          make
+
+      - name: boot under KVM
+        run: |
+          timeout 180 qemu-system-i386 -accel kvm -m 8 \
+            -fda image/fd1440.img -boot a \
+            -serial file:serial.log -display none -no-reboot &
+          QEMU=$!
+          # PASS: "login:"  FAIL: "panic"  FAIL: 150s without either (hang)
+          for i in $(seq 1 75); do
+            grep -q  'login:' serial.log 2>/dev/null && break
+            grep -qi 'panic'  serial.log 2>/dev/null && break
+            sleep 2
+          done
+          kill $QEMU 2>/dev/null || true
+          echo "===== serial console ====="
+          cat serial.log
+          echo "==========================="
+          grep -q 'login:' serial.log
+
+      - name: upload serial log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: serial-${{ matrix.config }}
+          path: serial.log


### PR DESCRIPTION
Following up on your comment that you can't test MMU crashes on MacOS, AI suggested to run build + run to login tests on github infrastructure that seemingly runs on x86 and supports VT-x. It seems to correctly fail on master, caused by hidden bugs in PM (see run reports in my fork).

AI description below:

Summary

Adds a workflow that builds ELKS and boots it under qemu-kvm (hardware VT-x via the runner's nested virtualization), grading the result from the serial console.

QEMU TCG does not enforce segment descriptor limits; KVM — like real silicon — does. The bug class fixed in #2735 (GDT_BIOSDATA/GDT_KDATA limits: boot triple-faults on VirtualBox/KVM while TCG boots fine) is therefore invisible to TCG-based testing, and to any macOS/ARM host. Runner-hosted KVM was verified to enforce limits identically to direct VT-x.

What it does

- Reuses the same cached cross/ toolchain as main.yml (first run builds it, ~20 min; cached runs ~5 min).
- Matrix over two configs: ibmpc-1440 (real-mode baseline) and ibmpc-pmode (286 protected mode — the limit-enforcement-sensitive build).
- Uncomments the console=ttyS0,19200 3 bootopts line in the test image so a serial getty makes the outcome observable.
- Boots image/fd1440.img with qemu-system-i386 -accel kvm and grades the serial log:
  - login: → pass
  - panic → fail
  - 150 s of neither → fail (hang, or triple-fault reset loop)
- Serial log is printed in the job output and uploaded as an artifact on failure.

First-run results (on my fork)

- ibmpc-1440: boots to login under KVM on a GitHub runner.
- ibmpc-pmode: fails at root mount — this is the pre-existing PM+XMS-under-hardware-virt issue (boot reaches df0: floppy type 1.44M after the xms banner, then dies; same image boots to login with xms=off). The job is marked continue-on-error so it reports as a warning rather than blocking, with a comment to flip it to gating once that issue is fixed. I can file the issue with the serial evidence separately.

Notes

- /dev/kvm needs an explicit chmod on the runners; the udev-rule-only recipe races (first run demonstrated it).
- Triple faults under -no-reboot leave a nearly-empty serial log — still a red X via the timeout path, which is the point.