### PR TITLE
[net] Fix ktcp silently dropping TX packets when NIC busy

### DIFF
--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -176,7 +176,10 @@ void eth_write(unsigned char *packet, int len)
     eth_printhex(packet,len);
 #endif
     netconf_capture_packet(packet, len, 1);
-    write(devfd, packet, len);
+    if (write(devfd, packet, len) < 0 && errno == EAGAIN) {
+	usleep(1000L);              /* TX busy: wait for it to drain, retry once */
+	write(devfd, packet, len);
+    }
     netstats.ethsndcnt++;
 }
 


### PR DESCRIPTION
'ktcp` was silently dropping TX ethernet packets when NIC was busy. Full discussion with various solutions suggested in https://github.com/ghaerr/elks/issues/2741#issuecomment-4995911784.

Fixed by waiting 1ms for hardware TX buffer to empty and retrying. This likely solves a longtime bug seen infrequently where local area network packets were dropped for no apparent reason. This apparently occurred more frequently on very fast systems, where ktcp built packets occasionally faster than the NIC could send them.

Tested on VirtualBox using new PCnet/LANCE driver in #2756.