### PR TITLE
[owlibc] Add precision timer library to ELKS OpenWatcom C library

### DIFF
--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -128,4 +128,16 @@
 
 #endif /* __ia16__ */
 
+#ifdef __WATCOMC__
+
+unsigned char inb(int port);
+#pragma aux inb parm[dx] =              \
+    "in al,dx";
+
+void outb(unsigned int value, int port);
+#pragma aux outb parm [ax] [dx] =         \
+    "out dx,al";
+
+#endif
+
 #endif /* !__ARCH_8086_IO_H*/

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -139,4 +139,27 @@ void do_bottom_half(void);
             :"memory")
 #endif
 
+#ifdef __WATCOMC__
+int clr_irq(void);
+#pragma aux clr_irq =           \
+    "cli";
+
+int set_irq(void);
+#pragma aux set_irq =           \
+    "sti";
+
+#define save_flags(x)           save_flags_addr(&x)
+int save_flags_addr(void *addr);
+#pragma aux save_flags_addr parm[bx] =  \
+    "pushf",                            \
+    "pop ax",                           \
+    "mov ax,[bx]";
+
+int restore_flags(unsigned int flags);
+#pragma aux restore_flags parm[ax] =    \
+    "push ax",                          \
+    "popf";
+
+#endif
+
 #endif

--- a/libc/debug/Makefile
+++ b/libc/debug/Makefile
@@ -5,7 +5,10 @@ LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
-OBJS = \
+OBJS = prectimer.o
+
+ifeq "$(COMPILER)" "ia16"
+OBJS += \
 	instrument.o \
 	readprologue.o \
 	syms.o \
@@ -15,6 +18,7 @@ OBJS = \
 	# end of list
 
 #OBJS += rdtsc.o
+endif
 
 all: $(LIB)
 

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -9,6 +9,7 @@ endif
 #endif
 
 INCLUDES = -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
+INCLUDES += -I$(TOPDIR)/include
 # Watcom headers now included in libc/include/watcom
 INCLUDES += -I$(TOPDIR)/libc/include/watcom
 # Don't pull in headers from Watcom installation

--- a/libc/watcom.mk
+++ b/libc/watcom.mk
@@ -4,7 +4,6 @@ include watcom.inc
 
 #NOTBUILT = \
 	asm	    \
-	debug	\
 	gcc	    \
 	math	\
 	crt0.S	\
@@ -12,6 +11,7 @@ include watcom.inc
 SUBDIRS =	\
 	watcom	\
 	ctype	\
+	debug	\
 	error	\
 	getent	\
 	malloc	\


### PR DESCRIPTION
Adds `init_ptime` and `get_ptime` into ELKS' C library for OpenWatcom.

Requested by @toncho11 in #2764.

@toncho11: this is untested, but I have reviewed the ASM output from the compiled prectimer.c and it looks good, as far as having had to add the ASM rmacros/routines that weren't previously present to allow this to be compiled. Recompile the entire C library with OWC and hopefully you should be good to go.