### PR TITLE
write - bugfix, recepient username is printed instead of sender username

### DIFF
--- a/elkscmd/busyelks/cmd/write.c
+++ b/elkscmd/busyelks/cmd/write.c
@@ -87,7 +87,7 @@ int write_main(int argc, char ** argv)
 			exit(1);
 		}
 	}
-	if ((pwdent = getpwnam(argv[1])) == NULL) {
+	if ((pwdent = getpwuid(getuid())) == NULL) {
 		fprintf(stderr, "%s: Who are you?\n", argv[0]);
 		exit(1);
 	}

--- a/elkscmd/sh_utils/write.c
+++ b/elkscmd/sh_utils/write.c
@@ -87,7 +87,7 @@ int main(int argc, char ** argv)
 			exit(1);
 		}
 	}
-	if ((pwdent = getpwnam(argv[1])) == NULL) {
+	if ((pwdent = getpwuid(getuid())) == NULL) {
 		fprintf(stderr, "%s: Who are you?\n", argv[0]);
 		exit(1);
 	}


### PR DESCRIPTION
I found this bug in write on Fuzix, so I thought I should upstream the fix here as well.

I have not been able to test the fix on elks as write is not built currently.