### PR TITLE
[kernel] Fix triple-fault condition in PM fault reporter

### DIFF
--- a/elks/arch/i86/lib/pmode.S
+++ b/elks/arch/i86/lib/pmode.S
@@ -63,12 +63,18 @@ pm_fault_vector:
         .set    fltv, 0
         .rept   32              // first 32 IDT entries report vector numbers 0..31
         pushw   $fltv
-        call    pm_exception_handler
+        jmp     pm_fault_common
         nop; nop; nop;          // each entry is 5 bytes code + 3 bytes NOP
         .set    fltv, fltv + 1
         .endr
         pushw   $0x00FF         // remainder vectors >= 32 report vector 255
+pm_fault_common:
+        push    %es             // save ES & DS for display in case of bad segment
+        push    %ds             // register load or limit/protection violation,
+        push    $SEL_KDATA      // then load valid DS for C handler
+        pop     %ds
         call    pm_exception_handler
+        // no return
 
 // send AL to COM1. Used as early_putchar before console init.
         .global putc_ser

--- a/elks/arch/i86/mm/pmode.c
+++ b/elks/arch/i86/mm/pmode.c
@@ -228,6 +228,7 @@ void pm_exception_handler(int arg)
 {
     unsigned int *p = (unsigned int *)&arg;
 
-    panic("EXC %04x CODE %04x CS %04x IP %04x FLAG %04x STK %04x %04x %04x %04x",
-        p[0], p[1], p[3], p[2], p[4], p[5], p[6], p[7], p[8]);
+    panic("unhandled PM fault\n"
+        "DS %04x ES %04x EXC %04x CODE %04x CS %04x IP %04x FLAG %04x STK %04x %04x",
+        p[0], p[1], p[2], p[3], p[5], p[4], p[6], p[7], p[8]);
 }


### PR DESCRIPTION
Fixes triple-fault occurring during call to PM fault handler/reporter by loading DS with a valid selector prior to calling the C handler.  For the time being, the fault handler still displays fault information, then halts the system through `panic`. This will be improved in future versions by writing handlers for specific PM faults. Note however that in general a kernel PM fault (vs user mode fault) will still likely have to end with halting for system stability reasons.

Potential solution identified by @duzenko and discussed in https://github.com/ghaerr/elks/pull/2738#issuecomment-4950933447, but manually revised in this PR.

Tested on QEMU using xms_fmemcpyw as example culprit from #2738. Early kernel init PM faults not tested in this PR, but fault reporter output should be displayed through COM1 until after the console is initialized.

The fault reporter now also displays DS and ES contents for easier debug tracing:
<img width="832" height="540" alt="Screenshot 2026-07-12 at 6 38 29 PM" src="https://github.com/user-attachments/assets/2756141d-9c52-4135-9be3-dba15393ae13" />
