### PR TITLE
[kernel] Port XMS ramdisk driver to PM kernel

### DIFF
--- a/elks/arch/i86/drivers/block/ssd-xms.c
+++ b/elks/arch/i86/drivers/block/ssd-xms.c
@@ -25,6 +25,7 @@
 /* current implementation requires no other XMS allocations other than XMS buffers */
 static ramdesc_t     xms_ram_base;      /* ramdisk XMS memory start address */
 static unsigned  int xms_ram_size;      /* ramdisk size in Kbytes */
+static segment_s *   xms_seg;           /* saved segment_s for PM dealloc */
 
 /* initialize SSD device */
 sector_t ssddev_init(void)
@@ -43,12 +44,18 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
         debug_blk("SSD: ioctl make %d\n", arg);
         if (xms_ram_size)
             return -EBUSY;
+#ifdef CONFIG_286_PMODE
+        xms_seg = seg_alloc_xms((selext_t)arg << 6, SEG_FLAG_RAMDSK);
+        if (!xms_seg)
+            return -ENOMEM;
+        xms_ram_base = xms_seg->addr << 4;  /* NOTE: selector in seg->base not used */
+#else
         xms_ram_base = xms_alloc(arg);      /* in Kbytes */
         if (!xms_ram_base)
             return -ENOMEM;
+#endif
         xms_ram_size = arg;
         ssd_num_sects = arg << 1;
