### PR TITLE
[net] Refactor /etc/net.cfg, use DHCP if LOCALIP= not set in /bootopts or env

### DIFF
--- a/elkscmd/ktcp/dhcp.c
+++ b/elkscmd/ktcp/dhcp.c
@@ -1,3 +1,6 @@
+/*
+ * DHCP client, internal to ktcp.
+ */
 #include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
@@ -8,9 +11,6 @@
 #include "dhcp.h"
 #include "deveth.h"
 #include "timer.h"
-
-int dhcp_enabled;
-int dhcp_timer_active;
 
 static int dhcp_state = DHCP_STATE_INIT;
 static timeq_t dhcp_retry_time;
@@ -195,10 +195,8 @@ void dhcp_init(void)
     dhcp_retry_count = 0;
     dhcp_start_time = Now;
 
-    dhcp_xid = ((uint32_t)eth_local_addr[0] << 24) |
-	       ((uint32_t)eth_local_addr[1] << 16) |
-	       ((uint32_t)eth_local_addr[2] << 8)  |
-	       eth_local_addr[3];
+    dhcp_xid = ((uint32_t)eth_local_addr[0] << 24) | ((uint32_t)eth_local_addr[1] << 16) |
+               (eth_local_addr[2] << 8)  | eth_local_addr[3];
     dhcp_xid ^= (Now & 0xFF) << 8;
 
     udp_register(DHCP_CLIENT_PORT, dhcp_input);

--- a/elkscmd/ktcp/dhcp.h
+++ b/elkscmd/ktcp/dhcp.h
@@ -55,8 +55,8 @@ struct dhcp_message_s {
 	uint8_t	file[128];
 };
 
-extern int dhcp_enabled;
-extern int dhcp_timer_active;
+extern char dhcp_enabled;
+extern char dhcp_timer_active;
 
 void dhcp_init(void);
 void dhcp_timer(void);

--- a/elkscmd/ktcp/icmp.h
+++ b/elkscmd/ktcp/icmp.h
@@ -2,7 +2,6 @@
 #define ICMP_H
 
 #define PROTO_ICMP	1
-#define PROTO_UDP	0x11
 
 #define ICMP_MIN_HDR_LEN	4
 

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -236,16 +236,17 @@ void ip_route(unsigned char *packet, int len, struct addr_pair *apair)
     /* broadcast to 255.255.255.255 */
     if (apair->daddr == 0xFFFFFFFF) {
         ip_addr = 0xFFFFFFFF;
-    /* route based on netmask. FIXME: interface never changed; ignored for SLIP/CSLIP interface*/
-    } else if ((local_ip & netmask_ip) != (apair->daddr & netmask_ip))
+    /* route based on netmask. */
+    /* FIXME: interface never changed; ignored for SLIP/CSLIP interface */
+    } else if ((local_ip & netmask_ip) != (apair->daddr & netmask_ip)) {
         /* Not on the same local network */
         /* Route to the gateway as local destination */
         ip_addr = gateway_ip;
-    else
+    } else {
         /* On the same local network */
         /* Route to the local destination */
         ip_addr = apair->daddr;
-
+    }
     if (linkprotocol == LINK_ETHER)
 	eth_route(packet, len, ip_addr);
     else

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -35,22 +35,19 @@
 #include "arp.h"
 #include "dhcp.h"
 
-ipaddr_t local_ip;
-ipaddr_t gateway_ip;
-ipaddr_t netmask_ip;
-
-#define DEFAULT_IP		"10.0.2.15"
+/* defaults*/
 #define DEFAULT_GATEWAY		"10.0.2.2"
 #define DEFAULT_NETMASK		"255.255.255.0"
-
-/* defaults*/
 int linkprotocol = 	LINK_ETHER;
 char ethdev[10] = 	"/dev/ne0";
 char *serdev = 		"/dev/ttyS0";
 speed_t baudrate = 	57600;
 
-int dflag;
+ipaddr_t local_ip;
+ipaddr_t gateway_ip;
+ipaddr_t netmask_ip;
 unsigned int MTU;
+
 static int intfd;	/* interface fd*/
 
 // rename		timer			function called when active
@@ -65,6 +62,8 @@ int cbs_in_time_wait;		/* time_wait timer active, call tcp_expire_timeouts */
 int cbs_in_user_timeout;	/* fin_wait/closing/last_ack active, call " */
 int tcpcb_need_push;		/* push required, tcpcb_push_data/call notify_data_avail */
 int tcp_retrans_memory;		/* total retransmit memory in use*/
