### PR TITLE
head, tail, uniq: use long counts to avoid 16-bit overflow

### DIFF
--- a/elkscmd/minix1/uniq.c
+++ b/elkscmd/minix1/uniq.c
@@ -65,10 +65,10 @@ static int equal(char *s1, char *s2)
   return !strcmp(skip(s1), skip(s2));
 }
 
-static void show(char *line, int count)
+static void show(char *line, long count)
 {
   if (cflag)
-	printf("%4d %s", count, line);
+	printf("%4ld %s", count, line);
   else {
 	if ((uflag && count == 1) || (dflag && count != 1))
 		printf("%s", line);
@@ -78,7 +78,7 @@ static void show(char *line, int count)
 static int uniq(void)
 {
   char *p;
-  int seen;
+  long seen;		/* long: duplicate runs can exceed 16-bit int */
 
   /* Setup */
   prevline = buf1;

--- a/elkscmd/minix3/head.c
+++ b/elkscmd/minix3/head.c
@@ -9,7 +9,7 @@
 #define DEFAULT 10
 
 _PROTOTYPE(int main, (int argc, char **argv));
-_PROTOTYPE(void do_file, (int n, FILE *f));
+_PROTOTYPE(void do_file, (long n, FILE *f));
 _PROTOTYPE(void usage, (void));
 
 int main(argc, argv)
@@ -17,7 +17,8 @@ int argc;
 char *argv[];
 {
   FILE *f;
-  int n, k, nfiles;
+  int k, nfiles;
+  long n;
   char *ptr;
 
   /* Check for flag.  Only flag is -n, to say how many lines to print. */
@@ -26,7 +27,7 @@ char *argv[];
   n = DEFAULT;
   if (argc > 1 && *ptr++ == '-') {
 	k++;
-	n = atoi(ptr);
+	n = atol(ptr);		/* long: line counts can exceed 16-bit int */
 	if (n <= 0) usage();
   }
   nfiles = argc - k;
@@ -56,7 +57,7 @@ char *argv[];
 
 
 void do_file(n, f)
-int n;
+long n;
 FILE *f;
 {
   int c;

--- a/elkscmd/minix3/tail.c
+++ b/elkscmd/minix3/tail.c
@@ -81,7 +81,7 @@ extern int optind;
 
 /* Internal functions - prototyped under Minix */
 _PROTOTYPE(int main, (int argc, char **argv));
-_PROTOTYPE(int tail, (int count, int bytes, int read_until_killed));
+_PROTOTYPE(int tail, (long count, int bytes, int read_until_killed));
 _PROTOTYPE(int keep_reading, (void));
 _PROTOTYPE(void usage, (void));
 
@@ -92,7 +92,7 @@ char *argv[];
   int cflag = FALSE;
   int nflag = FALSE;
   int fflag = FALSE;
-  int number = -DEFAULT_COUNT;
+  long number = -DEFAULT_COUNT;	/* long: counts can exceed 16-bit int */
   char *suffix;
   int opt;
   struct stat stat_buf;
@@ -110,7 +110,7 @@ char *argv[];
 			     (argv[1][1] == 'c' && argv[1][2] == 'f')))) {
 	--argc; ++argv;
 	if (isdigit(argv[0][1])) {
-		number = (int)strtol(argv[0], &suffix, 10);
+		number = strtol(argv[0], &suffix, 10);
 		if (number == 0) {		/* HISTORICAL */
 			if (argv[0][0] == '+')
 				number = 1;
@@ -151,10 +151,10 @@ char *argv[];
 		      case 'c':
 			cflag = TRUE;
 			if (*optarg == '+' || *optarg == '-')
-				number = atoi(optarg);
+				number = atol(optarg);
 			else
 			if (isdigit(*optarg))
-				number = -atoi(optarg);
+				number = -atol(optarg);
 			else
 				usage();
 			if (number == 0) {		/* HISTORICAL */
@@ -170,10 +170,10 @@ char *argv[];
 		      case 'n':
 			nflag = TRUE;
 			if (*optarg == '+' || *optarg == '-')
-				number = atoi(optarg);
+				number = atol(optarg);
 			else
 			if (isdigit(*optarg))
-				number = -atoi(optarg);
+				number = -atol(optarg);
 			else
 				usage();
 			if (number == 0) {		/* HISTORICAL */
@@ -224,7 +224,7 @@ char *argv[];
 }
 
 int tail(count, bytes, read_until_killed)
-int count;			/* lines or bytes desired */
+long count;			/* lines or bytes desired */
 int bytes;			/* TRUE if we want bytes */
 int read_until_killed;		/* keep reading at EOF */
 {


### PR DESCRIPTION
@ghaerr 
Can we please have 'long' versions of these utils? It would make quick benchmarking in CLI so much easier.

<img width="951" height="594" alt="image" src="https://github.com/user-attachments/assets/fea21e54-f850-4bb1-9510-54b9c79fe569" />

AI text below:

On ia16 int is 16 bits, so counts above 32767 overflowed: head -n and tail -n/-c/+N parsed with atoi into int, and uniq -c wrapped its duplicate counter. wc/grep/du/sum/cksum already use long.

Verified on ELKS: yes | head -40000 | wc -l now prints 40000 (was empty), uniq -c prints 40000 (was negative), and tail +79000c skips correctly (byte-exact output).