### PR TITLE
[cmds] Some fixups and cleanup for dmesg

### DIFF
--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -1,19 +1,12 @@
 #ifndef __LINUXMT_KERNEL_H
 #define __LINUXMT_KERNEL_H
 
-#include <linuxmt/types.h>
-#include <arch/cdefs.h>
-
-/*
- * 'kernel.h' contains some often-used function prototypes etc
- */
-
-#define INT_MAX		((int)(~0U>>1))
-#define UINT_MAX	(~0U)
-#define LONG_MAX	((long)(~0UL>>1))
-#define ULONG_MAX	(~0UL)
-
-#define structof(p,t,m) ((t *) ((char *) (p) - offsetof (t,m)))
+struct dmesg_queue {
+    unsigned int     len;       /* # chars in queue */
+    unsigned int     size;      /* queue size */
+    unsigned int     head;
+    unsigned char   base[];     /* queue data follows */
+};
 
 /* ordered arch_cpu values, used for feature selection */
 #define CPU_8088        0
@@ -25,20 +18,25 @@
 #define CPU_80286       6       /* first PC/AT */
 #define CPU_80386       7       /* 80386 or later, other CPUs not tested for */
 
+#ifdef __KERNEL__
+
+#include <linuxmt/types.h>
+#include <arch/cdefs.h>
+
+#define INT_MAX		((int)(~0U>>1))
+#define UINT_MAX	(~0U)
+#define LONG_MAX	((long)(~0UL>>1))
+#define ULONG_MAX	(~0UL)
+
+#define structof(p,t,m) ((t *) ((char *) (p) - offsetof (t,m)))
+
 extern unsigned char arch_cpu;
 extern char running_qemu;
 extern dev_t dev_console;
 extern int debug_level;
 
-extern seg_t dmesg_seg;     /* segment or selector of dmesg circular queue */
+extern seg_t dmesg_seg;         /* segment or selector of dmesg circular queue */
 
-struct dmesg_queue {
-    unsigned int     len;    /* # chars in queue */
-    unsigned int     size;   /* queue size */
-    unsigned int     head;
-    unsigned int     tail;
-    unsigned char   base[]; /* queue data follows */
-};
 extern seg_t kernel_cs, kernel_ds, kernel_ftext;
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
 extern short endistack[], istack[];
@@ -54,7 +52,6 @@ extern void panic(const char *, ...) noreturn;
 extern void printk(const char *, ...);
 extern void kputchar(int);
 extern void early_putchar(int);
-
 
 extern int wait_for_keypress(void);
 extern int in_group_p(gid_t);
@@ -72,5 +69,7 @@ extern int sys_execve(const char *,char *,size_t);
  */
 
 #define suser() (current->euid == 0)
+
+#endif /* __KERNEL__ */
 
 #endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -813,6 +813,9 @@ void INITPROC dmesg_init(void)
         if (dmesg > 63) dmesg = 63;
         dmesg_seg = memend - (dmesg << 6);
         memend -= (dmesg << 6);
+#ifdef CONFIG_286_PMODE
+        dmesg_seg = desc_alloc((addr_t)dmesg_seg << 4, (addr_t)dmesg << 10, DESC_KDATA);
+#endif
 
         q = _MK_FP(dmesg_seg, 0); 
         q->size = (dmesg << 10) - 3 * sizeof(int);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -53,8 +53,8 @@ int nr_ext_bufs, nr_xms_bufs, nr_map_bufs;
 int xms_bootopts;
 int ata_mode = -1;              /* =AUTO default set ATA CF driver mode automatically */
 char running_qemu;
-int dmesg;                  /* dmesg buffer size in K from /bootopts */
-seg_t dmesg_seg;            /* segment of dmesg circular queue */
+seg_t dmesg_seg;                /* segment of dmesg circular queue */
+static int dmesg;               /* dmesg buffer size in K from /bootopts */
 static int boot_console;
 static segext_t umbtotal;
 static kdev_t disabled[4];      /* disabled devices using disable= */
