### PR TITLE
ash/mkinit: use rename() instead of link()+unlink() to install init.c

### DIFF
--- a/elkscmd/ash/mkinit.c
+++ b/elkscmd/ash/mkinit.c
@@ -182,9 +182,7 @@ int main(int argc, char **argv)
 		readfile(*ap);
 	output();
 	if (file_changed()) {
-		unlink(OUTFILE);
-		link(OUTTEMP, OUTFILE);
-		unlink(OUTTEMP);
+		rename(OUTTEMP, OUTFILE);
 	} else {
 		unlink(OUTTEMP);
 		if (touch(OUTOBJ))


### PR DESCRIPTION
This is a follow up to my previous build PR. Regret my AI agent likes to cut corners all the time and never ran the proper build before now.
This PR fixes build the second (and last) `make all` error on non-POSIX file systems, such as vboxsf.
Unless we want to support pre-1989 systems, change to `rename()` is what it seems to be the modern approach to atomic file rename/replace.

*AI text below*

mkinit generates init.c into a temp (init.c.new) and, when the content changed, installs it with the classic pre-rename() atomic-move idiom:

    unlink(OUTFILE); link(OUTTEMP, OUTFILE); unlink(OUTTEMP);

The link() is a hardlink, and its return value is unchecked. On any filesystem without hardlink support this silently fails, then unlink() removes the temp, leaving init.c nonexistent -- the ash build then dies with "init.c: No such file or directory". This happens on VirtualBox shared folders (vboxsf), WSL drvfs, and some FUSE/CIFS mounts, which makes ELKS unbuildable from a source tree on such a mount.

rename() performs the same atomic move, preserves the change-detection / skip-recompile behaviour, is behaviourally identical on Linux, and works on filesystems that lack hardlinks. link()+unlink() dates from before rename() (4.2BSD, 1983) was widely portable; that constraint is long gone.

Same portability class as the elf2elks fd-close fix (PR #2765).