### PR TITLE
[net] Complete nonblocking INET connect

### DIFF
--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -67,6 +67,7 @@
 #define ETIMEDOUT       110     /* Connection timed out */
 #define ECONNREFUSED    111     /* Connection refused */
 #define EHOSTUNREACH    113     /* Host not reachable */
+#define EALREADY        114     /* Operation already in progress */
 #define EINPROGRESS     115     /* Operation now in progress */
 #define ENONAMESERVER   125     /* Nameserver not found */
 #define ENONAME         126     /* Name not found */

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -160,10 +160,29 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
     return (ret >= 0 ? 0 : ret);
 }
 
+/*
+ * Consume one completed KTCP connection attempt.  retval and every state
+ * value are native 16-bit or smaller fields.  A failed asynchronous attempt
+ * returns the socket to SS_UNCONNECTED so a later connect may retry it; no
+ * descriptor, pointer, or protocol address is widened here.
+ */
+static int inet_connect_result(struct socket *sock)
+{
+    int ret = sock->retval;
+
+    sock->flags &= ~SF_CONNECT;
+    if (ret == 0)
+        sock->state = SS_CONNECTED;
+    else
+        sock->state = SS_UNCONNECTED;
+    return ret;
+}
+
 static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
                         size_t sockaddr_len, int flags)
 {
     register struct tdb_connect *cmd;
+    int ret;
 
     debug_net("INET(%P) connect sock %x\n", sock);
 
@@ -173,16 +192,38 @@ static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
     if (get_user(&(((struct sockaddr_in *)uservaddr)->sin_family)) != AF_INET)
         return -EINVAL;
 
-    if (sock->state == SS_CONNECTING)
-        return -EINPROGRESS;
+    /*
+     * A second connect after select readiness is the small ELKS equivalent
+     * of reading SO_ERROR.  It returns the exact saved KTCP status and does
+     * not transmit another SYN.  While no status exists, POSIX distinguishes
+     * this repeat from the first EINPROGRESS with EALREADY.
+     */
+    if (sock->state == SS_CONNECTING) {
+        if (sock->flags & SF_CONNECT)
+            return inet_connect_result(sock);
+        return -EALREADY;
+    }
 
     sock->flags &= ~SF_CONNECT;
+    sock->retval = -EINPROGRESS;
+    sock->state = SS_CONNECTING;
     cmd = (struct tdb_connect *)get_tdout_buf();
     cmd->cmd = TDC_CONNECT;
     cmd->sock = sock;
     memcpy_fromfs(&cmd->addr, uservaddr, sockaddr_len);
 
-    tcpdev_inetwrite(cmd, sizeof(struct tdb_connect));
+    ret = tcpdev_inetwrite(cmd, sizeof(struct tdb_connect));
+    if (ret < 0) {
+        sock->state = SS_UNCONNECTED;
+        return ret;
+    }
+
+    /* Never sleep a file descriptor whose caller selected O_NONBLOCK. */
+    if (flags & O_NONBLOCK) {
+        if (sock->flags & SF_CONNECT)
+            return inet_connect_result(sock);
+        return -EINPROGRESS;
+    }
 
     do {
         interruptible_sleep_on(sock->wait);
@@ -190,9 +231,7 @@ static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
             return -ETIMEDOUT;
     } while (!(sock->flags & SF_CONNECT));
 
-    if (sock->retval == 0)
-        sock->state = SS_CONNECTED;
-    return sock->retval;
+    return inet_connect_result(sock);
 }
 
 
@@ -391,14 +430,34 @@ static int inet_select(register struct socket *sock, int sel_type)
          sock, sock->wait, sel_type, sock->avail_data);
 
     if (sel_type == SEL_IN) {
+        /* A connection attempt has no readable stream until it completes. */
+        if (sock->state == SS_CONNECTING) {
+            select_wait(sock->wait);
+            return 0;
+        }
         if (sock->avail_data || sock->state != SS_CONNECTED)
             return 1;
         else {
             select_wait(sock->wait);
             return 0;
         }
-    } else if (sel_type == SEL_OUT)
+    } else if (sel_type == SEL_OUT) {
+        if (sock->state == SS_CONNECTING) {
+            if (sock->flags & SF_CONNECT)
+                return 1;
+            select_wait(sock->wait);
+            return 0;
+        }
         return 1;
+    } else if (sel_type == SEL_EX) {
+        if (sock->state == SS_CONNECTING) {
+            if ((sock->flags & SF_CONNECT) && sock->retval < 0)
+                return 1;
+            if (!(sock->flags & SF_CONNECT))
+                select_wait(sock->wait);
+        }
+        return 0;
+    }
     return 0;
 }
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -29,6 +29,22 @@ static unsigned char sbuf[TCPDEV_BUFSIZ];
 
 int tcpdevfd;
 