+char dhcp_enabled;
+char dhcp_timer_active;
 
 void ktcp_run(void)
 {
@@ -75,8 +74,7 @@ void ktcp_run(void)
 
     while (1) {
 	if (tcp_timeruse > 0 || tcpcb_need_push > 0 || loopagain ||
-	    cbs_in_time_wait > 0 || cbs_in_user_timeout > 0 ||
-	    dhcp_timer_active) {
+	    cbs_in_time_wait > 0 || cbs_in_user_timeout > 0 || dhcp_timer_active) {
 
 	    //printf("tcp: timer %d needpush %d timewait %d usertime %d\n", tcp_timeruse,
 		//tcpcb_need_push, cbs_in_time_wait, cbs_in_user_timeout);
@@ -192,7 +190,7 @@ void catch(int sig)
 
 static void usage(void)
 {
-    printf("Usage: ktcp [-b] [-D] [-d] [-m MTU] [-p ee0|ne0|wd0|3c0|slip|cslip] [-s baud] [-l device] [local_ip] [gateway] [netmask]\n");
+    printf("Usage: ktcp [-b] [-d] [-m MTU] [-p ee0|ne0|wd0|3c0|slip|cslip] [-s baud] [-l device] [local_ip] [gateway] [netmask]\n");
     exit(1);
 }
 
@@ -202,18 +200,16 @@ int main(int argc,char **argv)
     int bflag = 0;
     int mtu = 0;
     char *p;
+    char *default_ip, *default_gateway, *default_netmask;
     static char *linknames[3] = { "", "slip", "cslip" };
 
-    while ((ch = getopt(argc, argv, "bDdm:p:s:l:")) != -1) {
+    while ((ch = getopt(argc, argv, "bdm:p:s:l:")) != -1) {
 	switch (ch) {
 	case 'b':		/* background daemon*/
 	    bflag = 1;
 	    break;
-	case 'D':		/* DHCP client*/
+	case 'd':		/* force enable DHCP for IP address*/
 	    dhcp_enabled = 1;
-	    break;
-	case 'd':		/* debug messages*/
-	    dflag++;
 	    break;
 	case 'm':		/* MTU*/
 		mtu = (int)atol(optarg);
@@ -246,22 +242,23 @@ int main(int argc,char **argv)
     if (timer_init() < 0)
 	exit(1);
     /*
-     * Default IP, gateway and netmask set by env variables in
-     * /bootopts or /etc/profile. They can be IP addresses or
+     * Three arguments can be passed to ktcp, which are the
+     * default IP, gateway and netmask. If not passed, the environment
+     * variables LOCALIP, GATEWAY and NETMASK are used, which can also
+     * be set in /bootopts or /etc/profile. They can be IP addresses or
      * names in /etc/hosts.
+     * If LOCALIP is not set by the environment or passed to ktcp, DHCP
+     * will be enabled to retrieve these settings from a local DHCP server.
      */
-
-    char *default_ip = (p=getenv("HOSTNAME"))? p: DEFAULT_IP;
-    char *default_gateway = (p=getenv("GATEWAY"))? p: DEFAULT_GATEWAY;
-    char *default_netmask = (p=getenv("NETMASK"))? p: DEFAULT_NETMASK;
-    if (!dhcp_enabled) {
+     if (!dhcp_enabled) {
+	default_ip = getenv("LOCALIP");
+	default_gateway = (p=getenv("GATEWAY"))? p: DEFAULT_GATEWAY;
+	default_netmask = (p=getenv("NETMASK"))? p: DEFAULT_NETMASK;
 	local_ip = in_gethostbyname(optind < argc? argv[optind++]: default_ip);
 	gateway_ip = in_gethostbyname(optind < argc? argv[optind++]: default_gateway);
 	netmask_ip = in_gethostbyname(optind < argc? argv[optind++]: default_netmask);
-    } else {
-	local_ip = 0;
-	gateway_ip = 0;
-	netmask_ip = 0;
+	if (!local_ip)
+	    dhcp_enabled = 1;
     }
     MTU = mtu ? mtu : (linkprotocol == LINK_ETHER ? ETH_MTU : SLIP_MTU);
 

--- a/elkscmd/ktcp/udp.c
+++ b/elkscmd/ktcp/udp.c
@@ -1,3 +1,6 @@
+/*
+ * Internal UDP implementation for DHCP. Not accessible through sockets.
+ */
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -5,6 +8,7 @@
 #include <arpa/inet.h>
 #include "config.h"
 #include "ip.h"
+#include "icmp.h"
 #include "udp.h"
 #include "netconf.h"
 

--- a/elkscmd/ktcp/udp.h
+++ b/elkscmd/ktcp/udp.h
@@ -1,36 +1,34 @@
 #ifndef UDP_H
 #define UDP_H
 
-#include <stdint.h>
-
-#define PROTO_UDP	0x11
-#define MAX_UDP_SOCKS	4
+#define PROTO_UDP       0x11
+#define MAX_UDP_SOCKS   4
 
 struct udphdr_s {
-	uint16_t	src;
-	uint16_t	dest;
-	uint16_t	len;
-	uint16_t	check;
+    __u16   src;
+    __u16   dest;
+    __u16   len;
+    __u16   check;
 };
 
-typedef void (*udp_callback_t)(struct iphdr_s *iph, uint16_t src_port,
-			       unsigned char *data, int datalen);
+typedef void (*udp_callback_t)(struct iphdr_s *iph, __u16 src_port,
+                               unsigned char *data, int datalen);
 
 struct udp_sock {
     int active;
-    uint16_t local_port;
-    ipaddr_t remaddr;		/* 0 if not connected */
-    uint16_t remport;		/* 0 if not connected */
+    __u16 local_port;
+    ipaddr_t remaddr;           /* 0 if not connected */
+    __u16 remport;              /* 0 if not connected */
     udp_callback_t callback;
 };
 
 extern struct udp_sock udp_socks[MAX_UDP_SOCKS];
 
 void udp_process(struct iphdr_s *iph, unsigned char *packet);
-void udp_send(ipaddr_t dst, uint16_t dstport, uint16_t srcport,
-	      unsigned char *data, int datalen, ipaddr_t src);
+void udp_send(ipaddr_t dst, __u16 dstport, __u16 srcport,
+              unsigned char *data, int datalen, ipaddr_t src);
 
-int udp_register(uint16_t local_port, udp_callback_t cb);
-void udp_unregister(uint16_t local_port);
+int udp_register(__u16 local_port, udp_callback_t cb);
+void udp_unregister(__u16 local_port);
 
 #endif

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -36,26 +36,14 @@ start_network()
 	case "$link" in
 	slip)
 		getty_off
-		if test "$dhcp" = "yes"; then
-			ktcp="ktcp -b -D -p slip -s $baud -l $device"
-		else
-			ktcp="ktcp -b -p slip -s $baud -l $device $localip $gateway $netmask"
-		fi
+		ktcp="ktcp -b -p slip -s $baud -l $device $localip $gateway $netmask"
 		;;
 	cslip)
 		getty_off
-		if test "$dhcp" = "yes"; then
-			ktcp="ktcp -b -D -p cslip -s $baud -l $device"
-		else
-			ktcp="ktcp -b -p cslip -s $baud -l $device $localip $gateway $netmask"
-		fi
+		ktcp="ktcp -b -p cslip -s $baud -l $device $localip $gateway $netmask"
 		;;
 	ne0|wd0|3c0)
-		if test "$dhcp" = "yes"; then
-			ktcp="ktcp -b -D -p $link $mtu"
-		else
-			ktcp="ktcp -b -p $link $mtu $localip $gateway $netmask"
-		fi
+		ktcp="ktcp -b -p $link $mtu $localip $gateway $netmask"
 		;;
 	*)
 		usage ;;

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,7 +1,9 @@
 ## /bootopts 1023 max
 #TZ=MDT6
-#LOCALIP=10.0.2.16
-#HOSTNAME=elks16
+#setting LOCALIP= disables DHCP, can use /etc/hosts names
+#LOCALIP=10.0.2.15
+#GATEWAY=10.0.2.2
+#NETMASK=255.255.255.0
 #ne0=12,0x300,,0x80
 #wd0=10,0x300,0xCC00,0x80
 #3c0=11,0x330,,0x80

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -1,15 +1,12 @@
 # ELKS Networking Configuration File
 # sourced by /bin/net for ktcp and daemons
 
-# Default IP address, gate and network mask.
+# Default IP address, gate and network mask set in /bootopts or overridden here.
 # These can be IP addresses or names in /etc/hosts.
-# Uncomment the following line to use DHCP instead of static config:
-#dhcp=yes
-if test "$dhcp" != "yes"; then
-    if test "$LOCALIP" != ""; then localip=$LOCALIP; else localip=10.0.2.15; fi
-    gateway=10.0.2.2
-    netmask=255.255.255.0
-fi
+# If not set, DCHP will be used.
+localip=$LOCALIP
+gateway=$GATEWAY
+netmask=$NETMASK
 
 # reduce for 8bit NE2K w/4K buffer
 mtu=
@@ -21,9 +18,6 @@ link=ne0
 # default serial port and baud rate if slip/cslip
 device=/dev/ttyS0
 baud=38400
-
-# to use ftp/ftpd in qemu
-#export QEMU=1
 
 # daemons to start are actually shell variable command lines see below
 netstart="telnetd ftpd"


### PR DESCRIPTION
Reworks /etc/net.cfg, /bin/net and /bootopts to allow for a more seamless integration of the new DHCP client from #2739.

Now, the new DHCP client for ELKS will automatically request an IP address (and gateway/netmask) if LOCALIP= is not set in either /bootopts, /etc/profile, or an environment variable. Setting LOCALIP= in /bootopts will automatically set the same named environment variable.

By default, LOCALIP= is not set in /bootopts, so DHCP will be used for the local IP address when `net start` is run. To force DHCP use in `ktcp`, the -d option can be used even when LOCALIP= is set for testing.

If LOCALIP= is set in /bootopts, it can specify either a numeric IP address or an entry in /etc/hosts.

Some small ktcp source cleanups were also made.