### PR TITLE
[kernel] Execute user programs in XMS memory using PM kernel

### DIFF
--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -67,7 +67,7 @@ struct console {
     void (*fsm)(struct console *, int);
     seg_t vseg;                 /* current render target: video page seg when foreground,
                                    ram_seg when backgrounded in RAM-buffer mode */
-    segext_t vseg_offset;       /* offset into vseg for buffer ram calculations */
+    segoff_t vseg_offset;       /* offset into vseg for buffer ram calculations */
     unsigned int crtc_offset;   /* CRTC start address (chars) for this VC's video page;
                                    only meaningful when this VC is video-page-backed */
     unsigned short crtc_base;   /* 6845 CRTC base I/O address */

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -82,7 +82,7 @@ static size_t zero_read(struct inode *inode, struct file *filp, char *data, size
 static size_t kmem_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     seg_t sseg;
-    segext_t soff;
+    segoff_t soff;
 
     if (filp->f_flags & O_ALT) {
         sseg = _FP_SEG(filp->f_pos);
@@ -113,7 +113,7 @@ static size_t kmem_read(struct inode *inode, struct file *filp, char *data, size
 static size_t kmem_write(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     seg_t dseg;
-    segext_t doff;
+    segoff_t doff;
 
     if (filp->f_flags & O_ALT) {
         dseg = _FP_SEG(filp->f_pos);

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -35,8 +35,7 @@ static byte_t seg_pm_access(word_t type)
 /* allocate selector for passed segment_s structure, 0 = GDT full or limit exceeded */
 static int seg_pm_attach(segment_s *seg, word_t type)
 {
-    seg->base = desc_alloc(PARA_BYTES(seg->addr), PARA_BYTES(seg->size),
-        seg_pm_access(type));
+    seg->base = desc_alloc(seg->addr << 4, seg->size << 4, seg_pm_access(type));
     return seg->base;
 }
 
@@ -72,9 +71,9 @@ static list_s _seg_free;
 
 // Split segment if enough large
 
-static segment_s * seg_split (segment_s * s1, segext_t size0)
+static segment_s * seg_split (segment_s * s1, SELEXT_T size0)
 {
-    segext_t size2 = s1->size - size0;
+    SELEXT_T size2 = s1->size - size0;
 
     if (size2 >= SEG_MIN_SIZE) {
 
@@ -103,18 +102,18 @@ static segment_s * seg_split (segment_s * s1, segext_t size0)
 
 // Get free segment
 
-static segment_s * seg_free_get (segext_t size0, word_t type)
+static segment_s * seg_free_get (SELEXT_T size0, word_t type)
 {
     // First get the smallest suitable free segment
 
     segment_s * best_seg  = 0;
-    segext_t best_size = 0xFFFF;
+    SELEXT_T best_size = (SELEXT_T)-1;
     list_s * n = _seg_free.next;
-    segext_t size00 = size0, incr = 0;
+    SELEXT_T size00 = size0, incr = 0;
 
     while (n != &_seg_free) {
         segment_s * seg = structof (n, segment_s, free);
-        segext_t size1 = seg->size;
+        SELEXT_T size1 = seg->size;
 
         if (type & SEG_FLAG_ALIGN1K)
             size00 = size0 + ((~BASE(seg) + 1) & ((1024 >> 4) - 1));
@@ -160,8 +159,7 @@ static void seg_merge (segment_s * s1, segment_s * s2)
 
 segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
 {
-    segment_s * seg = heap_alloc(sizeof(segment_s),
-        HEAP_TAG_SEG | HEAP_TAG_CLEAR);
+    segment_s * seg = heap_alloc(sizeof(segment_s), HEAP_TAG_SEG | HEAP_TAG_CLEAR);
     if (!seg)
         return seg;
 
@@ -178,7 +176,7 @@ segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
 
 #endif
 
-// Allocate segment
+// Allocate segment, limited to 64K in PM for now
 
 segment_s * seg_alloc (segext_t size, word_t type)
 {
@@ -186,7 +184,7 @@ segment_s * seg_alloc (segext_t size, word_t type)
 
     seg = seg_free_get (size, type);
 #ifdef CONFIG_286_PMODE
-    if (!seg) printk("MEM FAIL %02x paras\n", size);    // DEBUG REMOVE
+    if (!seg) printk("MEM FAIL %04x paras\n", size);    // DEBUG REMOVE
     if (seg && (seg->addr & 0xFFFF0000)) printk("seg_alloc: xms %08lx size %uK\n",
         seg->addr << 4, (size + 63) >> 6);
 #endif
@@ -462,20 +460,17 @@ int seg_verify_area(pid_t pid, seg_t base, segoff_t offset)
         segment_s * seg = structof (n, segment_s, all);
 
         if (seg->pid == pid && seg->base == base)
-            return offset <= (seg->size << 4);
+            return offset <= ((unsigned long)seg->size << 4);
         n = seg->all.next;
     }
     return 0;
 }
 
-void INITPROC seg_add(addr_t start, addr_t end)
+void INITPROC seg_add(SELEXT_T start, SELEXT_T end)
 {
     segment_s * seg = (segment_s *) heap_alloc (sizeof (segment_s), HEAP_TAG_SEG);
     if(seg) {
         BASE(seg) = start;
-#ifdef CONFIG_286_PMODE
-        if (end - start >= 0x10000) panic("seg_add TOO LARGE\n"); // DEBUG REMOVE
-#endif
         seg->size = end - start;
         seg->flags = SEG_FLAG_FREE;
         seg->ref_count = 0;

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -21,7 +21,7 @@
  * of the segment register value stored there in real mode.
  * Real mode just uses single 'base' member as segment address.
  */
-#define BASE(seg)   ((seg)->para)   /* use base paragraph address in protected mode */
+#define BASE(seg)   ((seg)->addr)   /* use base paragraph address in protected mode */
 
 static byte_t seg_pm_access(word_t type)
 {
@@ -35,7 +35,7 @@ static byte_t seg_pm_access(word_t type)
 /* allocate selector for passed segment_s structure, 0 = GDT full or limit exceeded */
 static int seg_pm_attach(segment_s *seg, word_t type)
 {
-    seg->base = desc_alloc(PARA_BYTES(seg->para), PARA_BYTES(seg->size),
+    seg->base = desc_alloc(PARA_BYTES(seg->addr), PARA_BYTES(seg->size),
         seg_pm_access(type));
     return seg->base;
 }
@@ -185,6 +185,11 @@ segment_s * seg_alloc (segext_t size, word_t type)
     segment_s * seg = 0;
 
     seg = seg_free_get (size, type);
+#ifdef CONFIG_286_PMODE
+    if (!seg) printk("MEM FAIL %02x paras\n", size);    // DEBUG REMOVE
+    if (seg && (seg->addr & 0xFFFF0000)) printk("seg_alloc: xms %08lx size %uK\n",
+        seg->addr << 4, (size + 63) >> 6);
+#endif
     if (seg && (type & SEG_FLAG_ALIGN1K))
         BASE(seg) += ((~BASE(seg) + 1) & ((1024 >> 4) - 1));
     if (seg && !seg_pm_attach(seg, type)) {
@@ -463,11 +468,14 @@ int seg_verify_area(pid_t pid, seg_t base, segoff_t offset)
     return 0;
 }
 
-void INITPROC seg_add(seg_t start, seg_t end)
+void INITPROC seg_add(addr_t start, addr_t end)
 {
     segment_s * seg = (segment_s *) heap_alloc (sizeof (segment_s), HEAP_TAG_SEG);
     if(seg) {
         BASE(seg) = start;
+#ifdef CONFIG_286_PMODE
+        if (end - start >= 0x10000) panic("seg_add TOO LARGE\n"); // DEBUG REMOVE
+#endif
         seg->size = end - start;
         seg->flags = SEG_FLAG_FREE;
         seg->ref_count = 0;

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -183,11 +183,6 @@ segment_s * seg_alloc (segext_t size, word_t type)
     segment_s * seg = 0;
 
     seg = seg_free_get (size, type);
-#ifdef CONFIG_286_PMODE
-    if (!seg) printk("MEM FAIL %04x paras\n", size);    // DEBUG REMOVE
-    if (seg && (seg->addr & 0xFFFF0000)) printk("seg_alloc: xms %08lx size %uK\n",
-        seg->addr << 4, (size + 63) >> 6);
-#endif
     if (seg && (type & SEG_FLAG_ALIGN1K))
         BASE(seg) += ((~BASE(seg) + 1) & ((1024 >> 4) - 1));
     if (seg && !seg_pm_attach(seg, type)) {

--- a/elks/arch/i86/mm/pmode.c
+++ b/elks/arch/i86/mm/pmode.c
@@ -66,7 +66,7 @@ void desc_chaccess(sel_t sel, byte_t access)
  * of the real mode segment in segment_s.base.  The far-memory primitives then load
  * that selector into a segment register and the CPU resolves it via the GDT.
  */
-sel_t desc_alloc(addr_t base, addr_t limit, byte_t access)
+sel_t desc_alloc(addr_t base, seloff_t limit, byte_t access)
 {
     int i, scanned;
     sel_t sel = 0;
@@ -101,7 +101,7 @@ addr_t desc_base(sel_t sel)
 }
 
 /* return selector limit (< 64K). FIXME: will need 16M limit for 386 PM/fmemalloc */
-addr_t desc_limit(sel_t sel)
+seloff_t desc_limit(sel_t sel)
 {
     return gdt[SEL_INDEX(sel)].limit_lo;
 }

--- a/elks/include/arch/seg286.h
+++ b/elks/include/arch/seg286.h
@@ -93,10 +93,10 @@ void enable_protected_mode(struct dtr *gdtr, struct dtr *idtr);
 /* allocate a descriptor for [base, base+paras*16) with `access`; returns a
  * selector (0 on table-full). seg_alloc() calls this after reserving physram.
  */
-sel_t  desc_alloc(addr_t base, addr_t limit, byte_t access);
+sel_t  desc_alloc(addr_t base, seloff_t limit, byte_t access);
 
 /* rewrite / free an existing selector's descriptor */
-sel_t  desc_set(sel_t sel, addr_t base, addr_t limit, byte_t access);
+sel_t  desc_set(sel_t sel, addr_t base, seloff_t limit, byte_t access);
 void   desc_chaccess(sel_t sel, byte_t access);
 void   desc_free(sel_t sel);
 
@@ -104,7 +104,7 @@ void   desc_free(sel_t sel);
 addr_t desc_base(sel_t sel);
 
 /* max valid byte offset in a selector's segment (its descriptor limit) */
-addr_t desc_limit(sel_t sel);
+seloff_t desc_limit(sel_t sel);
 
 /* install an interrupt gate (used by the IRQ/syscall path). */
 void idt_gate_set(unsigned int vect, unsigned int proc, sel_t selector, byte_t access);

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -6,10 +6,6 @@
  */
 #include <linuxmt/config.h>
 
-/* paragraph (16-byte) helpers shared with the real-mode arena allocator */
-#define PARA_BYTES(paras)   ((addr_t)(paras) << 4)
-#define BYTES_PARA(bytes)   (((bytes) + 15) >> 4)
-
 /* fixed GDT indices (kernel-private selectors) */
 #define GDT_NULL        0   /* required null descriptor          */
 #define GDT_KCODE       1   /* kernel CS  (near .text)           */

--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -20,11 +20,13 @@ typedef __u32                   long_t;
 
 typedef __u16                   seg_t;      /* segment value */
 typedef __u16                   sel_t;      /* selector value */
-typedef __u16                   segext_t;   /* paragraph count */
-typedef __u16                   segoff_t;   /* offset in segment */
-typedef __u16                   flag_t;     /* CPU flag word */
-
+typedef __u16                   segext_t;   /* RM segment paragraph count */
+typedef __u32                   selext_t;   /* PM selector paragraph count */
+typedef __u16                   segoff_t;   /* RM segment byte offset */
+typedef __u32                   seloff_t;   /* PM selector byte offset */
 typedef __u32                   addr_t;     /* linear 32-bit address */
+
+typedef __u16                   flag_t;     /* CPU flag word */
 
 /* Then we define registers, etc... */
 

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -30,7 +30,7 @@ extern void INITPROC inode_init(void);
 extern void INITPROC irq_init(void);
 extern void save_timer_irq(void);
 extern void INITPROC mm_init(seg_t,seg_t);
-extern void INITPROC seg_add(seg_t start, seg_t end);
+extern void INITPROC seg_add(addr_t start, addr_t end);
 extern void INITPROC sched_init(void);
 extern void INITPROC serial_init(void);
 extern void INITPROC rs_setbaud(dev_t dev, unsigned long baud);

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -30,7 +30,6 @@ extern void INITPROC inode_init(void);
 extern void INITPROC irq_init(void);
 extern void save_timer_irq(void);
 extern void INITPROC mm_init(seg_t,seg_t);
-extern void INITPROC seg_add(addr_t start, addr_t end);
 extern void INITPROC sched_init(void);
 extern void INITPROC serial_init(void);
 extern void INITPROC rs_setbaud(dev_t dev, unsigned long baud);

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -1,21 +1,29 @@
 #ifndef __LINUXMT_MM_H
 #define __LINUXMT_MM_H
 
+#include <linuxmt/config.h>
 #include <linuxmt/types.h>
 #include <linuxmt/list.h>
-#include <linuxmt/config.h>
+#include <linuxmt/init.h>
 
-/* main memory management */
+/* use 32-bit SELEXT_T for PM paragraph address >= 1M, keep small for real mode */
+#ifdef CONFIG_286_PMODE
+#define SELEXT_T    selext_t    /* PM 32-bit paragraph address or count */
+#else
+#define SELEXT_T    segext_t    /* RM 16-bit paragraph address or count */
+#endif
+
+/* main memory management, also used with XMS memory in PM */
 struct segment {
 	list_s    all;
 	list_s    free;
 	seg_t     base;             /* segment or selector used to access memory */
-	segext_t  size;             /* size in paragraphs */
 	byte_t    flags;
 	byte_t    ref_count;
 	word_t    pid;
+	SELEXT_T  size;             /* 16- or 32-bit size in paragraphs */
 #ifdef CONFIG_286_PMODE
-	addr_t    addr;             /* paragraph address of memory (=base in real mode) */
+	selext_t  addr;             /* paragraph address of memory (=base in real mode) */
 #endif
 };
 
@@ -61,6 +69,7 @@ int fs_memcmp(const void *,const void *,size_t);
 
 /* Memory allocation */
 
+void INITPROC seg_add(SELEXT_T start, SELEXT_T end);
 segment_s * seg_alloc_fixed (seg_t, segext_t, word_t);
 segment_s * seg_alloc (segext_t, word_t);
 void seg_free (segment_s *);

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -15,7 +15,7 @@ struct segment {
 	byte_t    ref_count;
 	word_t    pid;
 #ifdef CONFIG_286_PMODE
-	seg_t     para;             /* paragraph address of memory (=base in real mode) */
+	addr_t    addr;             /* paragraph address of memory (=base in real mode) */
 #endif
 };
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -282,18 +282,13 @@ static void INITPROC kernel_init(void)
     init_seg = desc_base(init_seg) >> 4;    /* convert selector to physical segment */
 
     /* calculate remaining xms start and end in paragraphs */
-    addr_t xms_start = (XMS_START_ADDR >> 4) + (xms_alloc_ptr << 6);
-    addr_t xms_end   = (XMS_START_ADDR >> 4) + ((addr_t)SETUP_XMS_KBYTES << 6);
+    selext_t xms_start = (XMS_START_ADDR >> 4) + (xms_alloc_ptr << 6);
+    selext_t xms_end   = (XMS_START_ADDR >> 4) + ((addr_t)SETUP_XMS_KBYTES << 6);
+    seg_add(xms_start, xms_end);            /* add remaining XMS memory paragraphs */
 
     // DEBUG REMOVE
     printk("mem: xms start %08lx end %08lx total %dK\n",
         xms_start << 4, xms_end << 4, (xms_end - xms_start) >> 6);
-    if (xms_end - xms_start >= 0x00010000)  // FIXME TEMP MAX FFF0 paragraphs max
-        xms_end = xms_start +  0x0000FFF0;
-    printk("mem2 xms start %08lx end %08lx total %dK (truncated)\n",
-        xms_start << 4, xms_end << 4, (xms_end - xms_start) >> 6);
-
-    seg_add(xms_start, xms_end);            /* add remaining XMS memory paragraphs */
 #endif
 
     seg_t s = init_seg + (((word_t)(void *)__start_fartext_init + 15) >> 4);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -225,8 +225,11 @@ static void INITPROC early_kernel_init(void)
     heap_init();                    /* init near memory allocator */
     heapofs = setup_arch();          /* sets membase and memend globals */
     heap_add((void *)heapofs, heapsize);
+#ifdef CONFIG_286_PMODE
+    /* force 256K base system ram to force immediate usage of XMS allocations */
+    memend = 256 << 6;      // DEBUG REMOVE
+#endif
     mm_init(membase, memend);       /* init far/main memory allocator */
-
 #ifdef CONFIG_BOOTOPTS
     struct umbseg *p;
     /* now able to add umb memory segments */
@@ -274,9 +277,25 @@ static void INITPROC kernel_init(void)
 #ifdef CONFIG_FARTEXT_KERNEL
     /* add .farinit.init section to main memory free list */
     seg_t     init_seg = _FP_SEG(__start_fartext_init);
+
 #ifdef CONFIG_286_PMODE
     init_seg = desc_base(init_seg) >> 4;    /* convert selector to physical segment */
+
+    /* calculate remaining xms start and end in paragraphs */
+    addr_t xms_start = (XMS_START_ADDR >> 4) + (xms_alloc_ptr << 6);
+    addr_t xms_end   = (XMS_START_ADDR >> 4) + ((addr_t)SETUP_XMS_KBYTES << 6);
+
+    // DEBUG REMOVE
+    printk("mem: xms start %08lx end %08lx total %dK\n",
+        xms_start << 4, xms_end << 4, (xms_end - xms_start) >> 6);
+    if (xms_end - xms_start >= 0x00010000)  // FIXME TEMP MAX FFF0 paragraphs max
+        xms_end = xms_start +  0x0000FFF0;
+    printk("mem2 xms start %08lx end %08lx total %dK (truncated)\n",
+        xms_start << 4, xms_end << 4, (xms_end - xms_start) >> 6);
+
+    seg_add(xms_start, xms_end);            /* add remaining XMS memory paragraphs */
 #endif
+
     seg_t s = init_seg + (((word_t)(void *)__start_fartext_init + 15) >> 4);
     seg_t e = init_seg + (((word_t)(void *)  __end_fartext_init + 15) >> 4);
     debug("init: seg %04x to %04x size %04x (%d)\n", s, e, (e - s) << 4, (e - s) << 4);
@@ -291,8 +310,8 @@ static void INITPROC kernel_init(void)
 static void INITPROC kernel_banner(seg_t init, seg_t extra)
 {
     kernel_banner_arch();
-    printk("syscaps %x, %uK base ram, %d tasks, %d files, %d inodes\n",
-        sys_caps, SETUP_MEM_KBYTES, max_tasks, nr_file, nr_inode);
+    printk("syscaps %x, %uK ram, %d tasks, %d files, %d inodes\n",
+        sys_caps, memend >> 6, max_tasks, nr_file, nr_inode);
     printk("ELKS %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -285,8 +285,6 @@ static void INITPROC kernel_init(void)
     selext_t xms_start = (XMS_START_ADDR >> 4) + (xms_alloc_ptr << 6);
     selext_t xms_end   = (XMS_START_ADDR >> 4) + ((addr_t)SETUP_XMS_KBYTES << 6);
     seg_add(xms_start, xms_end);            /* add remaining XMS memory paragraphs */
-
-    // DEBUG REMOVE
     printk("mem: xms start %08lx end %08lx total %dK\n",
         xms_start << 4, xms_end << 4, (xms_end - xms_start) >> 6);
 #endif

--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -153,13 +153,13 @@ int sys_signal(int signr, __kern_sighandler_t handler)
             s = current->mm[i];
             if (!s || (s->flags & SEG_FLAG_TYPE) != SEG_FLAG_CSEG)
                 continue;
-            debug("codeseg %04x (%x paras)\n", s->base, s->size);
+            debug("codeseg %04x (%x paras)\n", s->base, (segext_t)s->size);
             if (seg < s->base)
                 continue;
             seg_paras = seg - s->base;
-            if (seg_paras >= s->size)
+            if (seg_paras >= (segext_t)s->size)
                 continue;
-            if (off_paras < s->size - seg_paras) {
+            if (off_paras < (segext_t)s->size - seg_paras) {
                 current->sig.handler = handler;
                 current->sig.action[signr - 1].sa_dispose = SIGDISP_CUSTOM;
                 return 0;


### PR DESCRIPTION
ELKS is now no longer limited to running user programs in the lower 640K of memory!

Using the (experimental) protected mode kernel and running on a 286 or 386+ CPU, XMS memory above 1M is now usable for the code and data segments of user programs, where previously the system would run out of memory.

This PR implements a first-pass at adding XMS memory to the internal main memory manager, allowing the kernel to allocate from main or XMS memory for user program execution. XMS memory is still used for buffer allocations, and the amount remaining will be usable for program execution.

~~In this PR, only 1M of XMS memory is accessible for program execution, due to technical issues storing memory segment sizes larger than 1M (the size is stored in paragraphs in a 16-bit word and would overflow). An update allowing use of all XMS memory will come after more design considerations.~~ All of XMS memory is now available for   user program execution.

User program binaries compiled with either ia16-elf-gcc or OpenWatcom should work unmodified, provided that the program doesn't attempt to perform segment arithmetic internally. Most small and medium model programs will all run, while large model programs using normal \_\_far pointers should also work, unless special code is written to attempt to access segment offsets > 64K or use `fmemalloc` to allocate > 64K. The ELKS PM kernel allocates a single selector for each real mode segment in most cases, and an paragraph count cannot be directly added to a selector, unlike in real mode where it is permitted by the CPU. Up to 64K of offset can be used with any selector, just like real mode segments.

For ease of testing, this first commit contains code making the kernel think the size of main memory is only 256K, which forces XMS allocation soon after login. Then, most user programs will be running in XMS, also allowing deeper testing of the memory manager, which was updated to handle 24-bits of memory (=15MB XMS).

Some cleanup was done in a couple drivers changing segext_t types to segoff_t, for correctness. The first commit also contains lots of debug code that will be removed.