### PR TITLE
[kernel] Implement vfork kernel syscall

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -594,9 +594,7 @@ static void FARPROC finalize_exec(struct inode *inode, segment_s *seg_code,
     if (inode->i_mode & S_ISGID)
         currentp->egid = inode->i_gid;
 
-#if UNUSED      /* used only for vfork()*/
-    wake_up(&currentp->p_parent->child_wait);
-#endif
+    wake_up(&currentp->p_parent->child_wait);   /* wake up any vfork parent */
 
     /*
      * Arrange for our return from sys_execve onto the new

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -69,7 +69,7 @@ struct task_struct *find_empty_process(void)
  *  Clone a process.
  */
 
-pid_t do_fork(int virtual)
+static pid_t do_fork(int virtual, struct task_struct **ptask)
 {
     register struct task_struct *t;
     int j, k;
@@ -140,42 +140,45 @@ pid_t do_fork(int virtual)
     /*
      *      Return the created task.
      */
+    if (ptask) *ptask = t;
     return t->pid;
 }
 
 pid_t sys_fork(void)
 {
-    return do_fork(0);
+    return do_fork(0, NULL);
 }
 
 pid_t sys_vfork(void)
 {
-#if 1
-    return do_fork(0);
-#else
-    int retval, sc[5];
+    int retval, sc[6];      /* saves user stack libc IP, [CS,] FLAGS, CS, IP, BP */
+    struct task_struct *t;
 
-    if ((retval = do_fork(1)) >= 0) {
+    if ((retval = do_fork(1, &t)) >= 0) {
 
         /* Parent and child are sharing the user stack at this point.
          * The child will go first, coming into life in the middle of
          * the tswitch() function, returning to user space, then will
-         * return from the library code where the actual syscall was
-         * done and then will issue an exec syscall, destroying the
-         * first few bytes at the top of the user stack. Save those
-         * bytes in the parent's kernel stack.
+         * return from the library code where the actual syscall was done,
+         * destroying the first 5-6 words at the top of the user stack.
+         * Save those words in the parent's kernel stack.
          */
         memcpy_fromfs(sc, (void *)current->t_regs.sp, sizeof(sc));
+
         /*
-         * Let the child go on first.
+         * Let the child go on first, then check that the child task exited or exec'd
+         * before continuing parent execution.
          */
-        sleep_on(&current->child_wait);
+        for (;;) {
+            sleep_on(&current->child_wait);
+            if (t->state == TASK_UNUSED || t->mm[SEG_DATA] != current->mm[SEG_DATA])
+                break;
+        }
+
         /*
-         * By now, the child should have its own user stack. Restore
-         * the parent's user stack.
+         * The child now has its own user stack. Restore the parent's user stack.
          */
         memcpy_tofs((void *)current->t_regs.sp, sc, sizeof(sc));
     }
     return retval;
-#endif
 }


### PR DESCRIPTION
Adds `vfork` system call using a human rewrite of dormant code which also includes two of the AI-generated findings in  #2747 by @parabyte.

Requested by @parabyte for GEM and @toncho11 for use in `nxdsktop` when memory is tight.

`vfork` allocates a new process like `fork`, but doesn't copy the parent's data segment. Instead, the child runs using the parent's data segment, and the parent will not run until the child either exits (or is killed), or calls `exec` to start another program. This normally results in less memory being used, and can be faster if the parent has a large data segment and the child quickly calls `exec`.

NOTE: `vfork` differs from `fork` in that the parent process is not allowed to run until exit or exec, unlike `fork`, where both parent and child may get interleaved time slices. Thus, multiprocessing results may differ greatly.

Currently, only the `system` and `popen` C library routines use `vfork`, although it is also used in the `sash` shell, `vi` and `nxstart` applications.

Tested fork and vfork on normal and PM kernels using the following test program:
```
#include <unistd.h>
#include <stdlib.h>

#define fork    vfork

int main(int ac, char **av)
{
    int i, p1;

    for(i=0; i<10; i++) {
        p1 = fork();
        if (p1 < 0) continue;
        if (p1 == 0) {
            write(1, "B", 1);
            //sleep(1);
            if (getpid() & 1) _exit(0);
            execl("/bin/ls", "ls", "-lR", "/", NULL);
            _exit(0);
        }
        write(1, "A", 1);
    }
    return 0;
}
```
