### PR TITLE
[App] Add dmesg and screen to fd1232c

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -104,8 +104,8 @@ sys_utils/console               :sysutil                :1200k
 sys_utils/beep                  :sysutil                :1200k
 sys_utils/decomp                :sysutil         :360c              :1440k
 sys_utils/sysctl                :sysutil                :1200k
-sys_utils/dmesg                 :sysutil                            :1440k
-screen/screen                   :screen                             :1440c
+sys_utils/dmesg                 :sysutil                :1232c      :1440k
+screen/screen                   :screen                 :1232c      :1440c
 cron/cron                       :cron                   :1200k
 cron/crontab                    :cron                   :1200k
 sh_utils/basename               :be-shutil               :1200c


### PR DESCRIPTION
Hello @ghaerr and @djohanse 

I have confirmed that dmesg works on PC-98.

<img width="660" height="459" alt="Screenshot_20260726_140749" src="https://github.com/user-attachments/assets/14ea4357-4e04-4202-8594-67baf3de7c26" />

I have added 1232c label to the dmesg on the application list.

Also I have been using the screen since PC-98 does not have the switching console ability.
So I put it back to 1232c image.

Thank you.