### PR TITLE
[kernel] Fix medium model signal handler range check

### DIFF
--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -131,6 +131,9 @@ int sys_signal(int signr, __kern_sighandler_t handler)
 {
     int i;
     struct segment *s;
+    seg_t seg;
+    segoff_t off;
+    segext_t seg_paras, off_paras;
 
     debug_sig("SIGNAL(%P) sys_signal %2d action %x:%x\n", signr,
         _FP_SEG(handler), _FP_OFF(handler));
@@ -141,13 +144,22 @@ int sys_signal(int signr, __kern_sighandler_t handler)
     else if (handler == KERN_SIG_IGN)
         current->sig.action[signr - 1].sa_dispose = SIGDISP_IGN;
     else {
-        debug("handler %x:%x\n", _FP_SEG(handler), _FP_OFF(handler));
+        seg = _FP_SEG(handler);
+        off = _FP_OFF(handler);
+        debug("handler %x:%x\n", seg, off);
+        off_paras = off >> 4;
+
         for (i = 0; i < MAX_SEGS; i++) {
             s = current->mm[i];
             if (!s || (s->flags & SEG_FLAG_TYPE) != SEG_FLAG_CSEG)
                 continue;
-            debug("codeseg %x:%x\n", s->base, s->size<<4);
-            if (_FP_SEG(handler) == s->base && _FP_OFF(handler) < (s->size << 4)) {
+            debug("codeseg %04x (%x paras)\n", s->base, s->size);
+            if (seg < s->base)
+                continue;
+            seg_paras = seg - s->base;
+            if (seg_paras >= s->size)
+                continue;
+            if (off_paras < s->size - seg_paras) {
                 current->sig.handler = handler;
                 current->sig.action[signr - 1].sa_dispose = SIGDISP_CUSTOM;
                 return 0;


### PR DESCRIPTION
Found by and based on PR #2748 by @parabyte.

This fixes sys_signal() validation for medium-model executables whose combined code allocation crosses 64 KiB.

The current check converts the allocation from paragraphs to bytes with s->size << 4. That 16-bit expression wraps at 64 KiB, and requiring the handler segment to equal the allocation base also rejects valid far-text handlers.

Tested on [D-Flat's](https://github.com/ghaerr/dflat) `memopad` which uses medium model.