### PR TITLE
[console] Make graphics lock task-owned

### DIFF
--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -1,5 +1,13 @@
 /* shared console routines for Direct and BIOS consoles - #include in console drivers*/
 
+/*
+ * The console pointer in glock identifies the virtual console, but it does
+ * not identify the ELKS task which acquired graphics mode.  Keep that owner
+ * as one near kernel pointer.  This prevents another task which inherited or
+ * reopened the same tty from changing raw mode or releasing the lock.
+ */
+static struct task_struct *glock_owner;
+
 static void WriteChar(Console * C, int c)
 {
     /* check for graphics lock */
@@ -341,6 +349,65 @@ static segment_s *graph_save_seg[MAX_CONSOLES];
 static unsigned int graph_save_words;
 #endif
 
+/*
+ * Release graphics ownership only for the task which acquired it.  A normal
+ * DCREL_GRAPH supplies its console in C.  Task-exit cleanup passes NULL and
+ * releases whichever console the dying task owns.
+ *
+ * The current console implementation may hold one saved text segment per
+ * virtual console.  Restore and free those segments on both paths.  This is
+ * important on abnormal exit: merely clearing glock would leak the segments
+ * and leave the saved text pages unavailable to the next graphics client.
+ */
+static void console_graphics_unlock(Console *C, struct task_struct *owner)
+{
+    Console *locked = glock;
+
+    if (!locked || glock_owner != owner)
+        return;
+    if (C && locked != C)
+        return;
+    C = locked;
+
+#if VC_GRAPH_SAVE_RESTORE
+    {
+        int i, n;
+
+        n = UseRambuf ? 1 : NumConsoles;
+        for (i = 0; i < n; i++) {
+            Console *V = UseRambuf ? Visible[C->display] : &Con[i];
+
+            if (graph_save_seg[i]) {
+                fmemcpyw((void *)0, (seg_t) V->vseg,
+                         (void *)0, graph_save_seg[i]->base,
+                         graph_save_words);
+                seg_free(graph_save_seg[i]);
+                graph_save_seg[i] = 0;
+            }
+        }
+        graph_save_words = 0;
+
+        /*
+         * A normal graphics client restores text mode before release.  In
+         * page-flip mode, select the same foreground page it left.  The exit
+         * path also performs this bounded cleanup so no saved segment leaks.
+         */
+        if (!UseRambuf)
+            SetDisplayPage(Visible[C->display]);
+    }
+#endif
+
+    kraw = 0;
+    glock_owner = NULL;
+    glock = NULL;
+    wake_up(&glock_wait);
+}
+
+void console_graphics_task_exit(struct task_struct *owner)
+{
+    console_graphics_unlock(NULL, owner);
+}
+
 static int Console_ioctl(struct tty *tty, int cmd, char *arg)
 {
     Console *C = &Con[tty->minor];
@@ -372,46 +439,24 @@ static int Console_ioctl(struct tty *tty, int cmd, char *arg)
             }
 #endif
             glock = C;
+            glock_owner = current;
             return 0;
         }
         return -EBUSY;
     case DCREL_GRAPH:
-        if (glock == C) {
-#if VC_GRAPH_SAVE_RESTORE
-            int i, n;
-            n = UseRambuf ? 1 : NumConsoles;
-            for (i = 0; i < n; i++) {
-                Console *V = UseRambuf ? Visible[C->display] : &Con[i];
-                if (graph_save_seg[i]) {
-                    fmemcpyw((void *)0, (seg_t) V->vseg,
-                             (void *)0, graph_save_seg[i]->base,
-                             graph_save_words);
-                    seg_free(graph_save_seg[i]);
-                    graph_save_seg[i] = 0;
-                }
-            }
-            graph_save_words = 0;
-            /* The graphics app's BIOS mode reset left CRTC at page 0. In
-             * page-flip mode that may not be the foreground VC's page;
-             * re-program the start address so the user lands on the same
-             * VC they left. RAM-buffer mode never page-flips and needs no fixup.
-             */
-            if (!UseRambuf)
-                SetDisplayPage(Visible[C->display]);
-#endif
-            glock = NULL;
-            wake_up(&glock_wait);
+        if (glock == C && glock_owner == current) {
+            console_graphics_unlock(C, current);
             return 0;
         }
         break;
     case DCSET_KRAW:
-        if (glock == C) {
+        if (glock == C && glock_owner == current) {
             kraw = 1;
             return 0;
         }
         break;
     case DCREL_KRAW:
-        if ((glock == C) && (kraw == 1)) {
+        if (glock == C && glock_owner == current && kraw == 1) {
             kraw = 0;
             return 1;
         }

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -113,6 +113,13 @@ struct tty {            /* NOTE: first member used in fastser.S driver */
 
 extern struct tty ttys[];
 
+struct task_struct;
+
+#if defined(CONFIG_CONSOLE_DIRECT) || defined(CONFIG_CONSOLE_BIOS)
+/* Drop a task-owned graphics lock before do_exit() reuses its task slot. */
+extern void console_graphics_task_exit(struct task_struct *);
+#endif
+
 extern int tty_intcheck(struct tty *,unsigned char);
 		/* Check for ctrl-C etc.. */
 

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -11,6 +11,7 @@
 #include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/kd.h>
+#include <linuxmt/ntty.h>
 
 static void FARPROC reparent_children(void)
 {
@@ -128,6 +129,10 @@ void do_exit(int status)
     struct task_struct *parent;
 
     debug_wait("EXIT(%P) status %d\n", status);
+#if defined(CONFIG_CONSOLE_DIRECT) || defined(CONFIG_CONSOLE_BIOS)
+    /* A killed graphics client cannot issue DCREL_GRAPH itself. */
+    console_graphics_task_exit(current);
+#endif
     _close_allfiles();
 #ifdef CONFIG_AUDIO
     audio_seq_exit(current->pid);


### PR DESCRIPTION
## Summary

This makes `DCGET_GRAPH` ownership follow the ELKS task that acquired graphics mode, rather than treating an open console alone as sufficient authority.

- records the acquiring task in one near kernel pointer
- permits raw-mode changes and `DCREL_GRAPH` only from that task
- releases a dead task's graphics ownership from `do_exit()`
- wakes existing graphics-lock waiters after cleanup

## Current console integration

Recent master can retain one saved text segment per virtual console while graphics mode is active. The common unlock helper preserves that behavior on both normal release and abnormal task exit: it restores each saved text page, frees every saved segment, resets the saved-word count, and selects the foreground page when page flipping is in use.

This avoids leaving the console permanently busy after a killed desktop process and avoids leaking the newer virtual-console backing segments.

The release remains scoped to direct and BIOS console configurations. It adds no process-wide allocator or polling path.

## Validation

Validated at commit `6b44dfbb8fc9e7c67a2445d8e77958a76a206188` on upstream master `b7cfe4973487ab235169dd9eb489285409fb8b2a`:

- full IBM PC kernel build using `ibmpc-1440.config`: pass
- affected task-owner and unlock paths compiled with the ELKS `-mtune=i8086` kernel configuration: pass
- headless QEMU `isapc` crash/reacquire regression: `ELKS_GRAPH_LOCK_PASS`
- disposable test image verified; source image remained unchanged
- patch whitespace and one-commit branch audit: pass

This is independent of the GEM trap broker and can be reviewed as a console lifetime fix.

Related background: #871.