### PR TITLE
[net] Cleanup various network scripts, remove hardcoded devices from ktcp

### DIFF
--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -70,6 +70,7 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "ne0",	S_IFCHR | 0644, MKDEV(ETH_MAJOR, 0)         },
     { "wd0",	S_IFCHR | 0644, MKDEV(ETH_MAJOR, 1)         },
     { "3c0",	S_IFCHR | 0644, MKDEV(ETH_MAJOR, 2)         },
+    { "ul0",	S_IFCHR | 0644, MKDEV(ETH_MAJOR, 3)         },
     { "le0",	S_IFCHR | 0644, MKDEV(ETH_MAJOR, 4)         },
 };
 #endif

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -45,7 +45,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 #endif
 
 #ifdef CONFIG_FS_DEV
-#define DEVDIR_SIZE             52              /* # entries in FAT device table */
+#define DEVDIR_SIZE             53              /* # entries in FAT device table */
 #define DEVINO_BASE             0xFFFFFF00UL    /* faked base of /dev inode numbers */
 
 struct msdos_devdir_entry {

--- a/elkscmd/inet/ftpd.c
+++ b/elkscmd/inet/ftpd.c
@@ -481,8 +481,9 @@ int do_nlist(int dfd, char *iobuf)
 /* Passive mode: Server listens for incoming data connection */
 int do_pasv(int *datafd) {
 	int fd;
-	unsigned int i = 1, port = 0;
+	unsigned int i = 1, port = 0, len;
 	struct sockaddr_in pasv;
+	struct sockaddr_in local;
 	char *p, *a;
 	char str[100], *pasv_err = "425 Can't open passive connection.\r\n";
 
@@ -504,7 +505,8 @@ int do_pasv(int *datafd) {
 	pasv.sin_port = htons(port);
 	i = 0;
 	while (bind(fd, (struct sockaddr *)&pasv, sizeof(pasv)) < 0) {
-		if (debug) printf("PASV bind failed: host %s port %u\n", in_ntoa(pasv.sin_addr.s_addr), ntohs(pasv.sin_port));
+		if (debug) printf("PASV bind failed: host %s port %u\n",
+			in_ntoa(pasv.sin_addr.s_addr), ntohs(pasv.sin_port));
 		perror("PASV bind");
 		if (i++ > 10 || errno != EADDRINUSE) {
 			if (debug) printf("Bind: Could not connect on port %u\n", port);
@@ -529,12 +531,9 @@ int do_pasv(int *datafd) {
 	}
 
 	/* Get current local IP from control connection */
-	{
-		struct sockaddr_in local;
-		unsigned int len = sizeof(local);
-		if (getsockname(controlfd, (struct sockaddr *)&local, &len) == 0)
-			pasv.sin_addr.s_addr = local.sin_addr.s_addr;
-	}
+	len = sizeof(local);
+	if (getsockname(controlfd, (struct sockaddr *)&local, &len) == 0)
+		pasv.sin_addr.s_addr = local.sin_addr.s_addr;
 	if (pasv_ip)
 		pasv.sin_addr.s_addr = in_aton(pasv_ip);
 	a = (char *) &pasv.sin_addr;
@@ -662,11 +661,9 @@ int main(int argc, char **argv) {
 					pasv_min_port = atoi(argv[0]);
 					pasv_max_port = pasv_min_port;
 				}
-				if (debug) printf("PASV port range: %u-%u\n", pasv_min_port, pasv_max_port);
-			} 			else if (argv[0][1] == 'n') {
+			} else if (argv[0][1] == 'n') {
 				argc--; argv++;
 				pasv_ip = argv[0];
-				if (debug) printf("PASV IP: %s\n", pasv_ip);
 			} else
 				usage();
 		} else {

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -190,7 +190,7 @@ void catch(int sig)
 
 static void usage(void)
 {
-    printf("Usage: ktcp [-b] [-d] [-m MTU] [-p ee0|ne0|wd0|3c0|slip|cslip] [-s baud] [-l device] [local_ip] [gateway] [netmask]\n");
+    printf("Usage: ktcp [-b] [-d] [-m MTU] [-p <ethdev>|slip|cslip] [-s baud] [-l device] [local_ip] [gateway] [netmask]\n");
     exit(1);
 }
 
@@ -215,18 +215,11 @@ int main(int argc,char **argv)
 		mtu = (int)atol(optarg);
 		break;
 	case 'p':		/* link protocol*/
-	    linkprotocol = !strcmp(optarg, "ne0")? LINK_ETHER :
-			   !strcmp(optarg, "wd0")? LINK_ETHER :
-			   !strcmp(optarg, "3c0")? LINK_ETHER :
-			   !strcmp(optarg, "ee0")? LINK_ETHER :
-			   !strcmp(optarg, "le0")? LINK_ETHER :
-			   !strcmp(optarg, "ul0")? LINK_ETHER :
-			   !strcmp(optarg, "slip")? LINK_SLIP :
-			   !strcmp(optarg, "cslip")? LINK_CSLIP:
-			   -1;
-	    if (linkprotocol < 0) usage();
+	    linkprotocol = !strcmp(optarg, "slip")? LINK_SLIP :
+			   !strcmp(optarg, "cslip")? LINK_CSLIP :
+			    LINK_ETHER;
 	    if (linkprotocol == LINK_ETHER)
-		strcpy(&ethdev[5], optarg);
+		strncpy(&ethdev[5], optarg, 3);
 	    break;
 	case 's':		/* serial speed*/
 	    baudrate = atol(optarg);

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -33,7 +33,7 @@ int tcpdev_init(char *fdev)
 {
     int fd  = open(fdev, O_NONBLOCK | O_RDWR);
     if (fd < 0)
-	printf("ktcp: can't open tcpdev device %s\n",fdev);
+	printf("ktcp: can't open %s (is network already running?)\n", fdev);
     return fd;
 }
 

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -1,13 +1,11 @@
 # Start/stop ELKS networking
 #
-# Usage: net [start|stop|restart|show] [ne0|wd0|3c0|le0|slip|cslip] [baud] [device]
+# Usage: net [start|stop|restart|show] [<ethdev>|slip|cslip] [baud] [device]
 #
 # Examples:
-#	net start ne0			start ethernet networking
-#	net start slip			start slip networking
-#	net start slip 19200	start slip at 19200 baud
+#	net start ne0			start NE2K
+#	net start slip 19200		start slip at 19200 baud
 #	net start cslip 4800 /dev/ttyS1
-#	net show				shows settings for 'net start'
 #
 # See slattach.sh for Linux slip setup
 # See qemu.sh NET= line for host forwarding into ELKS using QEMU
@@ -19,7 +17,9 @@ source /etc/net.cfg
 
 usage()
 {
-	echo "Usage: net [start|stop|show] [ne0|wd0|3c0|le0|ul0|slip|cslip] [baud] [device]"
+	echo "Usage: net [start|stop|show] [<ethdev>|slip|cslip] [baud] [device]"
+	echo "Known <ethdev> devices:"
+	ls -l /dev | grep 9, | cut -c 56-
 	exit 1
 }
 
@@ -42,11 +42,9 @@ start_network()
 		getty_off
 		ktcp="ktcp -b -p cslip -s $baud -l $device $localip $gateway $netmask"
 		;;
-	ne0|wd0|3c0|le0|ul0)
+	*)
 		ktcp="ktcp -b -p $link $mtu $localip $gateway $netmask"
 		;;
-	*)
-		usage ;;
 	esac
 	# run ktcp as background daemon if successful starting networking
 	echo $ktcp
@@ -88,8 +86,7 @@ restart)
 	stop_network
 	start_network ;;
 show)