-
         /* clear XMS not supported w/INT 15 */
         if (xms_enabled != XMS_INT15) {
             for (sector_t sector = 0; sector < ssd_num_sects; sector++)
@@ -62,8 +69,13 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
         if (xms_ram_size) {
             invalidate_inodes(inode->i_rdev);
             invalidate_buffers(inode->i_rdev);
+#ifdef CONFIG_286_PMODE
+            seg_free(xms_seg);
+#else
             xms_alloc_ptr -= xms_ram_size;      /* NOTE: no xms_free yet */
+#endif
             xms_ram_size = 0;
+            ssd_num_sects = 0;
             ssd_initialized = 0;
             return 0;
         }

--- a/elks/arch/i86/drivers/block/ssd-xms.c
+++ b/elks/arch/i86/drivers/block/ssd-xms.c
@@ -56,6 +56,7 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
 #endif
         xms_ram_size = arg;
         ssd_num_sects = arg << 1;
+
         /* clear XMS not supported w/INT 15 */
         if (xms_enabled != XMS_INT15) {
             for (sector_t sector = 0; sector < ssd_num_sects; sector++)

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -133,7 +133,7 @@ static segment_s * seg_free_get (SELEXT_T size0, word_t type)
 #ifdef CONFIG_286_PMODE
             && (!(type & SEG_FLAG_XMS) || (seg->addr & 0x000F0000))
 #endif
-                                ) {
+                                                                    ) {
             best_seg  = seg;
             best_size = size1;
             incr = size00 - size0;

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -35,7 +35,18 @@ static byte_t seg_pm_access(word_t type)
 /* allocate selector for passed segment_s structure, 0 = GDT full or limit exceeded */
 static int seg_pm_attach(segment_s *seg, word_t type)
 {
-    seg->base = desc_alloc(seg->addr << 4, seg->size << 4, seg_pm_access(type));
+    selext_t limit = seg->size << 4;
+
+    /* Allow non-XMS selector limit of max 64K for now for automatic 80286 compatibility.
+     * User mode fmemalloc allocations are also limited to 64K max segments
+     * unless 32-bit instructions are used within the application.
+     */
+    if (!(type & SEG_FLAG_XMS) && (limit >> 16) > 1) {
+        printk("seg_alloc: %08lx limit > 64K\n", limit);
+        return 0;
+    }
+
+    seg->base = desc_alloc(seg->addr << 4, limit, seg_pm_access(type));
     return seg->base;
 }
 
@@ -118,7 +129,11 @@ static segment_s * seg_free_get (SELEXT_T size0, word_t type)
 
         if (type & SEG_FLAG_ALIGN1K)
             size00 = size0 + ((~BASE(seg) + 1) & ((1024 >> 4) - 1));
-        if ((seg->flags == SEG_FLAG_FREE) && (size1 >= size00) && (size1 < best_size)) {
+        if ((seg->flags == SEG_FLAG_FREE) && (size1 >= size00) && (size1 < best_size)
+#ifdef CONFIG_286_PMODE
+            && (!(type & SEG_FLAG_XMS) || (seg->addr & 0x000F0000))
+#endif
+                                ) {
             best_seg  = seg;
             best_size = size1;
             incr = size00 - size0;
@@ -177,7 +192,8 @@ segment_s * seg_alloc_fixed (seg_t base, segext_t size, word_t type)
 
 #endif
 
-// Allocate segment
+// Allocate segment (size < 1M)
+// NOTE: May allocate from main memory or XMS in PM
 
 segment_s * seg_alloc (segext_t size, word_t type)
 {
@@ -192,6 +208,25 @@ segment_s * seg_alloc (segext_t size, word_t type)
     }
     return seg;
 }
+
+#ifdef CONFIG_286_PMODE
+// Allocate any size segment (>= 1M ok) from XMS only
+// Primarily used for ramdisk support, not for general use
+// NOTE: Can't use desc_limit, no support for accessing data outside xms_fmemcpy
+
+segment_s * seg_alloc_xms (selext_t size, word_t type)
+{
+    segment_s * seg = 0;
+
+    type |= SEG_FLAG_XMS;
+    seg = seg_free_get (size, type);
+    if (seg && !seg_pm_attach(seg, type)) {
+        seg_free(seg);
+        seg = 0;
+    }
+    return seg;
+}
+#endif
 
 
 // Free segment
@@ -316,7 +351,7 @@ void mm_get_usage (struct mem_usage *mu)
     mu->main_free = ((free + 31) >> 6);
     mu->main_used = ((used + 31) >> 6);
 #ifdef CONFIG_FS_XMS
-    mu->xms_used = xms_alloc_ptr - KBYTES(XMS_START_ADDR) + xmsused;
+    mu->xms_used = xms_alloc_ptr - KBYTES(XMS_START_ADDR) + (xmsused >> 6);
     mu->xms_free = SETUP_XMS_KBYTES - mu->xms_used;
 #else
     mu->xms_free = 0;

--- a/elks/arch/i86/mm/pmode.c
+++ b/elks/arch/i86/mm/pmode.c
@@ -37,15 +37,6 @@ sel_t desc_set(sel_t sel, addr_t base, addr_t limit, byte_t access)
 {
     struct gdt_entry *d = &gdt[SEL_INDEX(sel)];
 
-    /* Allow selector limit of max 64K for now for automatic 80286 compatibility.
-     * User mode fmemalloc allocations are also limited to 64K max segments
-     * unless 32-bit instructions are used within the application.
-     */
-    if ((limit >> 16) > 1) {                /* limit size to 64K max for now */
-        printk("desc_set: %08lx limit > 64K\n", limit);
-        return 0;
-    }
-
     d->limit_lo     = (word_t)limit - 1;    /* limit is bytes-1 */
     d->base_lo      = base & 0xFFFF;
     d->base_hi      = (base >> 16) & 0xFF;
@@ -190,8 +181,7 @@ void pm_early_init(void)
     desc_set(MK_SEL(GDT_KCODE,  SEL_GDT, SEL_RPL0),
         (addr_t)kernel_cs << 4, (unsigned)_endtext, DESC_KCODE);
 
-    /* set 64K DS limit for now: we run before setup_arch() computes membase */
-    desc_set(MK_SEL(GDT_KDATA,  SEL_GDT, SEL_RPL0), data_base, 65536L, DESC_KDATA);
+    desc_set(MK_SEL(GDT_KDATA,  SEL_GDT, SEL_RPL0), data_base, 65536, DESC_KDATA);
 
     if (kernel_ftext) {
         desc_set(MK_SEL(GDT_KFTEXT, SEL_GDT, SEL_RPL0),
@@ -201,7 +191,7 @@ void pm_early_init(void)
     /* KCODE same base/limit as KDATA but executable+readable. IRQ trampolines are
      * built in the kernel data segment, and an IDT gate needs an executable selector.
      */
-    desc_set(MK_SEL(GDT_KDATA_EXEC, SEL_GDT, SEL_RPL0), data_base, 65536L, DESC_KCODE);
+    desc_set(MK_SEL(GDT_KDATA_EXEC, SEL_GDT, SEL_RPL0), data_base, 65536, DESC_KCODE);
 
     /* IDT replaces real mode IVT interrupt vector table + 8 bytes from 0:0 to 0:0407.
      * NOTE: With the normal MAX_IDT_ENTRIES of 129 (required for syscall INT 0x80),

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -32,6 +32,7 @@ typedef struct segment segment_s;
 #define SEG_FLAG_FREE    0x00
 #define SEG_FLAG_USED	 0x80
 #define SEG_FLAG_ALIGN1K 0x40
+#define SEG_FLAG_XMS     0x20   /* allocate only from XMS (PM only for now) */
 #define SEG_FLAG_TYPE	 0x0F
 #define SEG_FLAG_CSEG	 0x01   /* app code segment */
 #define SEG_FLAG_DSEG	 0x02   /* app auto (stack/heap) data segment */
@@ -69,8 +70,9 @@ int fs_memcmp(const void *,const void *,size_t);
 /* Memory allocation */
 
 void INITPROC seg_add(SELEXT_T start, SELEXT_T end);
-segment_s * seg_alloc_fixed (seg_t, segext_t, word_t);
 segment_s * seg_alloc (segext_t, word_t);
+segment_s * seg_alloc_xms (selext_t size, word_t type);     /* PM only for now */
+segment_s * seg_alloc_fixed (seg_t, segext_t, word_t);
 void seg_free (segment_s *);
 segment_s * seg_get (segment_s *);
 void seg_put (segment_s *);


### PR DESCRIPTION
The /dev/ssd XMS ramdisk driver now works with the PM kernel, and allows for creating and destroying XMS ram disks at any time, unlike current real mode XMS ramdisk which can only safely be allocated once.

Adds new seg_alloc_xms kernel memory allocation function to allow allocating large (>= 1M) XMS memory segments using the main kernel memory allocator. Currently usable only in PM kernel in multistep transition to enhanced kernel memory manager which will allow for managing main and XMS memory instead of using separate simple xms_alloc linear allocator.

After full transition, CONFIG_286_PMODE guards will be removed.

Tested with the following script creating a 4M ramdisk:
```
ramdisk /dev/ssd make 4096
mkfs /dev/ssd 4096
fsck -lvf /dev/ssd
meminfo -m
mount /dev/ssd /mnt
cp /bin/ls /mnt
df /dev/ssd
umount /dev/ssd
```
