### PR TITLE
[kernel,libc] Cleanup fmemalloc, add warning for allocations > 64K in PM

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -176,7 +176,7 @@ segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
 
 #endif
 
-// Allocate segment, limited to 64K in PM for now
+// Allocate segment
 
 segment_s * seg_alloc (segext_t size, word_t type)
 {
@@ -386,7 +386,8 @@ int sys_sbrk(int increment, segoff_t *pbrk)
 }
 
 // allocate memory for process, return segment
-int sys_fmemalloc(int paras, unsigned short *pseg)
+// size > 64K require PM-incompatible segment arithmetic or 32-bit instruction prefix
+int sys_fmemalloc(unsigned int paras, unsigned short *pseg)
 {
     segment_s *seg;
     int err;
@@ -396,7 +397,11 @@ int sys_fmemalloc(int paras, unsigned short *pseg)
         return err;
     if (paras == 0)
         return -EINVAL;
-    seg = seg_alloc((segext_t)paras, SEG_FLAG_FDAT);
+#ifdef CONFIG_286_PMODE
+    if (paras > 0x1000)
+        printk("fmemalloc: warning size %uK > 64K\n", paras >> 6);
+#endif
+    seg = seg_alloc(paras, SEG_FLAG_FDAT);
     if (!seg) {
         debug_brk("(%P)FMEMALLOC %ld FAIL\n", (unsigned long)paras << 4);
         return -ENOMEM;

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -29,8 +29,8 @@ extern unsigned int malloc_arena_thresh;        /* mem.c wrapper function */
 void __far *fmemalloc(unsigned long size);
 int         fmemfree(void __far *ptr);
 
-int        _fmemalloc(int paras, unsigned short *pseg); /* syscall */
-int        _fmemfree(unsigned short seg);               /* syscall */
+int        _fmemalloc(unsigned int paras, unsigned short *pseg); /* syscall */
+int        _fmemfree(unsigned short seg);                        /* syscall */
 #endif
 
 /* usable with all mallocs */

--- a/libc/malloc/fmemalloc.c
+++ b/libc/malloc/fmemalloc.c
@@ -20,16 +20,24 @@ static unsigned long maxsize;
 #define MK_FP(seg,off)   ((void __far *)((((unsigned long)(seg)) << 16) | \
                                            ((unsigned int)(off))))
 
+/*
+ * Allocate up to 1M-16 bytes from main or XMS memory.
+ * Requesting > 64K requires PM-incompatible segment arithmetic or 32-bit app code.
+ */
 void __far *fmemalloc(unsigned long size)
 {
     unsigned short seg;
-    unsigned int paras = (unsigned int)((size + 15) >> 4);
 
+    size = (size + 15) >> 4;
+    if (size & 0xFFFF0000) {    /* > (1M - 16) paragraphs */
+        errno = EINVAL;
+        return -1;
+    }
 #if DEBUG == 1
     sysctl(CTL_GET, "malloc.debug", &debug_level);
 #endif
     debug("(%d)FMEMALLOC(%5lu) ", getpid(), size);
-    if (_fmemalloc(paras, &seg)) {
+    if (_fmemalloc((unsigned int)size, &seg)) {
         debug("= FAIL\n");
         return 0;
     }

--- a/libc/watcom/syscall/fmemalloc.c
+++ b/libc/watcom/syscall/fmemalloc.c
@@ -7,7 +7,7 @@
 #include <malloc.h>
 #include "watcom/syselks.h"
 
-int _fmemalloc( int __paras, unsigned short *__pseg )
+int _fmemalloc( unsigned int __paras, unsigned short *__pseg )
 {
     sys_setseg(__pseg);
     syscall_res res = sys_call2( SYS_fmemalloc, __paras, (unsigned)__pseg);


### PR DESCRIPTION
This PR cleans up `fmemalloc` to allow accessing a maximum of 1M minus 16 bytes (=0xFFFF paragraphs) of memory outside the program's near data/stack address space. The PM kernel may allocate from main or XMS memory. 

Additionally, the PM kernel will now give a warning when a user program tries allocating more than 64K bytes using `fmemalloc`, since it is likely the system will get a GPF (general protection fault) if using segment arithmetic on the returned selector. Seeing the warning will help explain the GPF.

User programs calling `fmemalloc` should allocate a maximum of 64K to remain compatible for access from 16-bit code with the ELKS real mode or PM kernel. 

When `fmemalloc` is used for allocations > 64K and < 1M in real mode, segment arithmetic can be used to access the contiguous memory from the single segment (far pointer with offset 0) returned. In PM, a selector is returned with the associated size limit set for it, but segment arithmetic cannot be performed on a selector, so applications would need to use 32-bit addressing instructions (and a 386+ CPU) in order to access the byte array.