### PR TITLE
[kernel] Add optional GEM INT EF resident broker

### DIFF
--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -43,6 +43,81 @@ struct int_handler {
 static struct int_handler trampoline[NR_IRQS];
 static irq_handler irq_action[NR_IRQS];
 
+#ifdef CONFIG_GEM_TRAP
+/*
+ * Original GEM applications inspect bytes two through seven of the INT EFh
+ * target and require the literal "GEMAES" signature.  The short jump skips
+ * those six data bytes, then the normal ELKS far-call trampoline enters
+ * _irqit.  CALLF leaves its return offset pointing at irq, exactly like the
+ * compact struct int_handler used by every other ELKS interrupt.
+ */
+struct gem_int_handler {
+    byte_t jump_opcode;          /* EBh: 8086 short relative jump */
+    byte_t jump_bytes;           /* skip the six signature bytes */
+    byte_t signature[6];
+    byte_t call_opcode;          /* 9Ah: 8086 far call */
+    word_t proc;
+    word_t seg;
+    byte_t irq;
+} __attribute__ ((packed));
+
+static struct gem_int_handler gem_trampoline;
+static word_t gem_old_offset;
+static seg_t gem_old_segment;
+static byte_t gem_vector_installed;
+
+extern void gemtrap_interrupt(int irq, struct pt_regs *regs);
+
+/*
+ * Install the broker only while a resident owner is registered.  aescheck()
+ * therefore cannot mistake an ownerless kernel for a working AES service.
+ */
+void gemtrap_vector_enable(void)
+{
+    if (gem_vector_installed)
+        return;
+
+    int_vector_get(0xef, &gem_old_offset, &gem_old_segment);
+    int_vector_set(0xef, (word_t)&gem_trampoline, kernel_ds);
+    gem_vector_installed = 1;
+}
+
+void gemtrap_vector_disable(void)
+{
+    word_t offset;
+    seg_t segment;
+
+    if (!gem_vector_installed)
+        return;
+
+    /*
+     * Do not overwrite a later owner that deliberately replaced INT EFh.
+     * We restore the saved vector only when the IVT still points at us.
+     */
+    int_vector_get(0xef, &offset, &segment);
+    if (offset == (word_t)&gem_trampoline && segment == kernel_ds)
+        int_vector_set(0xef, gem_old_offset, gem_old_segment);
+    gem_vector_installed = 0;
+}
+
+static void INITPROC gemtrap_irq_init(void)
+{
+    gem_trampoline.jump_opcode = 0xeb;
+    gem_trampoline.jump_bytes = 6;
+    gem_trampoline.signature[0] = 'G';
+    gem_trampoline.signature[1] = 'E';
+    gem_trampoline.signature[2] = 'M';
+    gem_trampoline.signature[3] = 'A';
+    gem_trampoline.signature[4] = 'E';
+    gem_trampoline.signature[5] = 'S';
+    gem_trampoline.call_opcode = 0x9a;
+    gem_trampoline.proc = (word_t)_irqit;
+    gem_trampoline.seg = KERNEL_CS;
+    gem_trampoline.irq = IDX_GEM;
+    irq_action[IDX_GEM] = gemtrap_interrupt;
+}
+#endif
+
 /* called by _irqit assembler hook after saving registers */
 void do_IRQ(int i, struct pt_regs *regs)
 {
@@ -127,6 +202,10 @@ int free_irq(int irq)
 void INITPROC irq_init(void)
 {
     int_handler_add(IDX_SYSCALL, 0x80, _irqit); /* INT 80 for system calls */
+
+#ifdef CONFIG_GEM_TRAP
+    gemtrap_irq_init();                  /* INT EF is enabled by REGISTER */
+#endif
 
 #if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98) || \
     defined(CONFIG_ARCH_SOLO86) || defined(CONFIG_ARCH_SWAN) || \

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -459,6 +459,46 @@ int_vector_set:
         pop %ds
         ret
 
+//------------------------------------------------------------------------------
+// Read an interrupt vector as two independent 16-bit words.
+//------------------------------------------------------------------------------
+
+// void int_vector_get (int vect, word_t *proc, word_t *seg);
+// arg1: vector number (word)
+// arg2: near kernel pointer receiving the offset word
+// arg3: near kernel pointer receiving the segment word
+//
+// The IVT is a four-byte external ABI.  Keeping the offset and segment in two
+// words avoids 32-bit arithmetic and the compiler helpers that it would need on
+// an 8086.  BX, SI and DI are preserved for the C calling convention.
+
+        .global int_vector_get
+int_vector_get:
+        push %bx
+        push %si
+        push %di
+        mov  %sp,%bx
+        mov  8(%bx),%ax          // arg1 after three saved registers
+        mov 10(%bx),%si          // arg2
+        mov 12(%bx),%di          // arg3
+        shl  $1,%ax              // four bytes per IVT entry, 8086 form
+        shl  $1,%ax
+        mov  %ax,%bx
+
+        push %ds
+        xor  %ax,%ax
+        mov  %ax,%ds             // DS:BX points into the real-mode IVT
+        mov  (%bx),%cx
+        mov 2(%bx),%dx
+        pop  %ds
+
+        mov %cx,(%si)
+        mov %dx,(%di)
+        pop %di
+        pop %si
+        pop %bx
+        ret
+
         .data
         .global intr_count
         .global endistack

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -85,7 +85,7 @@ settimeofday	+61	2
 gettimeofday	+62	2
 select		+63	5	. 5 parameters is possible
 readdir		+64	3	*
-insmod		65	1	- Removed support for modules
+gemctl		+65	2	= CONFIG_GEM_TRAP
 fchown		+66	3
 dlload		67	2	- Removed support for dynamic libraries
 setsid		+68	0

--- a/elks/config.in
+++ b/elks/config.in
@@ -76,6 +76,10 @@ mainmenu_option next_comment
 	bool 'Real time clock in localtime'       CONFIG_TIME_RTC_LOCALTIME n
 	string 'Compiled-in TZ= timezone string'  CONFIG_TIME_TZ      ''
 	bool 'System tracing (set on for development)' CONFIG_TRACE   n
+	if [ "$CONFIG_ARCH_IBMPC" = "y" ] && \
+	   [ "$CONFIG_286_PMODE" != "y" ]; then
+		bool 'GEM INT EF resident-service broker' CONFIG_GEM_TRAP n
+	fi
 	bool 'Use INT 0Fh in idle loop for timer' CONFIG_TIMER_INT0F  n
 	bool 'Use INT 1Ch from BIOS for timer'    CONFIG_TIMER_INT1C  n
 

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -45,6 +45,9 @@
 #include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/memory.h>
+#ifdef CONFIG_GEM_TRAP
+#include <linuxmt/gemtrap.h>
+#endif
 #include <arch/segment.h>
 #include <arch/seg286.h>
 #pragma GCC diagnostic ignored "-Wunused-label"
@@ -528,6 +531,16 @@ static void FARPROC finalize_exec(struct inode *inode, segment_s *seg_code,
 {
     struct task_struct *currentp = current;
     int i, n, v;
+
+    /*
+     * A resident GEM owner may retain menu, desktop or event pointers in the
+     * old data segment.  Publish an EXIT lifecycle record before dropping the
+     * task's normal segment reference.  The broker's attachment reference
+     * keeps that old segment stable until the owner acknowledges teardown.
+     */
+#ifdef CONFIG_GEM_TRAP
+    gemtrap_task_exec(currentp);
+#endif
 
     /* From this point, the old code and data segments are not needed anymore */
     for (i = 0; i < MAX_SEGS; i++) {

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -7,7 +7,12 @@
 #define IDX_DIVZERO     17
 #define IDX_NMI         18
 #define IDX_NECV25_IBRK 19      /* NEC V25 specific IO Break Exception */
+#ifdef CONFIG_GEM_TRAP
+#define IDX_GEM         20      /* GEM AES/VDI software trap, INT EFh */
+#define NR_IRQS         21      /* = # IRQs plus special indexes above */
+#else
 #define NR_IRQS         20      /* = # IRQs plus special indexes above */
+#endif
 
 #define INT_GENERIC  0  // use the generic interrupt handler (aka '_irqit')
 #define INT_SPECIFIC 1  // use a specific interrupt handler
@@ -26,6 +31,11 @@ int free_irq(int irq);
 /* irqtab.S */
 void _irqit (void);
 void int_vector_set(unsigned int vect, word_t proc, seg_t seg);
+void int_vector_get(unsigned int vect, word_t *proc, seg_t *seg);
+#ifdef CONFIG_GEM_TRAP
+void gemtrap_vector_enable(void);
+void gemtrap_vector_disable(void);
+#endif
 void idle_halt(void);
 
 void div0_handler(int irq, struct pt_regs *regs);

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -44,8 +44,8 @@
 #define EPIPE           32      /* Broken pipe */
 #define EDOM            33      /* Math argument out of domain of func */
 #define ERANGE          34      /* Math result not representable */
-#if UNUSED
 #define EDEADLK         35      /* Resource deadlock would occur */
+#if UNUSED
 #define ENOLCK          37      /* No record locks available */
 #endif
 #define ENAMETOOLONG    36      /* File name too long */
@@ -57,6 +57,7 @@
 /* these are used, pulled out of the below unused list */
 #define ENODATA         61      /* No data available */
 #define ENOSR           63      /* Out of streams resources */
+#define EOVERFLOW       75      /* Value too large for defined data type */
 #define EILSEQ          84      /* Illegal byte sequence */
 #define ENOTSOCK        88      /* Socket operation on non-socket */
 #define EADDRINUSE      98      /* Address already in use */

--- a/elks/include/linuxmt/gemtrap.h
+++ b/elks/include/linuxmt/gemtrap.h
@@ -1,0 +1,64 @@
+#ifndef __LINUXMT_GEMTRAP_H
+#define __LINUXMT_GEMTRAP_H
+
+/*
+ * ELKS resident GEM AES/VDI trap broker.
+ *
+ * Every interface field is one unscaled 16-bit word.  In particular, far
+ * addresses remain the original offset and segment register pair; the broker
+ * never converts them to a 32-bit linear address and never copies a GEM object
+ * tree or parameter block.  A resident AES owner interprets the captured
+ * registers in the original way:
+ *
+ *   AES: CX = 200 or 201, ES:BX = AES parameter block
+ *   VDI: CX = 0473h,       DS:DX = VDI parameter block
+ */
+
+#define GEMCTL_REGISTER     0
+#define GEMCTL_NEXT         1
+#define GEMCTL_REPLY        2
+#define GEMCTL_CANCEL       3
+#define GEMCTL_UNREGISTER   4
+#define GEMCTL_NEXT_NOWAIT  5
+#define GEMCTL_ATTACH       6
+#define GEMCTL_DETACH       7
+
+/*
+ * The resident owner uses tags zero through eleven for GEM's original
+ * twelve PD slots.  EXIT is a kernel lifecycle record, not an AES or VDI
+ * opcode, so it uses a selector which no original GEM trap can issue.
+ */
+#define GEMTRAP_ATTACH_TAGS 12
+#define GEMTRAP_CX_EXIT     0xffffU
+
+struct gemtrap_request {
+    unsigned short slot;       /* stable ELKS task-slot number, 0..15 */
+    unsigned short pid;        /* guards against reuse of a task slot */
+    unsigned short ax;         /* caller AX; reply AX for REPLY */
+    unsigned short bx;         /* caller BX */
+    unsigned short cx;         /* AES/VDI selector */
+    unsigned short dx;         /* caller DX */
+    unsigned short es;         /* caller ES */
+    unsigned short ds;         /* caller DS */
+    unsigned short data_limit; /* exclusive byte limit of the pinned DS */
+    unsigned short generation_lo; /* low half: one count per accepted trap */
+    unsigned short generation_hi; /* high half: incremented on low carry */
+};
+
+typedef char gemtrap_request_must_be_22_bytes
+    [(sizeof(struct gemtrap_request) == 22) ? 1 : -1];
+
+/* The public syscall uses one near pointer in the resident owner's DS. */
+#ifndef __KERNEL__
+int gemctl(unsigned int operation, struct gemtrap_request *request);
+#else
+struct task_struct;
+struct pt_regs;
+
+int sys_gemctl(unsigned int operation, struct gemtrap_request *request);
+void gemtrap_interrupt(int irq, struct pt_regs *regs);
+void gemtrap_task_exec(struct task_struct *executing);
+void gemtrap_task_exit(struct task_struct *exiting);
+#endif
+
+#endif

--- a/elks/kernel/Makefile
+++ b/elks/kernel/Makefile
@@ -37,7 +37,11 @@ include $(BASEDIR)/Makefile-rules
 
 # unused: wait.o lock.o
 OBJS  = sched.o printk.o sleepwake.o version.o sys.o sys2.o fork.o \
-	exit.o time.o signal.o sysctl.o
+		exit.o time.o signal.o sysctl.o
+
+ifeq ($(CONFIG_GEM_TRAP), y)
+OBJS += gemtrap.o
+endif
 
 #########################################################################
 # Commands:

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -11,6 +11,9 @@
 #include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/kd.h>
+#ifdef CONFIG_GEM_TRAP
+#include <linuxmt/gemtrap.h>
+#endif
 
 static void FARPROC reparent_children(void)
 {
@@ -128,6 +131,10 @@ void do_exit(int status)
     struct task_struct *parent;
 
     debug_wait("EXIT(%P) status %d\n", status);
+#ifdef CONFIG_GEM_TRAP
+    /* Release broker ownership or a queued client before its task disappears. */
+    gemtrap_task_exit(current);
+#endif
     _close_allfiles();
 #ifdef CONFIG_AUDIO
     audio_seq_exit(current->pid);

--- a/elks/kernel/gemtrap.c
+++ b/elks/kernel/gemtrap.c
@@ -1,0 +1,680 @@
+/*
+ * Kernel-resident broker for the original GEM INT EFh AES/VDI ABI.
+ *
+ * ELKS owns processes, address spaces, scheduling and sleep/wakeup.  This file
+ * deliberately does not implement AES, VDI, menus, windows, resources or GEM's
+ * old DOS arena allocator.  It provides the rendezvous and segment lifetime
+ * rules required for one resident user process to run that original logic on
+ * behalf of several real ELKS processes.
+ *
+ * All counters, identifiers, limits and captured registers are 8- or 16-bit
+ * values.  There is no allocation: one fixed slot exists for every ELKS task.
+ */
+
+#include <linuxmt/config.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/gemtrap.h>
+#include <linuxmt/init.h>
+#include <linuxmt/limits.h>
+#include <linuxmt/mm.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/types.h>
+
+#include <arch/irq.h>
+
+#define GEM_REQUEST_FREE        0
+#define GEM_REQUEST_PENDING     1
+#define GEM_REQUEST_DELIVERED   2
+#define GEM_REQUEST_ABANDONED   3
+
+#define GEM_ATTACH_FREE         0
+#define GEM_ATTACH_LIVE         1
+#define GEM_ATTACH_EXIT_PENDING 2
+#define GEM_ATTACH_EXIT_SENT    3
+
+#define GEM_AES_SELECTOR        200U
+#define GEM_AES_ALT_SELECTOR    201U
+#define GEM_VDI_SELECTOR        0x0473U
+
+/* Packed original parameter-block sizes, in unscaled bytes. */
+#define GEM_AESPB_BYTES         24U
+#define GEM_VDIPB_BYTES         20U
+
+struct gemtrap_slot {
+    byte_t request_state;
+    byte_t slot_number;
+    pid_t request_pid;
+    struct task_struct *client;
+    struct gemtrap_slot *next;
+    word_t ax;
+    word_t bx;
+    word_t cx;
+    word_t dx;
+    word_t es;
+    word_t ds;
+    segment_s *request_segment;
+    word_t data_limit;
+    word_t request_generation_lo;
+    word_t request_generation_hi;
+
+    byte_t attach_state;
+    byte_t attach_tag;
+    pid_t attach_pid;
+    segment_s *attach_segment;
+    word_t attach_limit;
+    word_t attach_generation_lo;
+    word_t attach_generation_hi;
+};
+
+/*
+ * Near pointers are one word.  The exact layout makes the complete 16-task
+ * table 640 bytes and catches accidental growth at compile time.
+ */
+typedef char gemtrap_slot_must_be_40_bytes
+    [(sizeof(struct gemtrap_slot) == 40) ? 1 : -1];
+
+static struct gemtrap_slot gem_slots[MAX_TASKS];
+static struct gemtrap_slot *gem_pending_head;
+static struct gemtrap_slot *gem_pending_tail;
+static struct task_struct *gem_owner;
+static struct wait_queue gem_owner_wait;
+static word_t gem_generation_lo;
+static word_t gem_generation_hi;
+
+/* Return the fixed broker slot paired with an ELKS task table entry. */
+static struct gemtrap_slot *gem_slot_for_task(struct task_struct *wanted)
+{
+    struct task_struct *candidate;
+    struct gemtrap_slot *slot;
+    byte_t number;
+
+    candidate = &task[0];
+    slot = &gem_slots[0];
+    number = 0;
+    while (number < (byte_t)max_tasks && number < (byte_t)MAX_TASKS) {
+        if (candidate == wanted) {
+            slot->slot_number = number;
+            return slot;
+        }
+        candidate++;
+        slot++;
+        number++;
+    }
+    return NULL;
+}
+
+static struct gemtrap_slot *gem_slot_by_number(word_t number)
+{
+    struct gemtrap_slot * volatile slot;
+    word_t index;
+
+    if (number >= (word_t)MAX_TASKS || number >= (word_t)max_tasks)
+        return NULL;
+
+    slot = &gem_slots[0];
+    index = 0;
+    while (index < number) {
+        slot++;
+        index++;
+    }
+    return (struct gemtrap_slot *)slot;
+}
+
+/*
+ * Allocate one boot-lifetime trap generation using two explicit 16-bit
+ * halves.  The scale is exactly one accepted trap per increment.  Low-half
+ * wrap carries one into the high half; ffff:ffff saturates and is never
+ * reused.  No 32-bit temporary, helper, multiplication or division exists.
+ */
+static int gem_allocate_generation(struct gemtrap_slot *slot)
+{
+    if (gem_generation_lo == 0xffffU
+        && gem_generation_hi == 0xffffU)
+        return -EOVERFLOW;
+
+    gem_generation_lo++;
+    if (gem_generation_lo == 0)
+        gem_generation_hi++;
+    slot->request_generation_lo = gem_generation_lo;
+    slot->request_generation_hi = gem_generation_hi;
+    return 0;
+}
+
+/* Find a live request using the complete stale-operation guard. */
+static struct gemtrap_slot *gem_find_request(word_t number, pid_t pid,
+                                              word_t generation_lo,
+                                              word_t generation_hi)
+{
+    struct gemtrap_slot *slot;
+
+    slot = gem_slot_by_number(number);
+    if (!slot || slot->request_state == GEM_REQUEST_FREE
+        || slot->request_pid != pid
+        || slot->request_generation_lo != generation_lo
+        || slot->request_generation_hi != generation_hi)
+        return NULL;
+    return slot;
+}
+
+static void gem_queue_append(struct gemtrap_slot *slot)
+{
+    slot->next = NULL;
+    if (gem_pending_tail)
+        gem_pending_tail->next = slot;
+    else
+        gem_pending_head = slot;
+    gem_pending_tail = slot;
+}
+
+static void gem_queue_remove(struct gemtrap_slot *wanted)
+{
+    struct gemtrap_slot *slot;
+    struct gemtrap_slot *previous;
+
+    previous = NULL;
+    slot = gem_pending_head;
+    while (slot) {
+        if (slot == wanted) {
+            if (previous)
+                previous->next = slot->next;
+            else
+                gem_pending_head = slot->next;
+            if (gem_pending_tail == slot)
+                gem_pending_tail = previous;
+            slot->next = NULL;
+            return;
+        }
+        previous = slot;
+        slot = slot->next;
+    }
+}
+
+/*
+ * Validate [offset, offset + length) without ever forming a wrapped sum.
+ * limit is the exclusive 16-bit ELKS data/stack segment byte boundary.
+ */
+static int gem_range_valid(word_t offset, word_t length, word_t limit)
+{
+    if (offset > limit)
+        return 0;
+    return length <= (word_t)(limit - offset);
+}
+
+static void gem_drop_request_segment(struct gemtrap_slot *slot)
+{
+    if (slot->request_segment) {
+        seg_put(slot->request_segment);
+        slot->request_segment = NULL;
+    }
+    slot->data_limit = 0;
+}
+
+/* Release one request while leaving any persistent attachment untouched. */
+static void gem_release_request(struct gemtrap_slot *slot, int result)
+{
+    struct task_struct *client;
+
+    client = slot->client;
+    if (slot->request_state == GEM_REQUEST_PENDING)
+        gem_queue_remove(slot);
+
+    /*
+     * INT EF returns one original 16-bit AES/VDI status in AX.  All other
+     * saved registers remain exactly as supplied by the client.  Converting
+     * the signed result to word_t preserves its two's-complement bit pattern;
+     * no rounding or saturation is involved.
+     */
+    if (client)
+        client->t_regs.ax = (word_t)result;
+
+    gem_drop_request_segment(slot);
+    slot->request_state = GEM_REQUEST_FREE;
+    slot->request_pid = 0;
+    slot->client = NULL;
+    slot->next = NULL;
+    slot->request_generation_lo = 0;
+    slot->request_generation_hi = 0;
+
+    /* The signal-abort path is already running in its own client task. */
+    if (client && client != current
+        && (client->state == TASK_INTERRUPTIBLE
+            || client->state == TASK_UNINTERRUPTIBLE))
+        wake_up_process(client);
+}
+
+/*
+ * The owner has already seen this request and may be reading the client DS.
+ * Let the signalled client continue with -EINTR, but retain the segment pin
+ * until the owner acknowledges the stale request with REPLY or CANCEL.
+ */
+static void gem_abandon_request(struct gemtrap_slot *slot, int result)
+{
+    if (slot->client)
+        slot->client->t_regs.ax = (word_t)result;
+    slot->client = NULL;
+    slot->request_state = GEM_REQUEST_ABANDONED;
+}
+
+static void gem_release_attachment(struct gemtrap_slot *slot)
+{
+    if (slot->attach_segment) {
+        seg_put(slot->attach_segment);
+        slot->attach_segment = NULL;
+    }
+    slot->attach_state = GEM_ATTACH_FREE;
+    slot->attach_tag = 0;
+    slot->attach_pid = 0;
+    slot->attach_limit = 0;
+    slot->attach_generation_lo = 0;
+    slot->attach_generation_hi = 0;
+}
+
+static void gem_release_owner(int result)
+{
+    struct gemtrap_slot *slot;
+    byte_t count;
+
+    gem_owner = NULL;
+    gemtrap_vector_disable();
+
+    slot = &gem_slots[0];
+    count = 0;
+    while (count < (byte_t)MAX_TASKS) {
+        if (slot->request_state != GEM_REQUEST_FREE)
+            gem_release_request(slot, result);
+        if (slot->attach_state != GEM_ATTACH_FREE)
+            gem_release_attachment(slot);
+        slot++;
+        count++;
+    }
+    gem_pending_head = NULL;
+    gem_pending_tail = NULL;
+}
+
+static struct gemtrap_slot *gem_exit_pending(void)
+{
+    struct gemtrap_slot *slot;
+    byte_t count;
+
+    slot = &gem_slots[0];
+    count = 0;
+    while (count < (byte_t)MAX_TASKS) {
+        if (slot->attach_state == GEM_ATTACH_EXIT_PENDING)
+            return slot;
+        slot++;
+        count++;
+    }
+    return NULL;
+}
+
+static void gem_copy_trap_request(struct gemtrap_request *request,
+                                  struct gemtrap_slot *slot)
+{
+    request->slot = slot->slot_number;
+    request->pid = slot->request_pid;
+    request->ax = slot->ax;
+    request->bx = slot->bx;
+    request->cx = slot->cx;
+    request->dx = slot->dx;
+    request->es = slot->es;
+    request->ds = slot->ds;
+    request->data_limit = slot->data_limit;
+    request->generation_lo = slot->request_generation_lo;
+    request->generation_hi = slot->request_generation_hi;
+}
+
+static void gem_copy_exit_request(struct gemtrap_request *request,
+                                  struct gemtrap_slot *slot)
+{
+    request->slot = slot->slot_number;
+    request->pid = slot->attach_pid;
+    request->ax = (word_t)slot->attach_tag;
+    request->bx = 0;
+    request->cx = GEMTRAP_CX_EXIT;
+    request->dx = 0;
+    request->es = slot->attach_segment ? slot->attach_segment->base : 0;
+    request->ds = request->es;
+    request->data_limit = slot->attach_limit;
+    request->generation_lo = slot->attach_generation_lo;
+    request->generation_hi = slot->attach_generation_hi;
+}
+
+/*
+ * Dequeue one lifecycle record or trap.  Exit records are deliberately first:
+ * after exec the same PID may immediately queue APPL_INIT from a new segment,
+ * and the owner must destroy the old PD state before attaching that new image.
+ */
+static int FARPROC gem_take_request(struct gemtrap_request *user_request,
+                                    int may_wait)
+{
+    struct gemtrap_request request;
+    struct gemtrap_slot *exit_slot;
+    struct gemtrap_slot *request_slot;
+    int error;
+
+    if (!may_wait) {
+        exit_slot = gem_exit_pending();
+        request_slot = gem_pending_head;
+        if (!exit_slot && !request_slot)
+            return -EAGAIN;
+    } else {
+        for (;;) {
+            prepare_to_wait_interruptible(&gem_owner_wait);
+            exit_slot = gem_exit_pending();
+            request_slot = gem_pending_head;
+            if (exit_slot || request_slot)
+                break;
+            if (current->signal) {
+                finish_wait(&gem_owner_wait);
+                return -EINTR;
+            }
+            do_wait();
+            finish_wait(&gem_owner_wait);
+        }
+    }
+
+    if (exit_slot)
+        gem_copy_exit_request(&request, exit_slot);
+    else
+        gem_copy_trap_request(&request, request_slot);
+
+    error = verified_memcpy_tofs(user_request, &request, sizeof(request));
+    if (!error) {
+        if (exit_slot)
+            exit_slot->attach_state = GEM_ATTACH_EXIT_SENT;
+        else {
+            gem_queue_remove(request_slot);
+            request_slot->request_state = GEM_REQUEST_DELIVERED;
+        }
+    }
+    if (may_wait)
+        finish_wait(&gem_owner_wait);
+    return error;
+}
+
+/*
+ * Called by the normal ELKS software-interrupt path with the complete saved
+ * user register frame.  Only the primary data segment is pinned; the kernel
+ * does not parse or copy nested AES/VDI pointers.
+ */
+void gemtrap_interrupt(int irq, struct pt_regs *regs)
+{
+    struct gemtrap_slot *slot;
+    segment_s *data_segment;
+    word_t parameter_offset;
+    word_t parameter_bytes;
+
+    if (irq != IDX_GEM || !gem_owner) {
+        regs->ax = (word_t)-ENOSYS;
+        return;
+    }
+    if (current == gem_owner) {
+        /* The sole dequeuer cannot sleep waiting for its own reply. */
+        regs->ax = (word_t)-EDEADLK;
+        return;
+    }
+
+    data_segment = current->mm[SEG_DATA];
+    if (!data_segment || regs->ds != data_segment->base) {
+        regs->ax = (word_t)-EFAULT;
+        return;
+    }
+
+    if (regs->cx == GEM_AES_SELECTOR
+        || regs->cx == GEM_AES_ALT_SELECTOR) {
+        if (regs->es != data_segment->base) {
+            regs->ax = (word_t)-EFAULT;
+            return;
+        }
+        parameter_offset = regs->bx;
+        parameter_bytes = GEM_AESPB_BYTES;
+    } else if (regs->cx == GEM_VDI_SELECTOR) {
+        parameter_offset = regs->dx;
+        parameter_bytes = GEM_VDIPB_BYTES;
+    } else {
+        regs->ax = (word_t)-ENOSYS;
+        return;
+    }
+
+    if (!gem_range_valid(parameter_offset, parameter_bytes,
+                         current->t_endseg)) {
+        regs->ax = (word_t)-EFAULT;
+        return;
+    }
+
+    slot = gem_slot_for_task(current);
+    if (!slot || slot->request_state != GEM_REQUEST_FREE) {
+        regs->ax = (word_t)-EAGAIN;
+        return;
+    }
+    if (gem_allocate_generation(slot)) {
+        regs->ax = (word_t)-EOVERFLOW;
+        return;
+    }
+
+    slot->request_state = GEM_REQUEST_PENDING;
+    slot->request_pid = current->pid;
+    slot->client = current;
+    slot->ax = regs->ax;
+    slot->bx = regs->bx;
+    slot->cx = regs->cx;
+    slot->dx = regs->dx;
+    slot->es = regs->es;
+    slot->ds = regs->ds;
+    slot->request_segment = seg_get(data_segment);
+    slot->data_limit = current->t_endseg;
+    gem_queue_append(slot);
+
+    wake_up(&gem_owner_wait);
+
+    /*
+     * Keep the INT EF kernel continuation until the owner releases the slot
+     * or a signal becomes pending.  Marking the task interruptible before the
+     * state test closes the single-CPU wakeup race without a lock.
+     */
+    for (;;) {
+        current->state = TASK_INTERRUPTIBLE;
+        if (slot->request_state == GEM_REQUEST_FREE)
+            break;
+        if (current->signal) {
+            if (slot->request_state == GEM_REQUEST_PENDING)
+                gem_release_request(slot, -EINTR);
+            else if (slot->request_state == GEM_REQUEST_DELIVERED)
+                gem_abandon_request(slot, -EINTR);
+            break;
+        }
+        schedule();
+    }
+    current->state = TASK_RUNNING;
+}
+
+static int FARPROC gem_attach_request(struct gemtrap_request *request)
+{
+    struct gemtrap_slot *slot;
+    struct gemtrap_slot *candidate;
+    byte_t count;
+    byte_t tag;
+
+    if (request->ax >= GEMTRAP_ATTACH_TAGS)
+        return -EINVAL;
+    tag = (byte_t)request->ax;
+
+    slot = gem_find_request(request->slot, (pid_t)request->pid,
+                            request->generation_lo,
+                            request->generation_hi);
+    if (!slot || slot->request_state != GEM_REQUEST_DELIVERED
+        || !slot->request_segment)
+        return -ESRCH;
+    if (request->ds != slot->ds || request->ds != slot->request_segment->base)
+        return -ESRCH;
+
+    /*
+     * A task-table slot may be reused while an old image's EXIT has been sent
+     * but not detached.  Never overwrite that attachment pointer: doing so
+     * would lose its sole seg_put() path.  Only the exact live
+     * image/tag/DS/generation tuple is an idempotent repeat.
+     */
+    if (slot->attach_state != GEM_ATTACH_FREE) {
+        if (slot->attach_state == GEM_ATTACH_LIVE
+            && slot->attach_pid == slot->request_pid
+            && slot->attach_tag == tag
+            && slot->attach_segment == slot->request_segment
+            && slot->attach_generation_lo == slot->request_generation_lo
+            && slot->attach_generation_hi == slot->request_generation_hi)
+            return 0;
+        return -EBUSY;
+    }
+
+    candidate = &gem_slots[0];
+    count = 0;
+    while (count < (byte_t)MAX_TASKS) {
+        if (candidate->attach_state != GEM_ATTACH_FREE) {
+            if (candidate->attach_tag == tag
+                || candidate->attach_pid == slot->request_pid)
+                return -EBUSY;
+        }
+        candidate++;
+        count++;
+    }
+
+    slot->attach_segment = seg_get(slot->request_segment);
+    slot->attach_limit = slot->data_limit;
+    slot->attach_pid = slot->request_pid;
+    slot->attach_tag = tag;
+    slot->attach_generation_lo = slot->request_generation_lo;
+    slot->attach_generation_hi = slot->request_generation_hi;
+    slot->attach_state = GEM_ATTACH_LIVE;
+    return 0;
+}
+
+static int FARPROC gem_detach_request(struct gemtrap_request *request)
+{
+    struct gemtrap_slot *slot;
+
+    if (request->ax >= GEMTRAP_ATTACH_TAGS)
+        return -EINVAL;
+    slot = gem_slot_by_number(request->slot);
+    if (!slot || slot->attach_state == GEM_ATTACH_FREE
+        || slot->attach_pid != (pid_t)request->pid
+        || slot->attach_tag != (byte_t)request->ax
+        || !slot->attach_segment
+        || slot->attach_segment->base != request->ds
+        || slot->attach_generation_lo != request->generation_lo
+        || slot->attach_generation_hi != request->generation_hi)
+        return -ESRCH;
+
+    gem_release_attachment(slot);
+    return 0;
+}
+
+int sys_gemctl(unsigned int operation, struct gemtrap_request *user_request)
+{
+    struct gemtrap_request request;
+    struct gemtrap_slot *slot;
+    int error;
+
+    if (operation == GEMCTL_REGISTER) {
+        if (gem_owner && gem_owner != current)
+            return -EBUSY;
+        if (!gem_owner) {
+            gem_owner = current;
+            gemtrap_vector_enable();
+        }
+        return 0;
+    }
+
+    if (gem_owner != current)
+        return -EPERM;
+
+    if (operation == GEMCTL_NEXT || operation == GEMCTL_NEXT_NOWAIT) {
+        if (!user_request)
+            return -EFAULT;
+        return gem_take_request(user_request, operation == GEMCTL_NEXT);
+    }
+
+    if (operation == GEMCTL_UNREGISTER) {
+        gem_release_owner(-EPIPE);
+        return 0;
+    }
+
+    if (!user_request)
+        return -EFAULT;
+    error = verified_memcpy_fromfs(&request, user_request, sizeof(request));
+    if (error)
+        return error;
+
+    if (operation == GEMCTL_ATTACH)
+        return gem_attach_request(&request);
+    if (operation == GEMCTL_DETACH)
+        return gem_detach_request(&request);
+    if (operation != GEMCTL_REPLY && operation != GEMCTL_CANCEL)
+        return -EINVAL;
+
+    slot = gem_find_request(request.slot, (pid_t)request.pid,
+                            request.generation_lo,
+                            request.generation_hi);
+    if (!slot)
+        return -ESRCH;
+    if (slot->request_state == GEM_REQUEST_ABANDONED) {
+        gem_release_request(slot, -EINTR);
+        return -ESRCH;
+    }
+
+    if (operation == GEMCTL_REPLY) {
+        if (slot->request_state != GEM_REQUEST_DELIVERED)
+            return -EINVAL;
+        gem_release_request(slot, (int)request.ax);
+    } else {
+        gem_release_request(slot, -EINTR);
+    }
+    return 0;
+}
+
+/* Mark a retained old image before finalize_exec drops its normal DS ref. */
+void gemtrap_task_exec(struct task_struct *executing)
+{
+    struct gemtrap_slot *slot;
+
+    if (!gem_owner)
+        return;
+    if (executing == gem_owner) {
+        /*
+         * The registered server identity is an executable image, not merely
+         * a PID.  Replacing that image must disable INT EFh and release every
+         * request and attachment exactly as owner exit or UNREGISTER does.
+         */
+        gem_release_owner(-EPIPE);
+        return;
+    }
+    slot = gem_slot_for_task(executing);
+    if (!slot || slot->attach_state != GEM_ATTACH_LIVE
+        || slot->attach_pid != executing->pid)
+        return;
+
+    slot->attach_state = GEM_ATTACH_EXIT_PENDING;
+    wake_up(&gem_owner_wait);
+}
+
+void gemtrap_task_exit(struct task_struct *exiting)
+{
+    struct gemtrap_slot *slot;
+
+    if (gem_owner == exiting) {
+        gem_release_owner(-EPIPE);
+        return;
+    }
+
+    slot = gem_slot_for_task(exiting);
+    if (!slot)
+        return;
+
+    if (slot->request_state == GEM_REQUEST_PENDING)
+        gem_release_request(slot, -EINTR);
+    else if (slot->request_state == GEM_REQUEST_DELIVERED)
+        gem_abandon_request(slot, -EINTR);
+
+    if (slot->attach_state == GEM_ATTACH_LIVE
+        && slot->attach_pid == exiting->pid)
+        slot->attach_state = GEM_ATTACH_EXIT_PENDING;
+    wake_up(&gem_owner_wait);
+}

--- a/libc/system/Makefile
+++ b/libc/system/Makefile
@@ -22,7 +22,7 @@ syscall.mk: $(SYSCALLDAT) $(dir)syscall.awk
 	awk -f $(dir)syscall.awk regparmcall=$(regparmcall) $< > $@
 
 out: syscall.mk
-	$(MAKE) -f $(dir)out.mk
+	$(MAKE) -f $(dir)out.mk all
 .PHONY: out
 
 clean:


### PR DESCRIPTION
## Summary

This adds a default-off, real-mode IBM PC broker for the original GEM INT EFh AES/VDI entry point.

- installs the signed `GEMAES` vector only while one resident user process is registered
- transfers requests through one fixed slot per ELKS task
- pins the client's native data segment while the resident process handles the request
- reports exec and exit lifecycle records so retained process state is released safely
- keeps AES, VDI, menus, windows, and desktop policy in user space

The control call uses syscall slot 65, whose former module-loading operation is already removed.

## Compatibility and bounds

`CONFIG_GEM_TRAP` defaults to off and is offered only for IBM PC real-mode builds. The direct IVT path is excluded when `CONFIG_286_PMODE` is selected.

All public fields, registers, limits, counters, and generation halves are 8 or 16 bits. The broker uses a fixed 640-byte table, performs no dynamic allocation, and preserves far addresses as explicit segment and offset words.

The saved vector is restored only if INT EFh still points to this broker. Owner exec, owner exit, client exec, client exit, interruption, cancellation, and stale replies all have explicit cleanup paths.

## Validation

Validated at commit `e1cf24a810c7c1e74d1ca53f84a8a8ca66a2d432` on upstream master `b7cfe4973487ab235169dd9eb489285409fb8b2a` with an IBM PC configuration generated with `CONFIG_GEM_TRAP=y`:

- full kernel build: pass
- `gemtrap.o` and broker test-object 8086 instruction audits: pass
- source and executable-model gates: pass
- headless QEMU `isapc` guest regression: `GEM_TRAP_BROKER_PASS`
- disposable test image verified; source image remained unchanged
- resulting kernel: 116208 bytes total, including 64096 bytes near code and 32832 bytes far text

This is deliberately separate from the GEM user-space desktop integration so the kernel ABI can be reviewed on its own.

Related background: #871.