### PR TITLE
[build] Add optional GEM Desktop external application

### DIFF
--- a/Documentation/Readme.md
+++ b/Documentation/Readme.md
@@ -21,6 +21,8 @@ This section contains some HOWTOs to help using ELKS.
 
 * [The Kilo editor](https://htmlpreview.github.io/?https://github.com/jbruchon/elks/master/Documentation/html/user/kilo.html)
 
+* [GEM Desktop on ELKS](https://raw.githubusercontent.com/ghaerr/elks/master/Documentation/text/gem.txt)
+
 * [Writing applications for ELKS in C](https://htmlpreview.github.io/?https://github.com/jbruchon/elks/blob/master/Documentation/html/user/writing_apps_in_C.html)
 
 * [Writing applications for ELKS in assembler](https://htmlpreview.github.io/?https://github.com/jbruchon/elks/blob/master/Documentation/html/user/writing_apps_in_assembler.html)

--- a/Documentation/text/gem.txt
+++ b/Documentation/text/gem.txt
@@ -1,0 +1,40 @@
+GEM Desktop for ELKS
+====================
+
+The optional GEM Desktop external application is intended for IBM PC compatible
+8088 and 8086 systems using an ELKS hard disk image.  It runs in real mode and
+requires CONFIG_GEM_TRAP=y.  It is unavailable when CONFIG_286_PMODE=y or when
+another ELKS architecture is selected.
+
+The GEM AES, VDI and Desktop sources and direct runtime resources are derived
+from the GPL-2.0 FreeGEM/OpenGEM source release; original copyright and GPL
+notices are retained.  ELKS-specific adaptation sources in Gem-elks are
+distributed under GPL-2.0-only.  See the external repository's LICENSE and
+provenance manifest for exact source revisions and asset hashes.
+
+The build is pinned to the v2026.07.14-core.1 tag at:
+
+    https://github.com/parabyte/Gem-elks
+
+After configuring ELKS, build the pinned source with:
+
+    ./buildext.sh elksgem
+
+Then enable "GEM Desktop (hard disk only)" in the Userland configuration and
+build the hard disk image normally.  The installation contains:
+
+    /bin/gemaes
+    /bin/gemdesk
+    /GEMAPPS/GEMSYS/DESKTOP.RSC
+    /GEMAPPS/GEMSYS/DESKHI.ICN
+    /GEMAPPS/GEMSYS/DESKLO.ICN
+    /GEMAPPS/GEMSYS/DESKTOP.INF
+
+Start /bin/gemaes first, then start /bin/gemdesk from a second shell or from a
+separate supervised startup entry.  gemaes must remain running as the shared
+AES and VDI owner while gemdesk uses the kernel GEM broker.  gemdesk cannot be
+started before the resident owner.
+
+The four data files are original GEM resources.  They are installed unchanged
+and parsed directly on ELKS; no resource conversion program is used on the
+target system.

--- a/buildext.sh
+++ b/buildext.sh
@@ -14,6 +14,7 @@
 #       microwindows_pc98 ia16-elf-gcc  Nano-X Graphical Windowing Environment for PC-98
 #       dcc             ia6-elf-gcc     DCC self-compiling C compiler for ELKS
 #       dflat           ia16-elf-gcc    D-Flat TUI memopad/library
+#       elksgem         ia16-elf-gcc    GEM Desktop for ELKS
 #       elkirc          ia16-elf-gcc    IRC for ELKS
 #       elksdigger      ia16-elf-gcc    Digger for ELKS
 #       owc_libc        OpenWatcom      ELKS C Library compiled by OWC
@@ -190,6 +191,25 @@ dflat()
     echo "D-Flat build complete"
 }
 
+elksgem()
+{
+    ELKSGEM_TAG=v2026.07.14-core.1
+
+    echo "Building GEM Desktop for ELKS..."
+    cd $TOPDIR/extapps
+    if [ ! -d elks-gem ] ; then
+        git clone --branch $ELKSGEM_TAG --depth 1 \
+            https://github.com/parabyte/Gem-elks.git elks-gem
+    fi
+    cd elks-gem
+    git fetch --depth 1 origin \
+        refs/tags/$ELKSGEM_TAG:refs/tags/$ELKSGEM_TAG
+    git checkout --detach $ELKSGEM_TAG
+    make -f Makefile.elks clean
+    make -f Makefile.elks ELKS_ROOT=$TOPDIR
+    echo "GEM Desktop build complete"
+}
+
 elksdoom()
 {
     echo "Building Doom..."
@@ -340,6 +360,7 @@ make_all()
     microwindows
     dcc
     dflat
+    elksgem
     elkirc
     elksdigger
     if [ -n "$WATCOM" ] ; then

--- a/elkscmd/ExtApplications
+++ b/elkscmd/ExtApplications
@@ -23,6 +23,7 @@
 #   :1440k      Set of apps to fit on 1440k disks (and 1200k if compressed)
 #   :1440c      Extra apps to add to 1440k disks if CONFIG_APPS_COMPRESS set
 #   :2880k      Set of apps to fit on 2880k disks
+#   :elksgem    GEM Desktop files for hard disk images
 #   :::file     install as symlink
 #
 # ------------- ----------------------------------------------------------
@@ -45,6 +46,12 @@ microwindows/src/bin/nxselect                       :nanox  :1232c
 microwindows/src/demos/nanox/images/girl1.jpg ::root/girl1.jpg :nanox
 microwindows/src/demos/nanox/images/earth.jpg ::root/earth.jpg :nanox
 dflat/memopad                                       :dflat              :2880k
+elks-gem/build/bin/gemaes       ::bin/gemaes        :elksgem
+elks-gem/build/bin/gemdesk      ::bin/gemdesk       :elksgem
+elks-gem/assets/GEMAPPS/GEMSYS/DESKTOP.RSC ::GEMAPPS/GEMSYS/DESKTOP.RSC :elksgem
+elks-gem/assets/GEMAPPS/GEMSYS/DESKHI.ICN  ::GEMAPPS/GEMSYS/DESKHI.ICN  :elksgem
+elks-gem/assets/GEMAPPS/GEMSYS/DESKLO.ICN  ::GEMAPPS/GEMSYS/DESKLO.ICN  :elksgem
+elks-gem/assets/GEMAPPS/GEMSYS/DESKTOP.INF ::GEMAPPS/GEMSYS/DESKTOP.INF :elksgem
 # sample ELKS OWC/C86 files
 ../elkscmd/basic/basic.os2                          :owc                :2880k
 ../elkscmd/fsck_dos/fsck-dos.os2                    :owc                :2880k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -54,6 +54,19 @@ ifdef CONFIG_APP_ELVIS
 	TAGS += :elvis|
 endif
 
+ifdef CONFIG_APP_GEM
+	ifneq ($(CONFIG_ARCH_IBMPC), y)
+		$(error CONFIG_APP_GEM requires CONFIG_ARCH_IBMPC=y)
+	endif
+	ifeq ($(CONFIG_286_PMODE), y)
+		$(error CONFIG_APP_GEM is not available in protected mode)
+	endif
+	ifneq ($(CONFIG_GEM_TRAP), y)
+		$(error CONFIG_APP_GEM requires CONFIG_GEM_TRAP=y)
+	endif
+	TAGS += :elksgem|
+endif
+
 ifdef CONFIG_APP_KTCP
 	TAGS += :net|
 endif

--- a/elkscmd/config.in
+++ b/elkscmd/config.in
@@ -31,6 +31,23 @@ mainmenu_option next_comment
 		bool 'other'         	CONFIG_APP_OTHER        y
 		bool 'test'       		CONFIG_APP_TEST         n
 		bool 'busyelks'			CONFIG_APP_BUSYELKS		n
+
+		comment 'Graphical desktop'
+
+		if [ "$CONFIG_ARCH_IBMPC" = "y" ]; then
+			if [ "$CONFIG_286_PMODE" != "y" ]; then
+				if [ "$CONFIG_GEM_TRAP" = "y" ]; then
+					bool 'GEM Desktop (hard disk only)' CONFIG_APP_GEM n
+				else
+					comment '(GEM Desktop needs the GEM INT EF broker)'
+				fi
+			else
+				comment '(GEM Desktop needs an 8086 real-mode kernel)'
+			fi
+		else
+			comment '(GEM Desktop is available for IBM PC only)'
+		fi
+
 		string 'Additional TAG string for app selection'  CONFIG_APP_TAGS      ''
 
 		#comment 'Commands not compiling'


### PR DESCRIPTION
## Summary

- add a default-off IBM PC real-mode GEM Desktop external application pinned to public tag v2026.07.14-core.1
- build the native AES/VDI owner and original Desktop client with the ELKS GNU ia16 toolchain
- install exactly two executables and four original Desktop resources into hard-disk images
- fail closed when IBM PC, real mode, or CONFIG_GEM_TRAP requirements are not met
- document build, runtime ordering, GPL provenance, and the direct resource path

Public source: https://github.com/parabyte/Gem-elks
Pinned commit: 9797037be09f1a064e63d8c03843c35b8f2d947a

## Dependencies

This draft depends on #2745 for the GEM INT EF broker and gemctl ABI. Runtime qualification also used #2747 for true vfork, #2746 for task-owned graphics access, and #2748 for medium-model signal delivery. #2749 is useful for supervised direct startup but is not required for manual startup.

## Validation

- anonymous HTTPS clone and pinned detached checkout passed
- buildext completed from the public tag
- ELKS model gates passed for both 01 03 executables
- source gate passed 151 files
- 8086 disassembly gate passed 127 objects
- retained-function audit passed with zero duplicate strong symbols and 91.35% core GEM lineage
- image installer staged exactly /bin/gemaes, /bin/gemdesk, and four GEMSYS assets; all six byte comparisons passed
- config visibility matrix and install-time dependency failures passed
- original asset SHA-256 manifest passed
- final diff, path, commit metadata, and public-source privacy scans passed

Binary SHA-256 values:

- gemaes: 159bbb34de4c597237fdff253c29a3d1e6e834e6d9c365409d695eaf1eb6fbe4
- gemdesk: 255098a800e10f129716694d961ca651197be0fcc104e4ead1ac5206bd57dd7a

## Licensing

The retained FreeGEM/OpenGEM core and original runtime assets carry their GPL version 2 release notices. ELKS adaptation work is GPL-2.0-only, with historical notices and pinned provenance retained. The DRI Toolkit Clock-derived material is not included.