### PR TITLE
[kernel] Fix XMS PM copy descriptor limits (byte length, not word count)

### DIFF
--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -122,7 +122,13 @@ ramdesc_t xms_alloc(unsigned int kbytes)
 
 #ifdef CONFIG_286_PMODE
 
-/* copy words between XMS and far memory using dynamic PM selector */
+/* copy words between XMS and far memory using dynamic PM selector.
+ * The temp selector's byte limit must cover the whole access: the far
+ * pointer's offset plus (count words << 1) bytes.  count is a WORD count,
+ * so the limit is offset + (count << 1), NOT count (which would be half a
+ * word-copy's length and fault on the first access past it on hardware
+ * that enforces segment limits - QEMU TCG does not, hardware VT-x/KVM do).
+ */
 void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
 		size_t count)
 {
@@ -132,11 +138,11 @@ void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
         dst_seg, dst_off, src_seg, src_off, count);
 
     if (src_seg >> 16) {
-        sel_src = desc_alloc(src_seg, count, DESC_KDATA);
+        sel_src = desc_alloc(src_seg, (size_t)src_off + (count << 1), DESC_KDATA);
         src_seg = sel_src;
     }
     if (dst_seg >> 16) {
-        sel_dst = desc_alloc(dst_seg, count, DESC_KDATA);
+        sel_dst = desc_alloc(dst_seg, (size_t)dst_off + (count << 1), DESC_KDATA);
         dst_seg = sel_dst;
     }
 	fmemcpyw(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
@@ -154,11 +160,11 @@ void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
         dst_seg, dst_off, src_seg, src_off, count);
 
     if (src_seg >> 16) {
-        sel_src = desc_alloc(src_seg, count, DESC_KDATA);
+        sel_src = desc_alloc(src_seg, (size_t)src_off + count, DESC_KDATA);
         src_seg = sel_src;
     }
     if (dst_seg >> 16) {
-        sel_dst = desc_alloc(dst_seg, count, DESC_KDATA);
+        sel_dst = desc_alloc(dst_seg, (size_t)dst_off + count, DESC_KDATA);
         dst_seg = sel_dst;
     }
 	fmemcpyb(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
@@ -174,7 +180,7 @@ void xms_fmemset(void *dst_off, ramdesc_t dst_seg, size_t count)
     debug("xms_fmemset(%08lx:%04x count %u\n", dst_seg, dst_off, count);
 
     if (dst_seg >> 16) {
-        sel_dst = desc_alloc(dst_seg, count, DESC_KDATA);
+        sel_dst = desc_alloc(dst_seg, (size_t)dst_off + count, DESC_KDATA);
         dst_seg = sel_dst;
     }
 	fmemsetb(dst_off, (seg_t)dst_seg, 0, count);


### PR DESCRIPTION
This is another attempt to fix the master PM crash by AI.
This time it's more localized and grounded. It actually fixed the CI build to login test.

AI description:

xms_fmemcpyw() allocates a temporary GDT selector to reach an XMS (>1MB linear) operand, then copies `count` WORDS through it:

    sel_src = desc_alloc(src_seg, count, DESC_KDATA);   /* limit = count bytes */
    ...
    fmemcpyw(dst_off, dst_seg, src_off, src_seg, count); /* copies 2*count bytes */

The descriptor limit is passed `count`, but every caller passes a word count (BLOCK_SIZE/2, sector_size>>1, ...) and the copy touches 2*count bytes starting at the far pointer's offset.  So the selector is up to half the size the access needs, and the far pointer offset is ignored entirely.  xms_fmemcpyb()/xms_fmemset() have the same offset omission (without the word-doubling).

On QEMU TCG segment limits aren't checked, so this is invisible.  On hardware-assisted virtualization (VirtualBox VT-x, QEMU/KVM) the limit is enforced: at root mount the first block read out of the XMS floppy track cache

    xms_fmemcpyw(req->rq_buffer, req->rq_seg, cache_offset, df_cache_seg,
                 BLOCK_SIZE/2);       /* directfd.c */

reads 1024 bytes at cache_offset (up to ~8K into the 9K cache) through a selector limited to 512 bytes -> #GP.  The PM fault reporter then faults again on the same path -> triple fault, so ibmpc-pmode with XMS enabled resets/Guru-Meditates right after "df0: floppy type 1.44M" and never mounts root.  xms=off avoids it only because it removes the XMS selector from the path.

Set the limit to cover the whole access: offset + (count << 1) for the word copy, offset + count for the byte copy and memset.

Same one-line unit-mismatch family as the GDT_BIOSDATA and GDT_KDATA descriptor-limit fixes.

Tested: ibmpc-pmode with XMS on now boots to login (mounts root, runs /etc/rc.sys) on VirtualBox VT-x and under QEMU/KVM, where it previously triple-faulted; QEMU TCG unaffected.