+/*
+ * Select a native 16-bit ephemeral port.  Increment wraps by the C unsigned
+ * rule; values below 1024 are then saturated upward to 1024.  KTCP cannot
+ * hold every remaining port on an 8086, so this bounded-memory search always
+ * finds a free control block without division, multiplication, or wide math.
+ */
+static __u16 tcpdev_ephemeral_port(void)
+{
+    do {
+        next_port++;
+        if (next_port < 1024)
+            next_port = 1024;
+    } while (tcpcb_check_port(next_port) != NULL);
+    return next_port;
+}
+
 int tcpdev_init(char *fdev)
 {
     int fd  = open(fdev, O_NONBLOCK | O_RDWR);
@@ -85,13 +101,9 @@ static void tcpdev_bind(void)
     }
 
     port = ntohs(db->addr.sin_port);
-    if (port == 0) {
-	if (++next_port < 1024)
-	    next_port = 1024;
-	while (tcpcb_check_port(next_port) != NULL)
-	    next_port++;
-	port = next_port;
-    } else {
+    if (port == 0)
+	port = tcpdev_ephemeral_port();
+    else {
 	struct tcpcb_list_s *n2 = tcpcb_check_port(port);
 	if (n2) {			/* port already bound */
 	    if (!db->reuse_addr) {	/* no SO_REUSEADDR on socket */
@@ -218,8 +230,21 @@ static void tcpdev_connect(void)
     ipaddr_t addr;
 
     n = tcpcb_find_by_sock(db->sock);
-    if (!n || n->tcpcb.state != TS_CLOSED) {
-	debug_tcp("tcp: panic in connect\n");
+    if (!n) {
+	/* POSIX connect performs an implicit ephemeral bind when needed. */
+	n = tcpcb_new(CB_NORMAL_BUFSIZ);
+	if (!n) {
+	    notify_sock(db->sock, TDT_CONNECT, -ENOMEM);
+	    return;
+	}
+	n->tcpcb.sock = db->sock;
+	n->tcpcb.localaddr = local_ip;
+	n->tcpcb.localport = tcpdev_ephemeral_port();
+	n->tcpcb.state = TS_CLOSED;
+    }
+    if (n->tcpcb.state != TS_CLOSED) {
+	debug_tcp("tcp: connect on socket in state %d\n", n->tcpcb.state);
+	notify_sock(db->sock, TDT_CONNECT, -EINVAL);
 	return;
     }
 

--- a/elkscmd/rootfs_template/etc/perror
+++ b/elkscmd/rootfs_template/etc/perror
@@ -48,6 +48,7 @@
 110 Connection timed out 
 111 Connection refused 
 113 Host not reachable 
+114 Operation already in progress
 115 Operation now in progress 
 125 Nameserver not found 
 126 Name not found 


### PR DESCRIPTION
## Summary

This completes the ELKS/KTCP path for `connect()` on an `O_NONBLOCK` INET socket.

- the first call starts the attempt and returns `EINPROGRESS`
- a repeat before completion returns `EALREADY`
- write-select becomes ready when KTCP reports completion
- exception-select becomes ready for a failed attempt
- a second `connect()` after readiness consumes the stored KTCP result without sending another SYN
- failed completion returns the socket to `SS_UNCONNECTED` so it can be retried
- KTCP performs the required implicit ephemeral bind for an unbound socket
- ephemeral port selection uses bounded 16-bit increment/wrap logic
- the guest `/etc/perror` table now includes error 114

ELKS does not currently provide a `SO_ERROR` retrieval path. Reusing the second connect call to return the saved completion is the intentionally small ABI here; it is documented explicitly rather than silently reporting success or starting another connection.

## State ordering

The socket enters `SS_CONNECTING` before the command is sent to tcpdev, and a synchronous command-write error restores `SS_UNCONNECTED`. Blocking callers retain their wait behavior but now consume completion through the same helper as nonblocking callers.

Read-select does not expose an incomplete stream as readable. Write and exception waiters register on the existing socket wait queue.

## Validation

Validated at published commit `06f275caf69965c01b22748ab5c6fc13f0a34f13` on upstream master `b7cfe4973487ab235169dd9eb489285409fb8b2a`:

- full IBM PC `CONFIG_INET` kernel build: pass
- resulting kernel: 113168 bytes, including 62464 bytes near code and 32112 bytes far text
- complete KTCP build and small-model link: pass
- `af_inet.o` and `tcpdev.o` 8086 instruction audits: pass
- touched functions contain no multiply, divide, wide register, or later-CPU opcode
- headless disposable QEMU transport regression: `NET_CONNECT_RUNTIME_PASS`
- guest asserted `EINPROGRESS`, write readiness without exception, stored success from the second call, and a successful stream write
- host listener received the exact 19-byte test payload
- source gate, errno text check, and patch whitespace audit: pass

Related KTCP audit discussion: #2662.