-	echo -n ip $localip gateway $gateway mask $netmask $link
-	if test "$link" = "slip"; then echo "" $baud $device; else echo; fi ;;
+	ifconfig ;;
 *) usage ;;
 esac
 

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -8,6 +8,7 @@
 #wd0=10,0x300,0xCC00,0x80
 #3c0=11,0x330,,0x80
 #le0=9,0x340,,0x80
+#net=ne0
 #comirq=,,7,10
 #umb=0xC000:0x800,0xD000:0x1000
 dmesg=1
@@ -36,7 +37,6 @@ hma=kernel
 #kstack
 #strace
 #FTRACE=1
-#net=ne0
 #debug=1
 #istack
 #console=ttyS0,19200 3

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -12,7 +12,7 @@ netmask=$NETMASK
 mtu=
 #mtu="-m 1000"
 
-# default link layer [ne0|wd0|3c0|le0|ul0|slip|cslip]
+# default link layer
 link=ne0
 
 # default serial port and baud rate if slip/cslip

--- a/elkscmd/rootfs_template/etc/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.sys
@@ -19,22 +19,9 @@ fi
 # start networking
 #
 # check /bootopts "net=" env variable
-case "$net" in
-ne0|wd0|3c0|le0|ul0)
+if test "$net" != ""; then
 	net start $net
-	;;
-slip)
-	net start slip
-	;;
-cslip)
-	net start cslip
-	;;
-*)
-	if test "$net" != ""; then
-		echo "Unrecognized /bootopts network option: net=$net"
-	fi
-	;;
-esac
+fi
 
 # View message of day
 #if test -f /etc/motd; then

--- a/qemu.sh
+++ b/qemu.sh
@@ -12,11 +12,11 @@
 # Select disk image to use
 # MINIX or FAT .config build
 #IMAGE="-fda image/fd2880.img"
-#IMAGE="-fda image/fd1440.img"
+IMAGE="-fda image/fd1440.img"
 #IMAGE="-fda image/fd1200.img"
 #IMAGE="-fda image/fd720.img"
 #IMAGE="-fda image/fd360.img"
-IMAGE="-hda image/hd.img"
+#IMAGE="-hda image/hd.img"
 #IMAGE="-boot order=a -fda image/fd1440.img -drive file=image/hd32-minix.img,format=raw,if=ide"
 
 # FAT package manager build
@@ -104,7 +104,6 @@ hostfwd=tcp::8048-:49828,\
 hostfwd=tcp::8049-:49829,\
 hostfwd=tcp::49152-:49152,\
 hostfwd=tcp::49153-:49153"
-
 
 # new style
 #NET="-net nic,model=ne2k_isa -net user,$FWD"


### PR DESCRIPTION
Cleans up the requirement of having to specifically add new NIC driver names into /bin/net, /etc/net.cfg and ktcp.c.
Now, the scripts and ktcp just try to open the passed device (e.g. ne0 = /dev/ne0) without having to be recompiled.

`net show` now calls `ifconfig` as certain shells script variables are no longer used which caused it not to work.
`net` will now read /dev to show the available ethernet devices that can be used (ne0, wd0, etc) as an argument to `net start`.

A couple ktcp error messages are improved and the the ftpd -n and -p arguments aren't re-displayed by ftpd since the command line is readily visibile when ftpd is started by `net start`.

Adds /dev/ul0 to the fake FAT filesystem for use with the new SMC Ultra NIC driver.

qemu.sh IMAGE= defaults reset to 1440k floppy.