### PR TITLE
elf2elks: Windows share compatibility

### DIFF
--- a/elks/tools/elf2elks/elf2elks.c
+++ b/elks/tools/elf2elks/elf2elks.c
@@ -1024,6 +1024,19 @@ main(int argc, char **argv)
   output_scns_stuff ();
   output_relocs ();
   output_symtab ();
+  /*
+   * Release the input file before end_output() renames the temp over it.
+   * elf2elks converts in place (input file == output file), and libelf reads
+   * sections lazily, so the input stays open (and may be mmap'd) all through
+   * output generation.  On Linux renaming over an open file is fine, but on a
+   * Windows-backed share (VirtualBox vboxsf, WSL drvfs) the open handle makes
+   * rename() fail with EPERM.  elf_end() drops libelf's hold (unmaps if mmap'd);
+   * close() drops the fd.  Guard the globals so error_exit() stays idempotent.
+   */
+  elf_end (elf);
+  elf = NULL;
+  close (ifd);
+  ifd = -1;
   end_output ();
   return 0;
 }


### PR DESCRIPTION
I'm trying to streamline my testing workflow and the problem is that I have the repo clone in Windows (for GUI branch management and also AI agent lives here) while the build happens in Alpine VM. I would like to avoid copying files around every time, because it gets messy fast. My Windows dir is mounted to Alpine via vboxsf.

The default build process renames one file while it's open for editing. It would be a real usability improvement for me if the file descriptor was closed at that time.

Sorry about another edge case PR. 

AI text below:

elf2elks converts an ELF to an ELKS a.out in place (input file == output file): input_for_header() opens the input O_RDONLY and hands the fd to libelf, which reads sections lazily throughout output generation, so the input stays open (and possibly mmap'd) until the very end. end_output() then writes a temp and rename()s it over the input file.

On Linux/ext4 replacing an open file is fine, but on a Windows-backed share (VirtualBox vboxsf, WSL drvfs, CIFS) the open handle makes rename() fail with EPERM -- and end_output() only retries on EEXIST, so the build dies with "cannot rename ... to system". This blocks building ELKS in a shared-folder / mounted-clone workflow.

Release the input (elf_end + close) after the last input read and before end_output(), guarding the globals so error_exit() stays idempotent. No behavioural change on Linux.