@@ -100,7 +100,7 @@ static void FARPROC far_start_kernel(void);
 static void INITPROC early_kernel_init(void);
 static void INITPROC kernel_init(void);
 static void INITPROC kernel_banner(seg_t init, seg_t extra);
-static void INITPROC dmesg_init();
+static void INITPROC dmesg_init(void);
 static void init_task(void);
 static void idle_loop(void);
 
@@ -808,7 +808,6 @@ static char * INITPROC option(char *s)
 void INITPROC dmesg_init(void)
 {
     struct dmesg_queue __far *q;
-    seg_t para;
 
     if (dmesg) {
         if (dmesg > 63) dmesg = 63;
@@ -816,7 +815,7 @@ void INITPROC dmesg_init(void)
         memend -= (dmesg << 6);
 
         q = _MK_FP(dmesg_seg, 0); 
-        q->size = (dmesg << 10) - 4 * sizeof(int);
-        q->len = q->head = q->tail = 0;
+        q->size = (dmesg << 10) - 3 * sizeof(int);
+        q->len = q->head = 0;
     }   
 }      

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -58,7 +58,7 @@ dev_t dev_console;
 #define DEVCONSOLE  MKDEV(TTY_MAJOR,TTY_MINOR_OFFSET)   /* /dev/tty1*/
 #endif
 static void (*kputc)(dev_t, int) = 0;
-void dmesg_addch(int c);
+static void dmesg_addch(int c);
 
 void set_console(dev_t dev)
 {
@@ -369,8 +369,9 @@ void dprintk(const char *fmt, ...)
     vprintk(fmt, p);
     va_end(p);
 }
+#endif
 
-void dmesg_addch(int c)
+static void dmesg_addch(int c)
 {
     struct dmesg_queue __far *q = _MK_FP(dmesg_seg, 0);
 
@@ -382,5 +383,3 @@ void dmesg_addch(int c)
         q->len++;
     set_irq();
 }
-
-#endif

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -104,8 +104,8 @@ sys_utils/console               :sysutil                :1200k
 sys_utils/beep                  :sysutil                :1200k
 sys_utils/decomp                :sysutil         :360c              :1440k
 sys_utils/sysctl                :sysutil                :1200k
-sys_utils/dmesg                 :sysutil 
-screen/screen                   :screen                 :1200k
+sys_utils/dmesg                 :sysutil                            :1440k
+screen/screen                   :screen                             :1440c
 cron/cron                       :cron                   :1200k
 cron/crontab                    :cron                   :1200k
 sh_utils/basename               :be-shutil               :1200c

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -10,6 +10,7 @@
 #le0=9,0x340,,0x80
 #comirq=,,7,10
 #umb=0xC000:0x800,0xD000:0x1000
+dmesg=1
 hma=kernel
 #xms=off
 #xms=on
@@ -41,4 +42,3 @@ hma=kernel
 #console=ttyS0,19200 3
 #MOUSE_PORT=/dev/ttyS1
 #DEBUG_PORT=none
-dmesg=2

--- a/elkscmd/sys_utils/dmesg.c
+++ b/elkscmd/sys_utils/dmesg.c
@@ -1,69 +1,74 @@
-#define __KERNEL__
-#include <linuxmt/ntty.h>       /* for struct tty */
-#undef __KERNEL__
-
-#include <linuxmt/mm.h>
-#include <linuxmt/mem.h>
-#include <linuxmt/memory.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <linuxmt/mem.h>
+#include <linuxmt/kernel.h>
+#include <linuxmt/segment.h>
 
-struct dmesg_queue {
-    unsigned int     len;
-    unsigned int     size;
-    unsigned int     head;
-    unsigned int     tail;
-    unsigned char    base[1];
-};
-
+#define MIN(a,b)    ((a) < (b)? (a): (b))
 #define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
 
-static int memread(int fd, word_t off, seg_t seg, void *buf, int size)
+static unsigned char buf[2048];
+
+static int memread(int fd, unsigned int off, unsigned int seg, void *buf, int size)
 {
     if (lseek(fd, _MK_LP(seg, off), SEEK_SET) == (off_t)-1)
         return -1;
     return read(fd, buf, size);
 }
 
