### PR TITLE
[kernel] Restore true vfork for low-memory exec

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -594,9 +594,13 @@ static void FARPROC finalize_exec(struct inode *inode, segment_s *seg_code,
     if (inode->i_mode & S_ISGID)
         currentp->egid = inode->i_gid;
 
-#if UNUSED      /* used only for vfork()*/
+    /*
+     * A vfork parent sleeps on child_wait while the child shares its data
+     * segment.  The child now owns a private data/stack segment, so release
+     * that parent immediately.  Ordinary exec may cause a harmless spurious
+     * wakeup; wait4 rechecks child state before returning.
+     */
     wake_up(&currentp->p_parent->child_wait);
-#endif
 
     /*
      * Arrange for our return from sys_execve onto the new

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -148,12 +148,48 @@ pid_t sys_fork(void)
     return do_fork(0);
 }
 
+/*
+ * Return nonzero only while the exact vfork child still uses the parent's
+ * data/stack segment.  child_wait is also used by wait4 and by every child,
+ * so waking on that queue alone is not proof that this particular child has
+ * completed exec or exit.  Comparing the kernel segment pointers costs only
+ * one 16-bit pointer comparison on the 8086 and does not expose a physical
+ * address to user space.
+ */
+static int vfork_child_shares_data(pid_t pid, struct segment *shared_data)
+{
+    register struct task_struct *p;
+    int count;
+
+    /*
+     * Do not form &task[max_tasks] here.  Scaling that variable array index
+     * makes the 16-bit compiler emit MUL on an original 8088/8086.  A bounded
+     * countdown and one structure-pointer increment per slot use only cheap
+     * word decrement, compare and add instructions.
+     */
+    p = &task[0];
+    count = max_tasks;
+    while (count--) {
+        if (p->p_parent == current && p->pid == pid &&
+            p->state != TASK_UNUSED)
+            return p->mm[SEG_DATA] == shared_data;
+        p++;
+    }
+    return 0;
+}
+
 pid_t sys_vfork(void)
 {
-#if 1
-    return do_fork(0);
-#else
-    int retval, sc[5];
+    /*
+     * Preserve the complete IA16 medium-model user return frame while the
+     * child shares this data/stack segment.  The syscall entry frame is BP,
+     * IP, CS, FLAGS (four words), and libc's far return from vfork adds IP,
+     * CS (two words).  Saving only the historical five words lets the child
+     * overwrite the parent's final return word and leaves it asleep or
+     * returning through a damaged frame after exec/_exit.
+     */
+    int retval, sc[6];
+    struct segment *shared_data = current->mm[SEG_DATA];
 
     if ((retval = do_fork(1)) >= 0) {
 
@@ -167,9 +203,21 @@ pid_t sys_vfork(void)
          */
         memcpy_fromfs(sc, (void *)current->t_regs.sp, sizeof(sc));
         /*
-         * Let the child go on first.
+         * Let the child go on first.  Register on the wait queue before the
+         * condition test, then recheck the exact child's data segment after
+         * every wakeup.  An unrelated child may exec or exit on this same
+         * queue; that wakeup must never let the parent restore and reuse its
+         * stack while the vfork child still shares it.
          */
-        sleep_on(&current->child_wait);
+        for (;;) {
+            prepare_to_wait(&current->child_wait);
+            if (!vfork_child_shares_data((pid_t)retval, shared_data)) {
+                finish_wait(&current->child_wait);
+                break;
+            }
+            do_wait();
+            finish_wait(&current->child_wait);
+        }
         /*
          * By now, the child should have its own user stack. Restore
          * the parent's user stack.
@@ -177,5 +225,4 @@ pid_t sys_vfork(void)
         memcpy_tofs((void *)current->t_regs.sp, sc, sizeof(sc));
     }
     return retval;
-#endif
 }


### PR DESCRIPTION
## Summary

ELKS currently implements `sys_vfork()` as an ordinary copying `fork()`. This restores the dormant shared-data path so a child can exec on a small-memory 8088/8086 without first duplicating the parent's data and stack segment.

- `fork()` remains unchanged
- the vfork child shares the parent's data segment until exec or exit
- the parent waits for the exact child and shared-segment identity, not merely any wakeup on `child_wait`
- the complete six-word medium-model syscall/libc return frame is preserved
- successful exec wakes the sleeping parent after installing the child's private image

The task scan uses a bounded 16-bit countdown and fixed structure-pointer increments. It does not add a multiply to the existing fork object.

## False-wakeup and stack safety

`child_wait` is shared with normal wait handling and every child. The restored loop registers on the wait queue, rechecks the selected PID and data-segment pointer after every wakeup, and resumes the parent only after that exact child stops sharing its stack.

The previous dormant implementation saved five words. A medium-model return crosses both the syscall frame and libc far return, requiring six words; this patch saves and restores all six.

## Validation

Validated at published commit `1bc0a15517fe7b317cdeb8a609f61c7a26a2cf34` on upstream master `b7cfe4973487ab235169dd9eb489285409fb8b2a`:

- full IBM PC `ibmpc-1440` kernel build: pass
- resulting kernel: 113232 bytes; linked system: 111864 bytes
- changed helper disassembly: 8086 word operations only
- differential audit: both master and this branch have the same two pre-existing multiplies elsewhere in `fork.o`; this patch adds zero
- headless QEMU `isapc` guest regression: `VFORK_KERNEL_PASS`
- guest coverage includes shared-data exit and an unrelated-child false wakeup
- disposable test image verified; source image remained unchanged

This is a renewed, narrowly tested version of the area discussed in #2316, so it is submitted as a draft for stability review.