-static void ring_read(int fd, seg_t seg, struct dmesg_queue *q)
+static void ring_display(int fd, unsigned int seg, unsigned int start, unsigned int count)
+{
+    unsigned int n;
+
+    while (count) {
+        n = MIN(count, sizeof(buf));
+        n = memread(fd, sizeof(struct dmesg_queue) + start, seg, buf, n);
+        if (n <= 0)
+            break;
+       write(STDOUT_FILENO, buf, n);
+       start += n;
+       count -= n;
+    }
+}
+
+static void ring_read(int fd, unsigned int seg, struct dmesg_queue *q)
 {
     unsigned int avail, first, tail;
-    unsigned char buf[2048];
-    int r;
+
+    if (!q->len)
+        return;
 
     avail = q->len;
     if (avail > q->size)
         avail = q->size;
 
-    tail = (q->head - avail) % q->size;
+    tail = (avail == q->size)? q->head: 0;
 
     /* first part: tail to end of ring */
     first = q->size - tail;
     if (first > avail)
         first = avail;
 
-    r = memread(fd, (sizeof(*q) - 1) + tail, seg, buf, first);
-    if (r > 0)
-        write(STDOUT_FILENO, buf, r);
+    //printf("FIRST %d, len %d\n", tail, first);
+    ring_display(fd, seg, tail, first);
 
     /* second part: wrap around from start of ring */
     if (avail > first) {
-        r = memread(fd, sizeof(*q) - 1, seg, buf, avail - first);
-        if (r > 0)
-            write(STDOUT_FILENO, buf, r);
+        //printf("LAST %d, len %d\n", 0, avail-first);
+        ring_display(fd, seg, 0, avail - first);
     }
 }
 
 int main(void)
 {
     int fd;
-    seg_t seg;
+    unsigned int seg;
     struct dmesg_queue q;
 
     if ((fd = open("/dev/kmem", O_RDONLY|O_ALT)) < 0) {
-        errmsg("no dev/kmem\n");
+        errmsg("no /dev/kmem\n");
         return 1;
     }
 
@@ -73,14 +78,14 @@ int main(void)
         return 0;
     }
 
-    if (memread(fd, 0, seg, &q, sizeof(q) - 1) != sizeof(q) - 1) {
-        errmsg("dmesg: cannot read header\n");
+    if (memread(fd, 0, seg, &q, sizeof(q)) != sizeof(q)) {
+        errmsg("dmesg: cannot read queue\n");
         close(fd);
         return 1;
     }
 
-    if (q.len > 0)
-        ring_read(fd, seg, &q);
+    //printf("len %d, size %d, head %d\n", q.len, q.size, q.head);
+    ring_read(fd, seg, &q);
 
     close(fd);
     return 0;

--- a/elkscmd/sys_utils/dmesg.c
+++ b/elkscmd/sys_utils/dmesg.c
@@ -51,14 +51,11 @@ static void ring_read(int fd, unsigned int seg, struct dmesg_queue *q)
     if (first > avail)
         first = avail;
 
-    //printf("FIRST %d, len %d\n", tail, first);
     ring_display(fd, seg, tail, first);
 
     /* second part: wrap around from start of ring */
-    if (avail > first) {
-        //printf("LAST %d, len %d\n", 0, avail-first);
+    if (avail > first)
         ring_display(fd, seg, 0, avail - first);
-    }
 }
 
 int main(void)
@@ -84,7 +81,6 @@ int main(void)
         return 1;
     }
 
-    //printf("len %d, size %d, head %d\n", q.len, q.size, q.head);
     ring_read(fd, seg, &q);
 
     close(fd);


### PR DESCRIPTION
Followup to #2759. 

Both my suggested wrap code and the user mode dmesg display code in #2759 failed after the dmesg queue was full and wrapped. That took a while to debug and correct. This fixes that along with minor cleanups.

Adding dmesg support in the kernel resulted in 44 bytes of permanent code and 64 bytes of reusable INITPROC code. Pretty nice!!

The `screen` program was removed from the 1440k floppy image (put on compressed 1440c instead) in order to make room for the (very small) dmesg program; the image had zero space left.

