### PR TITLE
Sound Blaster /dev/dsp driver, OPTi MAD16 bring-up, and audio userland

### DIFF
--- a/Documentation/text/dsp-sb.txt
+++ b/Documentation/text/dsp-sb.txt
@@ -1,0 +1,224 @@
+ELKS Sound Blaster /dev/dsp driver
+==================================
+
+The CONFIG_CHAR_DEV_DSP driver plays digital audio on a Sound Blaster or
+compatible ISA card through /dev/dsp, using the OSS ioctl interface.  It is a
+playback-only driver: there is no recording path, no mixer ioctl, no MIDI and no
+sequencer.  Output level is set once at boot and can be changed from user space
+with sbmix(1); see "Output level" below.
+
+Only raw unsigned 8-bit mono PCM is accepted.  Sample rate conversion, WAV
+parsing and ADPCM decoding belong in user space.
+
+Hardware resources
+------------------
+
+The card is driven with 8-bit ISA DMA on the primary 8237, channel 1 or 3
+only, using the classic DSP 0x14 single-block command and a time constant.
+Any card from a Sound Blaster 1.0 upwards therefore works, including the SB
+Pro and SB16 in their compatible mode.  16-bit DMA and the SB16 high-DMA path
+are not used.
+
+Defaults are CONFIG_SB_PORT 0x220, CONFIG_SB_IRQ 5 and CONFIG_SB_DMA 1, which
+are the Creative factory settings.  /bootopts can override them without a
+rebuild:
+
+    sb=0x220,5,1        port, IRQ and DMA channel
+    sb=544,5,1          the port may also be given in decimal
+    sb=off              skip the driver on a machine with no card
+
+The IRQ is claimed during boot rather than at open, so the sound card wins any
+contest for it.  IRQ 5 is also Com3, so selecting it means the serial driver
+can no longer open /dev/ttyS2.  IRQ 7 is Com4 and the second parallel port,
+and additionally collects 8259 spurious interrupts, which the driver ignores.
+
+XT machines with a hard disk
+---------------------------
+
+A Sound Blaster leaves the factory on IRQ 5 and offers DMA 1 or 3, and on an
+XT-class machine with a hard disk fitted both of the defaults are already
+taken.  The Amstrad PC1640 technical reference is representative:
+
+    IRQ 2   real time clock, available on the expansion bus
+    IRQ 3   spare, used by the secondary serial and SDLC ports
+    IRQ 4   8250 UART (Com1)
+    IRQ 5   hard disk controller
+    IRQ 6   765 floppy disk controller
+    IRQ 7   parallel printer port
+
+    DMA 0   memory refresh
+    DMA 1   spare for the expansion bus
+    DMA 2   765 floppy disk controller
+    DMA 3   external hard disk controller
+
+So on such a machine jumper the card for IRQ 7 and DMA 1.  DMA 1 is the
+driver's default and the only spare channel.  IRQ 7 is nominally the parallel
+printer port, but the ELKS printer driver polls and never claims it, so it is
+free in practice; the driver tolerates the 8259 spurious interrupts that also
+arrive on IRQ 7.
+
+IRQ 2 and IRQ 3 are the other candidates if the printer port is genuinely
+needed, but check them against any network card first: an SMC Ultra reads its
+own interrupt out of the card's configuration, and dmesg reports which one it
+took at boot.
+
+When the driver is built together with the XT MFM hard disk driver it enforces
+this: DMA 3 is refused outright, because sharing the channel would corrupt disk
+transfers, and IRQ 5 produces a warning, because sharing the interrupt only
+costs spurious handler entries.
+
+Buffering and the gap between blocks
+------------------------------------
+
+The driver holds one DMA block in flight at a time.  write() copies up to
+CONFIG_SB_BOUNCE bytes into a low-memory buffer, starts the transfer, and
+returns once the previous block has drained, looping internally until the
+caller's whole buffer has been consumed.
+
+The DMA engine is therefore idle between blocks for the interrupt latency plus
+one buffer copy.  At the 4096-byte default that is a short gap roughly every
+CONFIG_SB_BOUNCE/rate seconds, or about every half second at 8000 Hz.  Making
+the buffer smaller makes the gaps more frequent rather than removing them.
+Eliminating them needs auto-init DMA (DSP command 0x1C with 8237 mode 0x58)
+over a split buffer, which is a larger change than this driver.
+
+The same single-block design sets the latency: SNDCTL_DSP_SYNC and an
+interrupted write take up to one block to take effect.
+
+Sample rates
+------------
+
+Rates from 4000 to 20000 Hz are accepted.  The upper limit is the documented
+ceiling for DSP 0x14 without the high-speed commands.
+
+The DSP is programmed with a time constant of 256 - 1000000/rate, so the
+achievable rates are quantised.  SNDCTL_DSP_SPEED is read-write and reports
+the rate actually programmed, which the caller should re-read.  4000, 8000 and
+20000 Hz are exact; 11025 Hz is not.
+
+Supported ioctls
+----------------
+
+    SNDCTL_DSP_RESET        halt playback
+    SNDCTL_DSP_SYNC         drain, then halt
+    SNDCTL_DSP_SPEED        read/write sample rate
+    SNDCTL_DSP_STEREO       read/write, 0 = mono
+    SNDCTL_DSP_CHANNELS     read/write channel count
+    SNDCTL_DSP_SETFMT       read/write format, AFMT_U8 only
+    SNDCTL_DSP_GETFMTS      supported format mask
+    SNDCTL_DSP_GETBLKSIZE   DMA block size in bytes
+    SNDCTL_DSP_POST         accepted, no effect
+    SNDCTL_DSP_GETERROR     underrun count since the last call
+
+Anything else returns EINVAL.  /dev/dsp allows a single opener at a time; a
+second open returns EBUSY.  Reading from it returns end of file.
+
+Output is mono.  SNDCTL_DSP_CHANNELS accepts a request for one channel and
+SNDCTL_DSP_STEREO accepts 0, both reporting back what was set; asking for two
+channels returns EINVAL.
+
+MAD16 boards
+------------
+
+CONFIG_SB_MAD16 adds bring-up for the OPTi 82C929 (MAD16 Pro) chipset, which
+answers SB DSP commands only once its control registers have been programmed
+to route the SB personality.  It is only attempted when /bootopts sets
+mad16=on, or mad16=port,irq,dma to route it somewhere other than the sb=
+settings.  A real Sound Blaster does not need it, but a card with no jumpers
+will not respond at all without it.
+
+The chip holds the SB route in three fields of its MC3 register:
+
+    bit    2    SB port, clear = 0x220, set = 0x240
+    bits 7:6    IRQ, 00 = 7, 10 = 5, 11 = disabled
+    bits 5:4    DMA, 00 = 1, 10 = 3, 11 = disabled
+
+There is no room for anything else, so a jumperless card can only be placed
+at port 0x220 or 0x240, on IRQ 5 or 7, using DMA 1 or 3.  The driver rejects
+any other request and says so:
+
+    sb: mad16 cannot route 0x260 irq 3 dma 1, allows port 0x220/0x240
+        irq 5/7 dma 1/3
+    sb: mad16 82c929 not detected
+
+Combined with the IRQ and DMA map above, a machine whose hard disk controller
+owns IRQ 5 and DMA 3 leaves exactly one usable route for such a card: IRQ 7
+with DMA 1, at either port.  There is no fallback if IRQ 7 is already taken,
+so check it against the network card before relying on it.
+
+Output level
+------------
+
+The driver programs the master and voice levels once during boot and never
+touches them again, so anything set afterwards stays set.  Both go to 2 of 7 on
+an SB Pro, which is 4 of 15 on an SB16: one register value, 0x44, lands on
+roughly the same fraction of full scale in both mixer layouts.
+
+Full scale would be the obvious choice for a driver with no volume ioctl, and it
+is wrong.  The voice and master attenuators are in series ahead of the output
+amplifier, so all-ones in both asks for the loudest analog path the card has.
+Eight-bit material already peaks near full scale, so the result clips in the
+mixer and sounds distorted rather than loud.  Cards left at zero out of reset
+are the opposite failure and look like a driver that runs silently, which is why
+both stages are always programmed rather than left alone.
+
+Boards differ in how much gain follows the mixer, so treat 0x44 as a starting
+point.  sbmix(1) reads the registers back and sets them live:
+
+    sbmix                   show the DSP version and decoded mixer levels
+    sbmix -m 30 -v 30       set master and voice, as a percentage of full scale
+    sbmix -s 0x22=0x44      write a raw register value
+    sbmix -r 0x0e           read one register
+
+It decodes levels according to the DSP version, since a DSP 3.xx card reads
+bits 7-5 and 3-1 as two 3-bit fields while a DSP 4.xx card reads bits 7-4 and
+3-0 as two 4-bit fields.  A DSP 1.xx or 2.xx card has no mixer at all and
+sbmix says so.  Run it while playback is idle: it resets the DSP to read the
+version, which would interrupt a transfer in progress.
+
+Playing audio
+-------------
+
+The audioplay command writes raw unsigned 8-bit PCM to /dev/dsp:
+
+    audioplay -r 8000 tone.raw
+    cat tone.raw | audioplay
+
+Convert material on the host first, for example:
+
+    sox in.wav -t raw -r 8000 -c 1 -b 8 -e unsigned out.raw
+    ffmpeg -i in.wav -f u8 -ar 8000 -ac 1 out.raw
+
+audioplay exits non-zero if the driver reported any underruns, so it can be
+used as a pass/fail check.
+
+Playing audio over the network
+------------------------------
+
+The audiorecv command listens on a TCP port and writes what arrives to
+/dev/dsp, which avoids copying a file over first:
+
+    audiorecv -r 8000                       one stream, then exit
+    audiorecv -d -r 8000                    detach, serve streams forever
+
+Nothing on the wire describes the audio, so -r has to match what the sender
+was told to produce.  From the host:
+
+    sox in.wav -t raw -r 8000 -c 1 -b 8 -e unsigned - | nc elks 4950
+    ffmpeg -i in.wav -f u8 -ar 8000 -ac 1 - | nc elks 4950
+
+The port defaults to 4950 and is set with -p.  Add audiorecv to netstart= in
+/etc/net.cfg to have /bin/net start it as a daemon; the command line is already
+there, commented out.
+
+Playback is real time, so the link has to sustain `rate' bytes per second, and
+the slack is one DMA block: 4096 bytes, about half a second at 8000 Hz.
+Ethernet manages this easily.  SLIP at 19200 baud carries around 1900 bytes per
+second and cannot feed even the 4000 Hz minimum, so a serial link needs 40000
+baud or better.  TCP flow control does the throttling, so a link that is too
+slow breaks the audio up rather than corrupting it, and the underrun count
+audiorecv prints at the end of each stream says how badly.
+
+/dev/dsp is opened per stream, not held open, so audioplay still works while
+the daemon is idle.  Streams are served one at a time because the device has a
+single opener.

--- a/config/Configure.help
+++ b/config/Configure.help
@@ -421,6 +421,83 @@ Enable standard serial ports
 CONFIG_CHAR_DEV_RS
   Include support for serial port devices.
 
+Sound Blaster /dev/dsp driver
+CONFIG_CHAR_DEV_DSP
+  Include support for playing sound on a Sound Blaster or compatible ISA
+  card through /dev/dsp, using the OSS ioctl interface.
+
+  Playback only, mono, raw unsigned 8-bit PCM, one DMA block in flight at
+  a time.  There is no recording, no mixer control and no MIDI.  Sample
+  conversion belongs in user space; see the audioplay command.
+
+  The card is driven with 8-bit ISA DMA on channel 1 or 3 only, using the
+  classic DSP 0x14 single-block command, so any card from a Sound Blaster
+  1.0 upwards will work at up to 20000 Hz.
+
+  /bootopts sb=port,irq,dma overrides the settings below without a
+  rebuild, and sb=off disables the driver on a machine that has no card.
+
+  On an XT-class machine with a hard disk the sound card must not use the
+  card's factory IRQ 5 or DMA 3, because the hard disk controller owns
+  both.  The Amstrad PC1640 technical reference assigns IRQ 5 to the hard
+  disk controller and DMA 3 to the external hard disk controller, leaving
+  DMA 1 spare for the expansion bus.  IRQ 7 is the parallel printer port,
+  which the ELKS printer driver never claims because it polls, so IRQ 7
+  with DMA 1 is the combination to jumper for on such a machine.  The
+  driver refuses DMA 3 and warns about IRQ 5 when built with the XT MFM
+  hard disk driver.
+
+Sound Blaster I/O port
+CONFIG_SB_PORT
+  Base I/O port of the card.  Sound Blasters are jumpered to 0x220 or
+  0x240; 0x210 through 0x260 are also possible on later cards.
+
+Sound Blaster IRQ
+CONFIG_SB_IRQ
+  Interrupt the card is jumpered to, normally 5 or 7 on an 8-bit card.
+  The IRQ is claimed during boot, so choosing 5 also stops the serial
+  driver opening Com3.  See the conflict note above before choosing 5 on
+  a machine with a hard disk.
+
+Sound Blaster DMA channel
+CONFIG_SB_DMA
+  8-bit DMA channel the card is jumpered to, either 1 or 3.  Channel 1 is
+  the Sound Blaster default and is the only safe answer on a machine with
+  an XT hard disk controller, which uses channel 3.
+
+Playback DMA buffer bytes
+CONFIG_SB_BOUNCE
+  Size of the low-memory DMA buffer, and therefore the size of one
+  playback block.  The default of 4096 is 512ms of audio at 8000 Hz.
+
+  Because only one block plays at a time, this also sets how long it takes
+  for a program to stop playback, and how much data is copied between
+  blocks.  Smaller values make the gap between blocks more frequent but
+  shorter; they do not remove it.
+
+OPTi 82C929 (MAD16) early init
+CONFIG_SB_MAD16
+  Program an OPTi 82C929 (MAD16 Pro) chipset into Sound Blaster Pro mode
+  before probing for the DSP.  Say N for a real Sound Blaster, and Y for a
+  card with no jumpers that is configured only by software, which will not
+  answer at all until this has run.
+
+  It takes effect when /bootopts sets mad16=on, which routes the chip to
+  the same port, IRQ and DMA as the sb= line, or mad16=port,irq,dma to use
+  something else.
+
+  The chip's MC3 register can only express these resources, so this is the
+  whole set of routes available on a jumperless card:
+
+    port    0x220 or 0x240
+    IRQ     5 or 7
+    DMA     1 or 3
+
+  On a machine whose hard disk controller owns IRQ 5 and DMA 3, such as the
+  Amstrad PC1640, that leaves exactly one usable combination: IRQ 7 with
+  DMA 1.  Check it against any network card first, since an SMC Ultra takes
+  its interrupt from its own configuration.
+
 Enable meta device driver
 CONFIG_DEV_META
   Include meta driver to provide support for userspace device drivers.

--- a/elks/arch/i86/drivers/block/mfmhd.c
+++ b/elks/arch/i86/drivers/block/mfmhd.c
@@ -95,6 +95,11 @@
 #define MFM_CTL_PIO_POLLED      MFMHD_CTL_PIO_POLLED
 #define MFM_CTL_VALID_MASK      (MFM_CTL_DRQEN | MFM_CTL_IRQEN)
 
+/* IRQ 5 is the PC/XT fixed-disk interrupt, as used by the WD1002 and clones. */
+#ifndef MFMHD_IRQ
+# define MFMHD_IRQ              5
+#endif
+
 /* Command-status byte bits. */
 #define MFM_CSB_ERROR           0x02
 #define MFM_CSB_LUN             0x20
@@ -461,6 +466,7 @@ static unsigned char mfmhd_control_shadow;
 static int mfmhd_quiet_probe;
 static char *mfmhd_bounce;
 extern int mfm_opts;        /* /bootopts mfm= options */
+extern int dma_extwrite_opt; /* /bootopts dmaxw=1: 8237 Extended Write */
 int mfmhd_slow_profile;     /* mfm= bit 0 selects slow timing */
 /*
  * mfm= bit 1 moves sector payloads over programmed I/O instead of
@@ -477,6 +483,23 @@ int mfmhd_pio;
  * before a freeze stays on screen.
  */
 int mfmhd_trace;
+/*
+ * mfm= bit 3 requests interrupt-driven command completion on IRQ 5, the XT
+ * fixed-disk line.  The controller has always been able to do this - bit 1 of
+ * the port+3 mask register (MFM_CTL_IRQEN) asserts IRQ on command completion -
+ * but the driver only ever wrote MFM_CTL_PIO_POLLED and span on the status
+ * port instead, which burns the CPU for the whole of every transfer.
+ *
+ * It is opt-in rather than default because this is the driver the system boots
+ * from: if the board does not actually drive the line, or the line is shared,
+ * an unbootable machine is the failure mode.  Booting without the bit restores
+ * the polled behaviour exactly.  The poll loop is retained underneath as a
+ * backstop, so a missing interrupt costs latency rather than a hang.
+ */
+int mfmhd_irq_mode;
+static struct wait_queue mfmhd_wait;
+static volatile unsigned char mfmhd_irq_seen;
+static unsigned char mfmhd_irq_armed;
 
 static jiff_t mfmhd_probe_deadline;     /* 0 once probing is over */
 
@@ -986,6 +1009,43 @@ mfmhd_dump_status(unsigned int port, const char *where, unsigned char status)
         (status & MFM_STAT_READY) != 0);
 }
 
+/*
+ * Completion interrupt.  The controller latches MFM_STAT_INTERRUPT in the
+ * status port; reading status is what the polled path already does, so the
+ * flag is simply recorded and the sleeper woken.  The PIC end-of-interrupt is
+ * issued by the irqit wrapper, so the PIC is not touched here.
+ */
+static void
+mfmhd_interrupt(int irq, struct pt_regs *regs)
+{
+    (void)irq;
+    (void)regs;
+    mfmhd_irq_seen = 1;
+    wake_up(&mfmhd_wait);
+}
+
+/*
+ * Wait for command completion.  With mfm= bit 3 the task sleeps until the
+ * controller's interrupt arrives, giving the CPU back for the duration of the
+ * transfer; the caller's own timeout still bounds the wait, and the polled
+ * loop below still runs afterwards to confirm the status bits, so an
+ * interrupt that never arrives degrades to the old behaviour rather than
+ * hanging.
+ */
+static void
+mfmhd_sleep_for_irq(jiff_t timeout)
+{
+    if (!mfmhd_irq_armed)
+        return;
+    prepare_to_wait_interruptible(&mfmhd_wait);
+    if (!mfmhd_irq_seen && !current->signal) {
+        current->timeout = jiffies() + timeout + 1;
+        do_wait();
+        current->timeout = 0;
+    }
+    finish_wait(&mfmhd_wait);
+}
+
 static int
 mfmhd_wait_status(unsigned int port, unsigned char flags, unsigned char mask,
     jiff_t timeout, const char *where)
@@ -1154,11 +1214,41 @@ mfmhd_data_out_burst(unsigned int port, unsigned char **pwrite,
 #define MFM_CMD_FAULT           (-1)    /* handshake fault: count + resync */
 #define MFM_CMD_NOSELECT        (-2)    /* never selected: quiet cleanup */
 
+/*
+ * A phase fault means the driver and the controller disagree about where they
+ * are in the command protocol, and the controller does not leave that state on
+ * its own: it sits with SELECT asserted (status 0xCB, drive light stuck on) and
+ * every later command fails, so a probe after one reports "no XT MFM drives
+ * found" on a perfectly good disk.  Worse, a fault part way through a write
+ * leaves the sector half written, which is how a file on this disk ends up
+ * truncated.
+ *
+ * Pulsing the reset port clears it - measured on a wedged WD1002A-WX1, status
+ * went from 0xCB straight back to 0xC0 - so recover here rather than leaving
+ * the board stuck for whatever runs next.  The command still fails and the
+ * caller still retries; this only ensures the retry meets a sane controller.
+ */
 static int
 mfmhd_phase_fault(unsigned int port, const char *where, unsigned char st)
 {
+    unsigned char after;
+    int i;
+
     mfmhd_dump_status(port, where, st);
     mfmhd_debug_set(40, -1, port, -1);
+
+    outb_p(1, port + MFM_HD_RESET);
+    for (i = 0; i < 1000; i++) {        /* the board needs a moment to settle */
+        after = STATUS(port);
+        if (!(after & MFM_STAT_SELECT))
+            break;
+    }
+    mfmhd_write_control(port, MFM_CTL_PIO_POLLED);
+    if (after & MFM_STAT_SELECT)
+        printk("mfmhd: controller still busy after reset, status=%02x\n", after);
+    else if (mfmhd_trace)
+        printk("mfmhd: controller reset after %s, status=%02x\n", where, after);
+
     return MFM_CMD_FAULT;
 }
 
@@ -1204,8 +1294,14 @@ mfmhd_cmd_raw(unsigned int port)
 
     /* Match Linux xd WD1002 select-then-control ordering. */
     outb_p(0, port + MFM_HD_SELECT);
-    mfmhd_write_control(port, dma_active ? MFM_CTL_DRQEN :
-        MFM_CTL_PIO_POLLED);
+    /*
+     * Clear the seen-flag before the controller can raise the line, or a
+     * stale interrupt from the previous command would satisfy this one's wait.
+     */
+    mfmhd_irq_seen = 0;
+    mfmhd_write_control(port,
+        (unsigned char)((dma_active ? MFM_CTL_DRQEN : MFM_CTL_PIO_POLLED) |
+                        (mfmhd_irq_armed ? MFM_CTL_IRQEN : 0)));
 
     if (mfmhd_trace)
         printk("mfmhd: cmd op=%02x dma=%d in=%u out=%u\n", op, dma_active,
@@ -1338,10 +1434,15 @@ done:
     if (dma_active)
         mfmhd_dma_stop();
 
+    /* Give the CPU up until the controller says it has finished. */
+    mfmhd_sleep_for_irq(mfmhd_select_ticks());
+
     if (mfmhd_wait_status(port, 0, MFM_STAT_SELECT, mfmhd_select_ticks(),
             "busy clear timeout"))
         return MFM_CMD_FAULT;
-    if (dma_active)
+    if (mfmhd_irq_armed)
+        mfmhd_write_control(port, MFM_CTL_PIO_POLLED);
+    else if (dma_active)
         mfmhd_write_control(port, MFM_CTL_PIO_POLLED);
 
     return (int)csb | (early_status ? MFM_CMD_EARLY_STATUS : 0);
@@ -2076,6 +2177,20 @@ struct gendisk * INITPROC mfmhd_init(void)
     mfmhd_slow_profile = mfm_opts & 1;  /* bit 0: slow controller timing */
     mfmhd_pio = (mfm_opts >> 1) & 1;    /* bit 1: PIO sector transfers */
     mfmhd_trace = (mfm_opts >> 2) & 1;  /* bit 2: driver request tracing */
+    mfmhd_irq_mode = (mfm_opts >> 3) & 1; /* bit 3: interrupt-driven completion */
+
+    /*
+     * dmaxw=1 lengthens the 8237's write strobe.  On the Amstrad PC1512/1640
+     * the controller is clocked at 4MHz for a 1.25us bus cycle on channels
+     * 1-3 and the ROS leaves it in Late Write, which is faster than 8-bit
+     * cards were built for; this board then misses its DMA handshake and the
+     * driver falls back to PIO.  Setting Extended Write here, once, before any
+     * transfer is programmed, gives the card the longer pulse it needs.
+     */
+    if (dma_extwrite_opt) {
+        outb_p(DMA1_CMD_EXTWRITE, DMA1_CMD_REG);
+        printk("mfmhd: 8237 extended write enabled\n");
+    }
 
     mfmhd_init_ports();
     mfmhd_debug_set(10, -1, MFMHD_PORT, 0);
@@ -2146,9 +2261,17 @@ struct gendisk * INITPROC mfmhd_init(void)
     /* The block layer scans partitions after this request path is live. */
     mfmhd_initialized = 1;
 
-    printk("mfmhd: found %d hard drive%c at port 0x%x, polled %s\n",
+    if (mfmhd_irq_mode) {
+        if (request_irq(MFMHD_IRQ, mfmhd_interrupt, INT_GENERIC))
+            printk("mfmhd: irq %d busy, staying polled\n", MFMHD_IRQ);
+        else
+            mfmhd_irq_armed = 1;
+    }
+
+    printk("mfmhd: found %d hard drive%c at port 0x%x, %s %s, dmaxw=%d\n",
         hdcnt, hdcnt == 1 ? ' ' : 's', MFMHD_PORT,
-        mfmhd_pio ? "pio" : "dma=3");
+        mfmhd_irq_armed ? "irq 5" : "polled",
+        mfmhd_pio ? "pio" : "dma=3", dma_extwrite_opt);
     mfmhd_debug_set(91, -1, MFMHD_PORT, 0);
     return &mfmhd_gendisk;
 }

--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -135,6 +135,13 @@ ifdef CONFIG_AUDIO
   OBJS += audio-8254.o
 endif
 
+ifdef CONFIG_CHAR_DEV_DSP
+  OBJS += dsp-sb.o
+  ifdef CONFIG_SB_MAD16
+    OBJS += dsp-mad16.o
+  endif
+endif
+
 ifdef CONFIG_ARCH_IBMPC
   OBJS += mouse-ps2.o
 endif

--- a/elks/arch/i86/drivers/char/config.in
+++ b/elks/arch/i86/drivers/char/config.in
@@ -51,4 +51,16 @@ mainmenu_option next_comment
 	#fi
 
 	bool 'Pseudo tty device driver'		CONFIG_PSEUDO_TTY	  y
+	if [ "$CONFIG_ARCH_IBMPC" = "y" ]; then
+		bool 'Sound Blaster /dev/dsp driver'	CONFIG_CHAR_DEV_DSP	  n
+	else
+		define_bool CONFIG_CHAR_DEV_DSP n
+	fi
+	if [ "$CONFIG_CHAR_DEV_DSP" = "y" ]; then
+		hex  '  Sound Blaster I/O port'		CONFIG_SB_PORT		  0x220
+		int  '  Sound Blaster IRQ'		CONFIG_SB_IRQ		  5
+		int  '  Sound Blaster DMA channel (1 or 3)' CONFIG_SB_DMA	  1
+		int  '  Playback DMA buffer bytes'	CONFIG_SB_BOUNCE	  4096
+		bool '  OPTi 82C929 (MAD16) early init'	CONFIG_SB_MAD16		  n
+	fi
 endmenu

--- a/elks/arch/i86/drivers/char/dsp-mad16.c
+++ b/elks/arch/i86/drivers/char/dsp-mad16.c
@@ -1,0 +1,396 @@
+/*
+ * OPTi 82C929 (MAD16 Pro) early initialisation for the /dev/dsp driver
+ *
+ * A MAD16 board answers Sound Blaster DSP commands at the usual ports, but
+ * only once the OPTi control registers have been programmed to route the SB
+ * personality to a port, IRQ and DMA channel.  A DOS driver normally does
+ * that at boot; when nothing has, the card looks present but never transfers.
+ * This file does the same bring-up as the Linux mad16.c C929 path, cut down to
+ * what an SB-only playback driver needs, and is only reached when /bootopts
+ * asks for it with mad16=on.
+ *
+ * The control registers are password gated: 0xE3 must be written to 0xF8F
+ * immediately before each access, so every read and write here runs with
+ * interrupts off.
+ *
+ * The attached WSS codec is initialised before the SB profile is written.
+ * Without that step some boards accept DSP commands but never drain enough of
+ * the internal FIFO to keep DRQ asserted, which looks like a dead DMA channel.
+ */
+
+#include <linuxmt/config.h>
+
+#if defined(CONFIG_CHAR_DEV_DSP) && defined(CONFIG_SB_MAD16)
+
+#include <linuxmt/types.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/kernel.h>
+#include <linuxmt/init.h>
+#include <linuxmt/string.h>
+#include <arch/io.h>
+#include <arch/irq.h>
+
+/*
+ * Every port access in this driver goes through the bus-recovery forms.  The
+ * xt-elks driver that worked on this machine built with CONFIG_XT_SLOW_ISA_IO=y
+ * and routed all 54 of its accesses through inb_p/outb_p (sb_dsp.c:46-52); that
+ * symbol does not exist in this tree, and these two sound files are the only
+ * drivers left using bare inb/outb - lp, kbd-scancode, serial-8250, mfmhd and
+ * directfd all still use the _p forms.
+ *
+ * On an 8 MHz Amstrad this matters.  Back-to-back accesses with no recovery
+ * cycle are dropped or mis-latched by slow ISA parts: the 8237 programming
+ * sequence writes the address and count as flip-flop pairs, so one lost byte
+ * points DMA at the wrong memory, and the OPTi password gate and the AD1848
+ * index/data pairs have the same exposure.  An emulator does not model bus
+ * recovery, which is why this reads clean in 86Box and breaks on real hardware.
+ */
+
+/*
+ * Raw, unpadded port access for the password gate only.  The OPTi opens its
+ * control registers for exactly one access after the password byte, and outb_p
+ * emits its recovery cycle AFTER the write - which would put a write to port
+ * 0x80 between the password and the register access and consume the gate.
+ * Everything else in this file keeps the recovery cycle.
+ */
+#define MC_RAW_OUTB(value, port)                            \
+    asm volatile ("outb %%al,%%dx"                          \
+                  : : "Ral" ((unsigned char)(value)), "d" (port))
+#define MC_RAW_INB(port) __extension__ ({                   \
+    unsigned char _v;                                       \
+    asm volatile ("inb %%dx,%%al" : "=Ral" (_v) : "d" (port)); \
+    _v; })
+
+
+/* MC1..MC6 control registers, password port, and the WSS window */
+#define MC_PWD_PORT     0xF8F
+#define MC_PASSWORD     0xE3
+#define MC1             0xF8D
+#define MC2             0xF8E
+#define MC3             0xF8F
+#define MC4             0xF90
+#define MC5             0xF91
+#define MC6             0xF92
+#define WSS_BASE        0x530
+#define CODEC_BASE      (WSS_BASE + 4)
+
+#define MC1_DEFAULT     0x00
+#define MC1_MASK        (0x40 | 0x01)
+#define MC1_WSS_MODE    0x80        /* WSS mode, WSBase 0x530 */
+#define MC2_DEFAULT     0x03
+#define MC2_OPL4        0x20
+#define MC2_CDSEL_OFF   0x03
+#define MC3_IRQ_MASK    0xC0
+#define MC3_DMA_MASK    0x30
+#define MC3_SB_240      0x04
+#define MC3_GP_TIMER    0x02        /* write GPMODE; read overlaps REV bit 1 */
+#define MC3_SB_OFF      0xF0        /* SB disabled while WSS is being set up */
+#define MC4_ADPCM       0x80
+#define MC4_TIMEOUT     0x20
+#define MC4_SBVER_3     0x02
+/*
+ * MC5 is the diagnostic register, and two of these bits were previously named
+ * as though they were reserved.  They are not: bit 7 is AUTOVOL and bit 2 is the
+ * Sound Blaster mixer enable.  The vendor driver makes the polarity explicit -
+ * "if (getbit(mc5data,7) = 0) then cfg.autovol := 1; {low means active here}" -
+ * so setting bit 7 DISABLES automatic volume.
+ *
+ * The datasheet gives a normal setting per codec: 0x2F for a CS4231/4248 and
+ * 0x25 for an AD1848/1846, the difference being CFIX, the fix for Crystal part
+ * synchronisation delays, which must be off for an AD1848.  SPACCESS stays clear
+ * so the codec is not reachable while the chip is in Sound Blaster mode, which
+ * is what the normal setting specifies.
+ */
+#define MC5_AUTOVOL_OFF 0x80        /* 1 = automatic volume disabled */
+#define MC5_MUST0_6     0x40
+#define MC5_SHPASS      0x20        /* protect the codec shadow registers */
+#define MC5_SPACCESS    0x10        /* codec reachable during SB mode */
+#define MC5_CFIFO       0x08
+#define MC5_SBMIX       0x04        /* Sound Blaster mixer enable */
+#define MC5_CFIX        0x02        /* 1 = CS4231/4248, 0 = AD1848/1846 */
+#define MC5_CDFTOEN     0x01
+#define MC6_MPU_ENABLE  0x80
+#define MC6_MPU_IRQ     0x18
+#define MC6_MPU_OFF     0x07
+#define MC6_WAVE        0x02
+#define MC6_ATTN        0x01
+
+#define MC4_DEFAULT     (MC4_ADPCM | MC4_TIMEOUT | MC4_SBVER_3)
+/*
+ * SPACCESS is deliberately NOT set.  It was tried, to make the codec readable at
+ * WSS_BASE+4 during Sound Blaster mode so the format the emulation programs
+ * could be inspected; the card then stopped answering the DSP at 0x220
+ * altogether.  On this part the codec window and the SB personality are
+ * mutually exclusive, so the datasheet's normal setting is a requirement rather
+ * than just a default.  0x25 is that setting for an AD1848.
+ */
+#define MC5_DEFAULT     (MC5_SHPASS | MC5_SBMIX | MC5_CDFTOEN)   /* 0x25 */
+#define MC6_DEFAULT     (MC6_WAVE | MC6_ATTN)
+
+#define CODEC_MCE       0x40        /* mode change enable in the index register */
+
+/*
+ * The SB profile is kept so it can be written again when /dev/dsp is opened:
+ * anything else that has touched the chip in the meantime, including the WSS
+ * side of the same board, may have moved the SB personality.
+ */
+static unsigned char mad16_profile_valid;
+static unsigned char mad16_mc[6];
+
+static void FARPROC mc_write(unsigned int port, unsigned char val)
+{
+    unsigned int flags;
+
+    save_flags(flags);
+    clr_irq();
+    MC_RAW_OUTB(MC_PASSWORD, MC_PWD_PORT);
+    MC_RAW_OUTB(val, port);
+    restore_flags(flags);
+}
+
+static unsigned char INITPROC mc_read(unsigned int port)
+{
+    unsigned int flags;
+    unsigned char val;
+
+    save_flags(flags);
+    clr_irq();
+    MC_RAW_OUTB(MC_PASSWORD, MC_PWD_PORT);
+    val = MC_RAW_INB(port);
+    restore_flags(flags);
+    return val;
+}
+
+static void FARPROC mc_write_profile(unsigned char *mc)
+{
+    mc_write(MC1, mc[0]);
+    mc_write(MC2, mc[1]);
+    mc_write(MC3, mc[2]);
+    mc_write(MC4, mc[3]);
+    mc_write(MC5, mc[4]);
+    mc_write(MC6, mc[5]);
+}
+
+void FARPROC mad16_restore_profile(void)
+{
+    if (mad16_profile_valid)
+        mc_write_profile(mad16_mc);
+}
+
+/*
+ * Present if MC1 reads differently through the password gate than without it,
+ * and if a toggled bit reads back through the gate.
+ */
+static int INITPROC mad16_detect(void)
+{
+    unsigned char mc1, ungated, toggled;
+
+    mc1 = mc_read(MC1);
+    if (mc1 == 0xFF)
+        return 0;
+    ungated = inb_p(MC1);
+    if (ungated == mc1)
+        return 0;
+
+    mc_write(MC1, (unsigned char)(mc1 ^ 0x80));
+    toggled = mc_read(MC1);
+    mc_write(MC1, mc1);
+    return toggled == (unsigned char)(mc1 ^ 0x80);
+}
+
+/*
+ * The chip can only put the Sound Blaster personality on the handful of
+ * resources MC3 has room to encode, so these are the only routes worth
+ * attempting.  A card that has no jumpers is limited to exactly this set.
+ */
+static int INITPROC mad16_valid_route(unsigned int port, int irq, int dma)
+{
+    if (port != 0x220 && port != 0x240)
+        return 0;
+    if (irq != 5 && irq != 7)
+        return 0;
+    if (dma != 1 && dma != 3)
+        return 0;
+    return 1;
+}
+
+/*
+ * MC3 holds the SB route in three fields:
+ *
+ *      bit    2    SB port, clear = 0x220, set = 0x240
+ *      bits 7:6    IRQ, 00 = 7, 10 = 5, 11 = disabled, 01 invalid
+ *      bits 5:4    DMA, 00 = 1, 10 = 3, 11 = disabled, 01 invalid
+ *
+ * mad16_valid_route has already rejected anything the fields cannot express,
+ * so the invalid 01 pattern cannot be produced here.
+ */
+static unsigned char INITPROC mad16_mc3_for_sb(unsigned int port, int irq, int dma)
+{
+    unsigned char mc3 = MC3_GP_TIMER;
+
+    if (irq == 5)
+        mc3 |= 0x80;
+    if (dma == 3)
+        mc3 |= 0x20;
+    if (port == 0x240)
+        mc3 |= MC3_SB_240;
+    return mc3;
+}
+
+static int INITPROC codec_wait(unsigned int base)
+{
+    unsigned int timeout = 60000;
+
+    while (timeout-- != 0) {
+        if ((inb_p(base) & 0x80) == 0)
+            return 0;
+        inb_p(0x61);                  /* ISA bus recovery delay */
+    }
+    return -EIO;
+}
+
+static unsigned char INITPROC codec_read(unsigned int base, unsigned char reg,
+                                         unsigned char mce)
+{
+    unsigned int flags;
+    unsigned char value;
+
+    (void)codec_wait(base);
+    save_flags(flags);
+    clr_irq();
+    outb_p((unsigned char)((reg & 0x1F) | mce), base);
+    value = inb_p(base + 1);
+    restore_flags(flags);
+    return value;
+}
+
+static void INITPROC codec_write(unsigned int base, unsigned char reg,
+                                 unsigned char value, unsigned char mce)
+{
+    unsigned int flags;
+
+    (void)codec_wait(base);
+    save_flags(flags);
+    clr_irq();
+    outb_p((unsigned char)((reg & 0x1F) | mce), base);
+    outb_p(value, base + 1);
+    restore_flags(flags);
+}
+
+/*
+ * Leaving mode change enable takes a while to settle.  Two bounded passes keep
+ * the original long wait without needing a 32-bit loop counter.
+ */
+static void INITPROC codec_leave_mce(unsigned int base)
+{
+    unsigned int timeout;
+    unsigned char pass;
+
+    (void)codec_wait(base);
+    outb_p(0, base);
+    outb_p(0, base);
+
+    for (pass = 0; pass < 2; pass++) {
+        timeout = 40000;
+        while (timeout-- != 0 && (codec_read(base, 11, 0) & 0x20) != 0)
+            inb_p(0x61);
+    }
+}
+
+/*
+ * Bring up the attached AD1848 class codec.  Returns 0 if no codec answered,
+ * which is not fatal: the SB profile is still written.
+ */
+static int INITPROC codec_init(unsigned int base, unsigned char *mc5_extra)
+{
+    static const unsigned char init_values[32] = {
+        0xa8, 0xa8, 0x08, 0x08, 0x08, 0x08, 0x00, 0x00,
+        0x00, 0x0c, 0x02, 0x00, 0x8a, 0x01, 0x00, 0x00,
+        0x80, 0x00, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    unsigned char tmp, cs_compat = 0;
+    unsigned int i;
+
+    *mc5_extra = 0;
+    if (codec_wait(base) < 0 || (inb_p(base) & 0x80) != 0)
+        return 0;
+
+    /* Writable-register check, as Linux ad1848_detect does */
+    codec_write(base, 0, 0xaa, CODEC_MCE);
+    codec_write(base, 1, 0x45, CODEC_MCE);
+    if (codec_read(base, 0, CODEC_MCE) != 0xaa ||
+        codec_read(base, 1, CODEC_MCE) != 0x45)
+        return 0;
+    codec_write(base, 0, 0x45, CODEC_MCE);
+    codec_write(base, 1, 0xaa, CODEC_MCE);
+    if (codec_read(base, 0, CODEC_MCE) != 0x45 ||
+        codec_read(base, 1, CODEC_MCE) != 0xaa)
+        return 0;
+
+    codec_write(base, 12, 0x40, CODEC_MCE);
+    tmp = codec_read(base, 12, CODEC_MCE);
+    if (tmp & 0x80)
+        cs_compat = 1;
+
+    for (i = 0; i < 16; i++)
+        codec_write(base, (unsigned char)i, init_values[i], CODEC_MCE);
+    codec_write(base, 9, (unsigned char)(codec_read(base, 9, CODEC_MCE) | 0x04),
+        CODEC_MCE);
+    if ((tmp & 0xC0) == 0xC0) {
+        codec_write(base, 12,
+            (unsigned char)(codec_read(base, 12, CODEC_MCE) | 0x40), CODEC_MCE);
+        for (i = 16; i < 32; i++)
+            codec_write(base, (unsigned char)i, init_values[i], CODEC_MCE);
+    }
+    outb_p(0, base + 2);
+    codec_leave_mce(base);
+
+    if (cs_compat)
+        *mc5_extra = MC5_CFIX;
+    return 1;
+}
+
+int INITPROC mad16_early_init(unsigned int port, int irq, int dma)
+{
+    unsigned char mc[6];
+    unsigned char mc5_extra = 0;
+
+    mad16_profile_valid = 0;
+    if (!mad16_valid_route(port, irq, dma))
+        return -EINVAL;
+    if (!mad16_detect())
+        return -ENODEV;
+
+    mc[0] = MC1_DEFAULT & MC1_MASK;
+    mc[1] = (MC2_DEFAULT & MC2_OPL4) | MC2_CDSEL_OFF;
+    mc[2] = mad16_mc3_for_sb(port, irq, dma);
+    mc[3] = MC4_DEFAULT;
+    mc[4] = MC5_DEFAULT;        /* datasheet normal setting for an AD1848 */
+    mc[5] = MC6_DEFAULT;
+
+    if ((mc[5] & MC6_MPU_ENABLE) == 0)
+        mc[5] &= MC6_MPU_OFF;
+    else if ((mc[5] & MC6_MPU_IRQ) == 0x00 || (mc[5] & MC6_MPU_IRQ) == 0x08)
+        mc[5] = (unsigned char)((mc[5] & ~MC6_MPU_IRQ) | 0x18);
+
+    /* WSS side first, with SB switched off while the codec is set up */
+    mc_write(MC1, MC1_WSS_MODE);
+    mc_write(MC2, mc[1]);
+    mc_write(MC3, MC3_SB_OFF);
+    mc_write(MC4, mc[3]);
+    mc_write(MC5, mc[4]);
+    mc_write(MC6, mc[5]);
+    outb_p((dma == 3)? 0x03: 0x02, WSS_BASE);
+    (void)codec_init(CODEC_BASE, &mc5_extra);
+
+    mc[4] |= mc5_extra;
+    mc_write_profile(mc);
+    memcpy(mad16_mc, mc, sizeof(mad16_mc));
+    mad16_profile_valid = 1;
+    return 0;
+}
+
+
+
+#endif /* CONFIG_CHAR_DEV_DSP && CONFIG_SB_MAD16 */

--- a/elks/arch/i86/drivers/char/dsp-sb.c
+++ b/elks/arch/i86/drivers/char/dsp-sb.c
@@ -1,0 +1,1245 @@
+/*
+ * Sound Blaster /dev/dsp driver
+ *
+ * Playback only, mono, raw unsigned 8-bit PCM, through 8-bit ISA DMA on the
+ * primary 8237 (channel 1 or 3) using the classic DSP 0x14 single-block command
+ * and a time constant, so anything from a Sound Blaster 1.0 upwards works.
+ * There is no 16-bit DMA, no SB16 high-DMA mode, no recording, no runtime mixer
+ * control and no MIDI.  Sample format conversion belongs in user space.
+ *
+ * On an XT with a hard disk the card cannot keep its factory IRQ 5 and DMA 3:
+ * the hard disk controller owns both of those, so jumper the card for IRQ 7 and
+ * DMA 1.  The Amstrad PC1640 is typical here, assigning IRQ 5 to the hard disk
+ * controller, DMA 3 to the external hard disk controller, and leaving DMA 1
+ * spare for the expansion bus.
+ *
+ * One DMA block is in flight at a time and write() blocks until the previous
+ * block has drained.  The bounce buffer holds two blocks so the next one is
+ * copied in while the current one plays, which keeps the copy out of the window
+ * when the DMA engine is stopped; what is left there is the interrupt latency
+ * plus reprogramming the 8237 and the DSP.  Closing that remainder as well needs
+ * auto-init DMA (DSP 0x1C with 8237 mode 0x58) over a circular buffer, which
+ * also requires DSP 2.00 and so would drop Sound Blaster 1.0.
+ *
+ * Completion is detected from the card's interrupt.  The 8237 status register
+ * is deliberately never read: reading it clears the terminal-count latch for
+ * every channel on the chip, which would eat the completion the MFM disk
+ * driver is waiting for on channel 3.  If a card whose interrupt is never
+ * delivered has to be supported, poll the DMA count register instead, which
+ * has no such side effect.  Until then a wrong irq= shows up as a per-block
+ * timeout rather than working silently.
+ *
+ * /bootopts sb=port,irq,dma overrides the compiled-in settings, and sb=off
+ * skips the driver entirely.
+ */
+
+#include <linuxmt/config.h>
+
+#ifdef CONFIG_CHAR_DEV_DSP
+
+#include <linuxmt/types.h>
+#include <linuxmt/major.h>
+#include <linuxmt/fs.h>
+#include <linuxmt/kernel.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/mm.h>
+#include <linuxmt/memory.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/string.h>
+#include <linuxmt/soundcard.h>
+#include <linuxmt/init.h>
+#include <arch/io.h>
+#include <arch/irq.h>
+#include <arch/dma.h>
+#include <arch/segment.h>
+#include <arch/divmod.h>
+
+/*
+ * Every port access in this driver goes through the bus-recovery forms.  The
+ * xt-elks driver that worked on this machine built with CONFIG_XT_SLOW_ISA_IO=y
+ * and routed all 54 of its accesses through inb_p/outb_p (sb_dsp.c:46-52); that
+ * symbol does not exist in this tree, and these two sound files are the only
+ * drivers left using bare inb/outb - lp, kbd-scancode, serial-8250, mfmhd and
+ * directfd all still use the _p forms.
+ *
+ * On an 8 MHz Amstrad this matters.  Back-to-back accesses with no recovery
+ * cycle are dropped or mis-latched by slow ISA parts: the 8237 programming
+ * sequence writes the address and count as flip-flop pairs, so one lost byte
+ * points DMA at the wrong memory, and the OPTi password gate and the AD1848
+ * index/data pairs have the same exposure.  An emulator does not model bus
+ * recovery, which is why this reads clean in 86Box and breaks on real hardware.
+ */
+
+/* DSP register offsets from the card base address */
+#define SB_RESET        0x06        /* w  write 1 then 0 to reset the DSP */
+#define SB_READ_DATA    0x0A        /* r  DSP data */
+#define SB_WRITE_DATA   0x0C        /* rw bit 7 of read = write not ready */
+#define SB_READ_STATUS  0x0E        /* r  bit 7 = data available, acks IRQ */
+#define SB_MIXER_ADDR   0x04        /* w  mixer register select */
+#define SB_MIXER_DATA   0x05        /* rw mixer register value */
+
+/* DSP commands used here */
+#define DSP_DIRECT_DAC  0x10        /* one sample straight to the DAC */
+#define DSP_SET_RATE    0x40        /* followed by the time constant */
+#define DSP_DMA_OUT_8   0x14        /* followed by length-1, single block */
+#define DSP_HALT_DMA    0xD0
+#define DSP_SPEAKER_ON  0xD1
+#define DSP_GET_VERSION 0xE1
+#define DSP_READY       0xAA        /* reset acknowledge byte */
+
+/* Mixer registers, SB Pro layout, kept by the SB16 for compatibility */
+#define SB_MIX_VOICE    0x04
+#define SB_MIX_MIC      0x0A
+#define SB_MIX_OUTFILT  0x0E        /* SB Pro output mode, not a level */
+#define SB_MIX_MASTER   0x22
+#define SB_MIX_FM       0x26
+#define SB_MIX_CD       0x28
+#define SB_MIX_LINE     0x2E
+
+/*
+ * SB_MIX_OUTFILT is where the SB Pro selects mono or stereo output; it is not
+ * in the DSP command.  A card left in stereo mode takes two bytes per frame, so
+ * a mono stream is consumed at twice the intended rate: it plays at double
+ * speed with alternate samples going to opposite channels.  Linux does the
+ * equivalent in sbpro_audio_prepare_for_output(), which calls
+ * sb_mixer_set_stereo() on every playback rather than once at init.
+ *
+ * The filter bit polarity is the other way round from what the name suggests.
+ * Linux's sb_mixer.h says so outright: "FILT_ON 0 - Yes, 0 to turn it on, 1 for
+ * off".  Leaving it on is what an 8 kHz reconstruction wants.
+ */
+#define SB_MONO_DAC     0x00
+#define SB_STEREO_DAC   0x02
+#define SB_FILT_OFF     0x20
+#define SB_OUTFILT_MONO (SB_MONO_DAC)   /* mono, output filter engaged */
+
+/*
+ * Playback levels, as percentages, matching the xt-elks driver that worked on
+ * this hardware (SB_DEFAULT_MASTERVOL/SB_DEFAULT_PLAYVOL, sb_dsp.c:63-64).
+ * sb_mixer_lr_byte() packs them for whichever layout the card uses.
+ *
+ * The master and voice attenuators are in series ahead of the output amplifier,
+ * so both at full scale asks for the loudest analog path the card can produce
+ * and 8-bit material that already peaks near full scale clips in the mixer.
+ * These two values are the ones that were in use when playback was known good;
+ * do not treat them as a free parameter without listening.
+ *
+ * A DSP 3.xx card packs each level as two 3-bit fields at bits 7-5 and 3-1 -
+ * only the SB16 uses 4-bit fields.  That also explains why this card looks like
+ * it ORs 0x11 into every mixer read: bits 4 and 0 are the don't-care bits of the
+ * 3-bit packing and are simply not implemented, so a read can never confirm
+ * them.  Do not read-modify-write these registers.
+ *
+ * sbmix(1) sets them live, which is how to find the right value for a
+ * particular board without rebuilding.
+ */
+/*
+ * These are percentages, quantised by sb_mixer_lr_byte to the eight steps a
+ * 3-bit field has: (pct * 7 + 50) / 100.  100 lands on 7/7 and 85 on 6/7 - any
+ * value from 93 to 100, and from 79 to 92 respectively, gives the same byte, so
+ * these are mid-range choices rather than edge ones.
+ */
+/*
+ * Master deliberately stays off full scale.  7/7 drives this card's output
+ * stage into audible clipping with hot PCM material - confirmed by dropping
+ * the register live during playback, which cleaned the sound up immediately -
+ * and 5/7 is the level every "plays perfectly" verdict on this hardware was
+ * actually given at.  Any percentage from 65 to 78 packs to the same 5/7 byte.
+ */
+#define SB_DEFAULT_MASTERVOL 85     /* 6/7 - full scale clips this card */
+#define SB_DEFAULT_PLAYVOL   85     /* 6/7 */
+/*
+ * The FM input is turned right down because nothing here drives the OPL3, so
+ * all it contributes is its idle noise floor.
+ *
+ * This has to be done from the driver, not from sbmix(1).  sbmix resets the DSP
+ * on every run, and this card restores its own mixer defaults afterwards, which
+ * puts FM back to 60% - so a level written by sbmix is undone before the tool
+ * has even finished.  Writing it here, in the open path where no reset follows,
+ * is what makes it stick: 0x26 then reads 0x11, which is 0/7 plus the two
+ * don't-care bits of the 3-bit packing.
+ */
+#define SB_DEFAULT_FMVOL     0
+
+/*
+ * SB_BOUNCE is one DMA block and is what SNDCTL_DSP_GETBLKSIZE reports.  Two
+ * of them are claimed as a single buffer so the next block can be copied in
+ * while the current one is still playing.
+ *
+ * DSP 0x14 is a single-shot command, so a transfer has to be restarted for
+ * every block, and the copy used to happen after the previous block had
+ * drained.  That put a 4 KB far memcpy inside the window when nothing was
+ * playing, which is milliseconds on an 8 MHz machine and was plainly audible
+ * as a gap once per block: twice a second at 8000 Hz, five times a second at
+ * 20000 Hz.  Filling the idle half in advance leaves only the 8237 and DSP
+ * reprogramming between blocks.
+ */
+#define SB_BOUNCE       CONFIG_SB_BOUNCE
+#define SB_BUFFER       (2 * SB_BOUNCE)
+#define SB_MIN_RATE     4000U
+/*
+ * 20 kHz is below half CD rate, divides the 1 MHz time-constant clock exactly
+ * and is the documented ceiling for DSP 0x14 without the high-speed commands.
+ */
+#define SB_MAX_RATE     20000U
+/*
+ * PIO playback is not bound by that ceiling.  It never issues DSP 0x14: every
+ * sample goes out through the direct DAC command with the 8253 setting the
+ * pace, so the limit is how fast the CPU can hand bytes over, not what the DSP
+ * will accept.  22050 leaves an 8 MHz 8086 about 45us per sample against
+ * roughly 12us of port I/O, which is comfortable; the rate is still quantised
+ * to whole PIT ticks, so the reported rate is what will actually be produced.
+ */
+#define SB_MAX_RATE_PIO 22050U
+
+#define SB_TC_CLOCK     1000000UL   /* time constant reference clock */
+
+/* LPT1 shares IRQ 7 with the card; bit 4 of its control register is IRQ enable */
+#define LPT1_CONTROL    0x37A
+#define LPT1_CTRL_IDLE  0x0C        /* INIT + SELECT_IN, interrupt disabled */
+
+/* /bootopts sb=port,irq,dma, parsed in init/main.c; -1 means not given */
+extern int sb_port_opt;
+extern int sb_irq_opt;
+extern int sb_dma_opt;
+extern int dma_extwrite_opt;    /* /bootopts dmaxw=1: 8237 Extended Write */
+#ifdef CONFIG_SB_MAD16
+extern int mad16_opt;
+extern int mad16_port_opt;
+extern int mad16_irq_opt;
+extern int mad16_dma_opt;
+#endif
+
+static unsigned int sb_base;
+static unsigned char sb_dma;
+static unsigned char sb_irq_line;
+static unsigned char sb_dsp_ver_major;
+static unsigned char sb_dsp_ver_minor;
+static unsigned char sb_present;
+static unsigned char sb_opened;
+
+static unsigned int sb_rate = 8000;
+static unsigned char sb_timeconst;
+/*
+ * PIO playback, selected with sb=port,irq,0 in /bootopts.
+ *
+ * The Amstrad PC1512/1640 chipset does not service DRQ the way a true XT does -
+ * mfmhd.c documents the same limitation for the hard disk on DRQ3, and on this
+ * machine the sound card's DMA channel is audibly broken: DMA playback is
+ * distorted while the DSP's direct DAC command, which touches no 8237 at all,
+ * is clean.  In PIO mode every sample is handed to the DSP by the CPU.
+ *
+ * The cost is real and unavoidable: the CPU can do nothing else while a block
+ * plays, because an 8086 has no time to spare between samples at 8 kHz.  The
+ * write() call therefore runs to completion with interrupts still enabled but
+ * the processor fully occupied, which is exactly what the hardware demands.
+ */
+static unsigned char sb_pio_mode;
+static unsigned int sb_full_play_ticks;  /* <= 103 by construction: fits 16 bits */
+
+/* cached 8237 ports for the configured channel */
+static unsigned int sb_dma_addr_port;
+static unsigned int sb_dma_page_reg;
+static unsigned int sb_dma_count_port;
+static unsigned char sb_dma_mask;
+
+static segment_s *sb_bounce_seg;
+static unsigned int sb_bounce_dma_off;   /* A15..A0 of the buffer */
+static unsigned char sb_bounce_dma_page; /* A23..A16 of the buffer */
+static unsigned char sb_fill;            /* half to copy into next, 0 or 1 */
+
+static unsigned char sb_active;          /* a block is playing */
+static unsigned int sb_active_len;
+static jiff_t sb_active_min_done;        /* earliest believable completion */
+static volatile unsigned char sb_dma_done;
+static struct wait_queue sb_wait;
+
+/* GETERROR payload: 104 bytes, far too big for the 640-byte kernel stack */
+static struct audio_errinfo sb_errinfo;
+static oss_int32_t sb_play_underruns;
+
+/*
+ * ceil(len * HZ / byte_rate) using the kernel's 32-bit divide helper rather
+ * than a hand-rolled 16-bit long division.  len * HZ overflows 16 bits for any
+ * buffer above 655 bytes, so the numerator has to be long.
+ */
+static unsigned int FARPROC sb_ceil_play_ticks(unsigned int len,
+                                               unsigned int byte_rate)
+{
+    unsigned int rem = byte_rate;
+    unsigned int ticks;
+
+    if (!byte_rate)
+        return 1;
+    ticks = (unsigned int)__divmod((unsigned long)len * HZ, &rem);
+    if (rem)
+        ticks++;
+    return ticks? ticks: 1;
+}
+
+/* Time constant the DSP wants for a byte rate: 256 - 1000000/rate. */
+static unsigned char FARPROC sb_timeconst_for(unsigned int byte_rate)
+{
+    unsigned int rem = byte_rate;
+    unsigned int div;
+
+    if (!byte_rate)
+        return 0;
+    div = (unsigned int)__divmod(SB_TC_CLOCK, &rem);
+    if (div > 255U)
+        div = 255U;
+    return (unsigned char)(256U - div);
+}
+
+static void FARPROC sb_rate_cache(unsigned int rate)
+{
+    sb_rate = rate;
+    sb_timeconst = sb_timeconst_for(rate);
+    sb_full_play_ticks = sb_ceil_play_ticks(SB_BOUNCE, rate);
+}
+
+/*
+ * Rate the card will really run at, which is what the caller gets back from
+ * SNDCTL_DSP_SPEED: the time constant quantises the divisor, so a requested
+ * 11025 Hz comes back as something a percent or so away.
+ */
+static unsigned int FARPROC sb_actual_rate(void)
+{
+    unsigned int rem = (unsigned int)(256U - sb_timeconst);
+
+    return (unsigned int)__divmod(SB_TC_CLOCK, &rem);
+}
+
+/*
+ * 16 bits on purpose: the count is bounded by ceil(SB_BOUNCE*HZ/4000) = 103,
+ * so carrying it as jiff_t forced 32-bit register-pair arithmetic through
+ * every block start.  It is widened exactly where it meets jiffies().
+ */
+static unsigned int FARPROC sb_play_ticks(unsigned int len)
+{
+    if (len == SB_BOUNCE)
+        return sb_full_play_ticks;
+    return sb_ceil_play_ticks(len, sb_rate);
+}
+
+static int FARPROC sb_time_reached(jiff_t when)
+{
+    jiff_t now = jiffies();
+
+    return now == when || time_after(now, when);
+}
+
+/*
+ * A block cannot legitimately finish before its samples have had time to play.
+ * With a single buffer, honouring an early or spurious interrupt would hand the
+ * buffer back while the card was still reading it.
+ */
+static int FARPROC sb_completion_mature(void)
+{
+    return !sb_active || sb_time_reached(sb_active_min_done);
+}
+
+static int FARPROC dsp_wait_w(void)
+{
+    jiff_t deadline = jiffies() + (HZ / 10) + 1;
+
+    do {
+        if ((inb_p(sb_base + SB_WRITE_DATA) & 0x80) == 0)
+            return 0;
+        inb_p(0x61);            /* delay: a read plus its recovery cycle */
+    } while (!time_after(jiffies(), deadline));
+
+    return -EIO;
+}
+
+static int FARPROC dsp_cmd(unsigned char v)
+{
+    if (dsp_wait_w() < 0)
+        return -EIO;
+    outb_p(v, sb_base + SB_WRITE_DATA);
+    return 0;
+}
+
+static int FARPROC dsp_read_byte(unsigned char *value)
+{
+    jiff_t deadline = jiffies() + (HZ / 10) + 1;
+
+    do {
+        if ((inb_p(sb_base + SB_READ_STATUS) & 0x80) != 0) {
+            *value = inb_p(sb_base + SB_READ_DATA);
+            return 0;
+        }
+        inb_p(0x61);
+    } while (!time_after(jiffies(), deadline));
+
+    return -EIO;
+}
+
+static int INITPROC sb_reset(void)
+{
+    int i;
+
+    outb_p(1, sb_base + SB_RESET);
+    for (i = 0; i < 200; i++)       /* the DSP needs 3us of reset */
+        inb_p(0x61);
+    outb_p(0, sb_base + SB_RESET);
+    for (i = 0; i < 500; i++) {
+        if ((inb_p(sb_base + SB_READ_STATUS) & 0x80) != 0) {
+            if (inb_p(sb_base + SB_READ_DATA) == DSP_READY)
+                return 0;
+        }
+    }
+    return -ENODEV;
+}
+
+static int INITPROC sb_read_dsp_version(void)
+{
+    if (dsp_cmd(DSP_GET_VERSION) < 0)
+        return -EIO;
+    if (dsp_read_byte(&sb_dsp_ver_major) < 0 ||
+        dsp_read_byte(&sb_dsp_ver_minor) < 0) {
+        sb_dsp_ver_major = 0;
+        sb_dsp_ver_minor = 0;
+        return -EIO;
+    }
+    return 0;
+}
+
+static void INITPROC sb_dma_cache(void)
+{
+    if (sb_dma == 1) {
+        sb_dma_addr_port = DMA_ADDR_1;
+        sb_dma_count_port = DMA_CNT_1;
+        sb_dma_page_reg = DMA_PAGE_1;
+    } else {
+        sb_dma_addr_port = DMA_ADDR_3;
+        sb_dma_count_port = DMA_CNT_3;
+        sb_dma_page_reg = DMA_PAGE_3;
+    }
+    sb_dma_mask = sb_dma;
+}
+
+/*
+ * The 8237 wants a page byte and a 16-bit offset.  LINADDR resolves a segment
+ * in real mode and a selector under CONFIG_286_PMODE, so it is the only correct
+ * way to get a physical address out of a segment_s: seg->base is a selector in
+ * protected mode and shifting it left by 4 would point at nothing.
+ */
+static void INITPROC sb_dma_addr_cache(addr_t phys)
+{
+    sb_bounce_dma_off = (unsigned int)phys;
+    sb_bounce_dma_page = (unsigned char)(phys >> 16);
+}
+
+/*
+ * A single 8237 transfer cannot step across a physical 64K page.  The whole
+ * two-block buffer is checked, not one block, so that adding a half-buffer
+ * offset to the cached low word can never carry into the page byte.
+ */
+static int INITPROC sb_dma_unusable(addr_t phys)
+{
+    if (phys + (addr_t)SB_BUFFER > 0x100000UL)      /* must be DMA-able */
+        return 1;
+    return ((phys & 0xffffUL) + (addr_t)SB_BUFFER - 1) > 0xffffUL;
+}
+
+/* Caller holds interrupts off: the address flip-flop is shared chip state. */
+static void FARPROC sb_dma_program(unsigned int off, unsigned int len)
+{
+    union {
+        unsigned int word;
+        unsigned char byte[2];
+    } address, count;
+
+    address.word = sb_bounce_dma_off + off;
+    count.word = len - 1U;              /* the 8237 is loaded with count-1 */
+
+    outb_p(sb_dma_mask | 4, DMA1_MASK_REG);       /* mask the channel */
+    outb_p(0, DMA1_CLEAR_FF_REG);
+    outb_p(DMA_MODE_WRITE | sb_dma, DMA1_MODE_REG);
+    outb_p(address.byte[0], sb_dma_addr_port);
+    outb_p(address.byte[1], sb_dma_addr_port);
+    outb_p(sb_bounce_dma_page, sb_dma_page_reg);
+    outb_p(count.byte[0], sb_dma_count_port);
+    outb_p(count.byte[1], sb_dma_count_port);
+    outb_p(sb_dma_mask, DMA1_MASK_REG);           /* unmask, transfer armed */
+}
+
+static void FARPROC sb_dma_stop(void)
+{
+    outb_p(sb_dma_mask | 4, DMA1_MASK_REG);
+}
+
+/*
+ * Pace samples off the 8253 rather than a calibrated delay loop.  Timer 0 runs
+ * at 1.193182 MHz regardless of CPU speed, so counting its ticks gives the same
+ * pitch on any machine, where a spin loop would have to be retuned per host and
+ * would drift with cache and refresh.  The counter counts DOWN and wraps at
+ * 65536, so elapsed ticks are (previous - current) & 0xFFFF.
+ */
+#define PIT_CH0         0x40
+#define PIT_CMD         0x43
+#define PIT_LATCH0      0x00        /* counter latch, channel 0 */
+
+static unsigned int FARPROC pit_read(void)
+{
+    unsigned int flags, lo, hi;
+
+    save_flags(flags);
+    clr_irq();
+    outb_p(PIT_LATCH0, PIT_CMD);
+    lo = inb_p(PIT_CH0);
+    hi = inb_p(PIT_CH0);
+    restore_flags(flags);
+    return (hi << 8) | lo;
+}
+
+/*
+ * Play one buffer a sample at a time.  Returns -EINTR if a signal arrives, so
+ * a player can still be killed part way through a long block.
+ */
+static int FARPROC sb_pio_play(unsigned int off, unsigned int len)
+{
+    unsigned int ticks_per_sample;
+    unsigned int prev, now, elapsed;
+    unsigned int i;
+    unsigned char sample;
+
+    /* 1193182 / rate, computed once per block rather than per sample */
+    {
+        unsigned int rem = sb_rate;
+        ticks_per_sample = (unsigned int)__divmod(1193182UL, &rem);
+    }
+    if (!ticks_per_sample)
+        ticks_per_sample = 1;
+
+    prev = pit_read();
+    for (i = 0; i < len; i++) {
+        sample = peekb((word_t)(off + i), sb_bounce_seg->base);
+        if (dsp_cmd(DSP_DIRECT_DAC) < 0 || dsp_cmd(sample) < 0)
+            return -EIO;
+        /* wait out this sample's period on the 8253 */
+        do {
+            now = pit_read();
+            elapsed = (prev - now) & 0xFFFF;
+        } while (elapsed < ticks_per_sample);
+        prev = (prev - ticks_per_sample) & 0xFFFF;
+        if ((i & 0x3FF) == 0 && current->signal)
+            return -EINTR;
+    }
+    return 0;
+}
+
+static int FARPROC sb_dsp_start(unsigned int len)
+{
+    unsigned int n = len - 1U;
+
+    /*
+     * The time constant is resent before EVERY block.  A real SB DSP latches
+     * it across 0x14 transfers, and gating the resend behind a rate-change
+     * flag measured fine on 86Box's SB Pro - but per-block resend is the only
+     * behaviour ever validated on the real OPTi 82C929, and a distortion
+     * report that arrived alongside the gating (later traced mainly to the
+     * master level being at full scale) was reason enough to keep the proven
+     * sequence.  Two dsp_cmd handshakes per 4096-byte block is a small price.
+     */
+    if (dsp_cmd(DSP_SET_RATE) < 0 || dsp_cmd(sb_timeconst) < 0)
+        return -EIO;
+    if (dsp_cmd(DSP_DMA_OUT_8) < 0 ||
+        dsp_cmd((unsigned char)(n & 0xFF)) < 0 ||
+        dsp_cmd((unsigned char)(n >> 8)) < 0)
+        return -EIO;
+    return 0;
+}
+
+static void FARPROC sb_idle(void)
+{
+    sb_dma_stop();
+    sb_active = 0;
+    sb_active_len = 0;
+    sb_dma_done = 0;
+    sb_active_min_done = 0;
+}
+
+static int FARPROC sb_start(unsigned int off, unsigned int len)
+{
+    unsigned int flags;
+    unsigned int ticks;
+    int ret;
+
+    /*
+     * PIO plays the whole block here and now, so sb_active is deliberately
+     * left clear: there is no completion interrupt to wait for, and anything
+     * that called sb_wait_complete afterwards would block forever.
+     */
+    if (sb_pio_mode)
+        return sb_pio_play(off, len);
+
+    ticks = sb_play_ticks(len);
+
+    save_flags(flags);
+    clr_irq();
+    sb_dma_done = 0;
+    sb_dma_program(off, len);
+    sb_active = 1;
+    sb_active_len = len;
+    sb_active_min_done = jiffies() + ((ticks > 1)? ticks - 1: 0);
+    restore_flags(flags);
+
+    ret = sb_dsp_start(len);
+    if (ret < 0) {
+        save_flags(flags);
+        clr_irq();
+        sb_idle();
+        sb_play_underruns++;
+        restore_flags(flags);
+    }
+    return ret;
+}
+
+static void FARPROC sb_halt(void)
+{
+    unsigned int flags;
+
+    (void)dsp_cmd(DSP_HALT_DMA);
+    save_flags(flags);
+    clr_irq();
+    sb_idle();
+    sb_fill = 0;
+    restore_flags(flags);
+}
+
+/*
+ * The mixer index and data ports need a real delay between them.  The OPTi
+ * 82C929 reference driver writes the index, waits a millisecond through INT
+ * 15h/86h, writes the data, then waits again (Knipperts, UNITS/SBPRO.PAS,
+ * Mixer_Write); its companion SBFIX TSR spaces the same two writes two timer
+ * ticks apart and says outright that "SB mixerchip needs a little delay".
+ *
+ * Issuing the two outb instructions back to back, which is what this driver did,
+ * loses the write entirely on such a card.  That is why reads came back as
+ * nonsense and why the output mode never changed: a mono stream was left playing
+ * on a card still in stereo, which splits it across the channels and sounds like
+ * one channel stuttering and the other badly aliased.
+ *
+ * inb from port 0x61 is the delay idiom already used for the DSP handshake; each
+ * one is roughly a microsecond of ISA bus time.  Mixer writes only happen at
+ * init and at open, so erring long here costs nothing.
+ */
+#define SB_MIXER_DELAY  1200        /* ~3ms: each inb_p is a read plus a recovery write */
+
+static void FARPROC sb_mixer_delay(void)
+{
+    int i;
+
+    for (i = 0; i < SB_MIXER_DELAY; i++)
+        inb_p(0x61);
+}
+
+static void FARPROC sb_mixer_write(unsigned char reg, unsigned char value)
+{
+    outb_p(reg, sb_base + SB_MIXER_ADDR);
+    sb_mixer_delay();
+    outb_p(value, sb_base + SB_MIXER_DATA);
+    sb_mixer_delay();
+}
+
+/* A Sound Blaster 1.x or 2.0 has no mixer at all. */
+static int FARPROC sb_has_mixer(void)
+{
+    return sb_dsp_ver_major == 0 || sb_dsp_ver_major >= 3;
+}
+
+/*
+ * Select mono output with the filter engaged.  The SB Pro is the model that
+ * keeps this in the mixer; a plain SB has no mixer, and the SB16 takes its
+ * channel count from the DSP command instead, so restrict this to DSP 3.xx as
+ * Linux does with its MDL_SBPRO test.
+ *
+ * Linux does a read-modify-write here.  We write the register outright because
+ * this is a two-bit register whose other bits we would only be preserving by
+ * luck: on a MAD16 the mixer does not read back faithfully, and honouring bits
+ * read from it would just write garbage back.
+ */
+/*
+ * Deliberately does nothing.  The xt-elks driver that worked on this hardware
+ * never wrote mixer register 0x0E in any shipped build - its whole stereo path
+ * sits inside #ifdef CONFIG_SB_STEREO and that symbol is "not set" in its
+ * config, so the only mixer registers it ever touched were 0x22 and 0x04.
+ * Writing 0x0E is therefore not required to get mono out of this card, and the
+ * card is left in whatever output mode it powered up in, exactly as before.
+ *
+ * Kept as an empty function rather than deleted so the ioctl call sites still
+ * document where a card that genuinely needs the write would want it.
+ */
+/*
+ * Mixer 0x0E bit 5 bypasses the SB Pro's output filter, a low pass around
+ * 3.2kHz meant for low rate 8-bit playback.  Leaving it engaged above about
+ * 8kHz throws away most of what the higher rate was for, so it is switched by
+ * rate rather than left at the card's power-on default.  Bit 1 (stereo) stays
+ * clear: this driver is mono only.
+ */
+#define SB_MIX_OUTMODE  0x0E
+#define SB_OUT_FILT_OFF 0x20
+
+static void FARPROC sb_set_output_mode(void)
+{
+    if (sb_has_mixer())
+        sb_mixer_write(SB_MIX_OUTMODE,
+            (unsigned char)((sb_rate > 8000U)? SB_OUT_FILT_OFF: 0x00));
+    return;
+}
+
+
+/*
+ * Cards can come out of reset with the voice or master level at zero, which
+ * looks exactly like a driver that runs but produces no sound, so both are
+ * always programmed rather than left at whatever reset gave us.
+ *
+ * The inputs are muted for the opposite reason.  This driver plays PCM and
+ * nothing else, but the FM synthesiser, CD, line and microphone inputs are
+ * summed into the same output, at whatever level the card powered up with -
+ * 57% for FM on the board this was tested against.  Nothing initialises the FM
+ * section, so that is somebody else's noise added to our output for no benefit.
+ */
+/*
+ * A DSP 3.xx card packs these levels as two 3-bit fields at bits 7-5 and 3-1,
+ * not two 4-bit fields; only the SB16 uses 4 bits.  That is also why this card
+ * appears to OR 0x11 into every read: bits 4 and 0 are the don't-care bits of
+ * the 3-bit packing, so they simply do not exist in the register file.
+ */
+static unsigned char FARPROC sb_mixer_lr_byte(unsigned int l, unsigned int r)
+{
+    if (sb_dsp_ver_major >= 4)          /* SB16: 4-bit fields, 7-4 and 3-0 */
+        return (unsigned char)((((l * 15U + 50U) / 100U) << 4) |
+                                ((r * 15U + 50U) / 100U));
+    /* SB Pro and MAD16: 3-bit fields at 7-5 and 3-1 */
+    return (unsigned char)((((l * 7U + 50U) / 100U) << 5) |
+                           (((r * 7U + 50U) / 100U) << 1));
+}
+
+static void FARPROC sb_mixer_program(void)
+{
+    if (!sb_has_mixer())
+        return;
+    sb_mixer_write(SB_MIX_MASTER, sb_mixer_lr_byte(SB_DEFAULT_MASTERVOL,
+                                                   SB_DEFAULT_MASTERVOL));
+    sb_mixer_write(SB_MIX_VOICE, sb_mixer_lr_byte(SB_DEFAULT_PLAYVOL,
+                                                  SB_DEFAULT_PLAYVOL));
+    sb_mixer_write(SB_MIX_FM, sb_mixer_lr_byte(SB_DEFAULT_FMVOL,
+                                               SB_DEFAULT_FMVOL));
+    sb_set_output_mode();
+}
+
+/*
+ * Programmed again on every open rather than only at init.  A DSP reset makes
+ * this card restore its own mixer defaults, which puts the FM input back to 60%
+ * and undoes the mute, so anything that has touched the card since boot leaves
+ * state we have to reassert rather than assume.
+ */
+static void INITPROC sb_mixer_init(void)
+{
+    sb_mixer_program();
+}
+
+/*
+ * SB Pro, MAD16 and many compatibles hold their interrupt asserted until the
+ * DSP read path is serviced, so drain it rather than just reading status once.
+ */
+static void sb_dsp_irq_ack(void)
+{
+    unsigned int n = 0;
+
+    while (n < 8 && (inb_p(sb_base + SB_READ_STATUS) & 0x80) != 0) {
+        inb_p(sb_base + SB_READ_DATA);
+        n++;
+    }
+}
+
+/*
+ * Must not be FARPROC: request_irq stores a near pointer and the trampoline
+ * calls it with KERNEL_CS.  The PIC end-of-interrupt is issued by the irqit
+ * wrapper, so this must not touch the PIC.  It can also be entered with no
+ * transfer running, both from a PIC spurious interrupt on irq 7 and from a
+ * card that interrupts after sb_halt().
+ */
+static void sb_interrupt(int irq, struct pt_regs *regs)
+{
+
+    sb_dsp_irq_ack();
+    if (!sb_active)
+        return;
+    sb_dma_done = 1;
+    wake_up(&sb_wait);
+}
+
+static int FARPROC sb_block_complete(void)
+{
+    if (!sb_dma_done)
+        return 0;
+    return sb_completion_mature();
+}
+
+/*
+ * Wait for the block in flight.
+ *
+ * The deadline is only a backstop against a card whose interrupt never arrives,
+ * so it is deliberately generous: twice the block's own play time plus two
+ * seconds.  A real card clocks the transfer from its own sample clock and
+ * finishes in exactly the play time, but an emulated one is driven by the host
+ * audio stack, which can stall DMA for a large fraction of a second while it
+ * buffers or resamples.  Half a second of slack was measured to be too little
+ * there.  Erring long costs nothing: it only changes how quickly a mis-set
+ * irq= reports failure, and playback itself always ends on the interrupt.
+ */
+static int FARPROC sb_wait_complete(unsigned int len)
+{
+    jiff_t deadline = jiffies() + sb_play_ticks(len) * 2 + (2 * HZ) + 1;
+    unsigned int flags;
+
+    for (;;) {
+        prepare_to_wait_interruptible(&sb_wait);
+        if (sb_block_complete()) {
+            finish_wait(&sb_wait);
+            break;
+        }
+        if (current->signal) {
+            finish_wait(&sb_wait);
+            sb_halt();
+            return -EINTR;
+        }
+        if (time_after(jiffies(), deadline)) {
+            finish_wait(&sb_wait);
+            sb_play_underruns++;
+            sb_halt();
+            return -EIO;
+        }
+        /*
+         * Sleep to the next actual event, not the next clock tick.  The
+         * completion interrupt wakes this task through sb_wait; the timer is
+         * only needed for an early interrupt gated by sb_completion_mature()
+         * (no further interrupt will come, so wake at the maturity time) and
+         * for the no-interrupt backstop.  Sleeping in 1-jiffy slices here
+         * cost about fifty scheduler round trips per block.  A deadline that
+         * has just slipped past is safe: schedule() treats timeout <= jiffies
+         * as already expired and keeps the task runnable.
+         */
+        current->timeout = (sb_dma_done? sb_active_min_done: deadline) + 1;
+        do_wait();
+        current->timeout = 0;
+        finish_wait(&sb_wait);
+    }
+
+    save_flags(flags);
+    clr_irq();
+    sb_idle();
+    restore_flags(flags);
+    sb_dsp_irq_ack();
+    return 0;
+}
+
+/*
+ * Copy into the idle half first, then wait for the playing half.  sb_fill only
+ * advances once the half it names has been handed to the card, so it always
+ * names the half the 8237 is not reading, and the copy overlaps playback of the
+ * other one.  When the wait returns, the next block is already in memory and
+ * only needs the chip programmed.
+ */
+static int FARPROC sb_queue_chunk(char *buf, unsigned int len)
+{
+    unsigned int off;
+    int ret;
+
+    if (len > SB_BOUNCE)            /* would overrun one half of the buffer */
+        return -EINVAL;
+    if (verify_area(VERIFY_READ, buf, len) != 0)
+        return -EFAULT;
+
+    off = sb_fill? SB_BOUNCE: 0;
+    fmemcpyb((void *)off, sb_bounce_seg->base, buf, current->t_regs.ds, len);
+
+    if (sb_active) {
+        ret = sb_wait_complete(sb_active_len);
+        if (ret < 0)
+            return ret;
+    }
+    ret = sb_start(off, len);
+    if (ret < 0)
+        return ret;
+    sb_fill ^= 1;
+    return 0;
+}
+
+static int FARPROC sb_open_impl(struct inode *inode, struct file *file)
+{
+
+    if (!sb_present || !sb_bounce_seg)
+        return -ENODEV;
+    if (MINOR(inode->i_rdev) != 0)
+        return -ENODEV;
+    if (sb_opened)
+        return -EBUSY;
+
+#ifdef CONFIG_SB_MAD16
+    /* something else may have moved the SB personality since we set it up */
+    mad16_restore_profile();
+#endif
+    (void)dsp_cmd(DSP_SPEAKER_ON);
+    sb_mixer_program();         /* a DSP reset may have undone all of it */
+    sb_play_underruns = 0;
+    sb_fill = 0;
+    sb_rate_cache(sb_rate);
+    sb_idle();
+    sb_opened = 1;
+    return 0;
+}
+
+static void FARPROC sb_release_impl(struct inode *inode, struct file *file)
+{
+
+    if (sb_active)
+        (void)sb_wait_complete(sb_active_len);
+    sb_halt();
+    sb_opened = 0;
+}
+
+/* No capture path, so a reader gets end of file rather than an error. */
+static size_t sb_read(struct inode *inode, struct file *file, char *buf,
+                      size_t count)
+{
+    return 0;
+}
+
+/*
+ * Loop internally over DMA-sized blocks so a caller that ignores the return
+ * value still plays all of its data.  A partial write reports the bytes that
+ * were accepted; the error is only returned when nothing at all was written,
+ * which is what lets a caller safely retry on EINTR.
+ */
+static size_t FARPROC sb_write_impl(struct inode *inode, struct file *file,
+                                    char *buf, size_t count)
+{
+    size_t done = 0;
+    unsigned int chunk;
+    int ret;
+
+
+    if (!(file->f_mode & FMODE_WRITE))
+        return -EINVAL;
+
+    while (done < count) {
+        chunk = (unsigned int)(count - done);
+        if (chunk > SB_BOUNCE)
+            chunk = SB_BOUNCE;
+        ret = sb_queue_chunk(buf + done, chunk);
+        if (ret < 0)
+            return done? done: (size_t)ret;
+        done += chunk;
+    }
+    return done;
+}
+
+static int FARPROC sb_get_arg(char *arg, void *dst, size_t len)
+{
+    if (!arg)
+        return -EINVAL;
+    return verified_memcpy_fromfs(dst, arg, len)? -EFAULT: 0;
+}
+
+static int FARPROC sb_put_arg(char *arg, void *src, size_t len)
+{
+    if (!arg)
+        return -EINVAL;
+    return verified_memcpy_tofs(arg, src, len)? -EFAULT: 0;
+}
+
+static int FARPROC sb_ioctl_impl(struct inode *inode, struct file *file,
+                                 int cmd, char *arg)
+{
+    oss_int32_t val;
+    unsigned int rate;
+    int ret;
+
+
+    switch (cmd) {
+    case SNDCTL_DSP_RESET:
+        sb_halt();
+        return 0;
+
+    case SNDCTL_DSP_SYNC:
+        if (sb_active) {
+            ret = sb_wait_complete(sb_active_len);
+            if (ret < 0)
+                return ret;
+        }
+        sb_halt();
+        return 0;
+
+    case SNDCTL_DSP_POST:
+        return 0;
+
+    case SNDCTL_DSP_SPEED:
+        ret = sb_get_arg(arg, &val, sizeof(val));
+        if (ret)
+            return ret;
+        if (val > 0) {                  /* 0 means read the current rate */
+            unsigned int ceiling = sb_pio_mode? SB_MAX_RATE_PIO: SB_MAX_RATE;
+
+            rate = (val > (oss_int32_t)ceiling)? ceiling:
+                   (val < (oss_int32_t)SB_MIN_RATE)? SB_MIN_RATE:
+                   (unsigned int)val;
+            sb_rate_cache(rate);
+        }
+        val = (oss_int32_t)sb_actual_rate();
+        return sb_put_arg(arg, &val, sizeof(val));
+
+    case SNDCTL_DSP_SETFMT:
+        ret = sb_get_arg(arg, &val, sizeof(val));
+        if (ret)
+            return ret;
+        if (val != (oss_int32_t)AFMT_QUERY && val != (oss_int32_t)AFMT_U8)
+            return -EINVAL;
+        val = (oss_int32_t)AFMT_U8;
+        return sb_put_arg(arg, &val, sizeof(val));
+
+    case SNDCTL_DSP_GETFMTS:
+        val = (oss_int32_t)AFMT_U8;
+        return sb_put_arg(arg, &val, sizeof(val));
+
+    /*
+     * Mono only: accept a request for one channel, reject two.  Both of these
+     * program the hardware rather than just agreeing with the caller, because
+     * on the SB Pro the channel count lives in a mixer register and reporting
+     * mono while the card is still wired for stereo is how a mono stream ends
+     * up played at double speed.
+     */
+    case SNDCTL_DSP_CHANNELS:
+        ret = sb_get_arg(arg, &val, sizeof(val));
+        if (ret)
+            return ret;
+        if (val != 0 && val != 1)
+            return -EINVAL;
+        sb_set_output_mode();
+        val = 1;
+        return sb_put_arg(arg, &val, sizeof(val));
+
+    case SNDCTL_DSP_STEREO:
+        ret = sb_get_arg(arg, &val, sizeof(val));
+        if (ret)
+            return ret;
+        if (val != 0)
+            return -EINVAL;
+        sb_set_output_mode();
+        val = 0;
+        return sb_put_arg(arg, &val, sizeof(val));
+
+    case SNDCTL_DSP_GETBLKSIZE:
+        val = (oss_int32_t)SB_BOUNCE;
+        return sb_put_arg(arg, &val, sizeof(val));
+
+    case SNDCTL_DSP_GETERROR:
+        memset(&sb_errinfo, 0, sizeof(sb_errinfo));
+        sb_errinfo.play_underruns = sb_play_underruns;
+        sb_play_underruns = 0;
+        return sb_put_arg(arg, &sb_errinfo, sizeof(sb_errinfo));
+    }
+
+    return -EINVAL;
+}
+
+/*
+ * The file_operations slots have to be near-callable, so these thin wrappers
+ * are what keeps the body of the driver in far text.
+ */
+static int sb_open(struct inode *inode, struct file *file)
+{
+    return sb_open_impl(inode, file);
+}
+
+static void sb_release(struct inode *inode, struct file *file)
+{
+    sb_release_impl(inode, file);
+}
+
+static size_t sb_write(struct inode *inode, struct file *file, char *buf,
+                       size_t count)
+{
+    return sb_write_impl(inode, file, buf, count);
+}
+
+static int sb_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
+{
+    return sb_ioctl_impl(inode, file, cmd, arg);
+}
+
+static struct file_operations sb_dsp_fops = {
+    NULL,                       /* lseek */
+    sb_read,                    /* read */
+    sb_write,                   /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    sb_ioctl,                   /* ioctl */
+    sb_open,                    /* open */
+    sb_release                  /* release */
+};
+
+/*
+ * Claim a bounce buffer the 8237 can actually reach.  seg_alloc gives no
+ * placement guarantee, so keep the rejects held until a usable block turns up,
+ * which stops the allocator handing back the same unusable one.
+ */
+#define SB_ALLOC_TRIES  4
+
+static addr_t INITPROC sb_alloc_bounce(void)
+{
+    segment_s *reject[SB_ALLOC_TRIES];
+    segment_s *seg;
+    addr_t phys = 0;
+    int nreject = 0;
+    int i;
+
+    for (i = 0; i < SB_ALLOC_TRIES; i++) {
+        seg = seg_alloc((segext_t)((SB_BUFFER + 15) >> 4),
+                        SEG_FLAG_EXTBUF | SEG_FLAG_ALIGN1K);
+        if (!seg)
+            break;
+        phys = LINADDR(seg->base, 0);
+        if (!sb_dma_unusable(phys)) {
+            sb_bounce_seg = seg;
+            break;
+        }
+        reject[nreject++] = seg;
+    }
+    while (nreject-- > 0)
+        seg_put(reject[nreject]);
+
+    return sb_bounce_seg? phys: 0;
+}
+
+void INITPROC sb_dsp_init(void)
+{
+    addr_t phys;
+
+    sb_base = CONFIG_SB_PORT;
+    sb_irq_line = CONFIG_SB_IRQ;
+    sb_dma = CONFIG_SB_DMA;
+
+    if (sb_port_opt == 0)               /* sb=off */
+        return;
+    if (sb_port_opt > 0)
+        sb_base = (unsigned int)sb_port_opt;
+    if (sb_irq_opt >= 0)
+        sb_irq_line = (unsigned char)sb_irq_opt;
+    if (sb_dma_opt >= 0)
+        sb_dma = (unsigned char)sb_dma_opt;
+    /*
+     * Same 8237 timing fix the disk needs.  Both drivers set it because either
+     * may be the first to initialise, and writing the command register twice
+     * with the same value is harmless - it is a single global setting for the
+     * controller, not a per-channel one.
+     */
+    if (dma_extwrite_opt) {
+        outb_p(DMA1_CMD_EXTWRITE, DMA1_CMD_REG);
+        printk("sb: 8237 extended write enabled\n");
+    }
+    /* sb=port,irq,0 selects PIO playback: no 8237, no completion interrupt */
+    if (sb_dma == 0) {
+        sb_pio_mode = 1;
+        sb_dma = 1;                 /* keep the cached port maths harmless */
+    }
+
+    if (sb_dma != 1 && sb_dma != 3) {
+        printk("sb: dma %d not 1 or 3\n", sb_dma);
+        return;
+    }
+#ifdef CONFIG_BLK_DEV_MFMHD
+    /*
+     * An XT hard disk controller owns DMA channel 3 and IRQ 5.  Sharing the
+     * channel would corrupt disk transfers, so refuse it outright; sharing the
+     * interrupt only costs us spurious handler entries, so warn and continue.
+     */
+    if (sb_dma == 3) {
+        printk("sb: dma 3 belongs to the hard disk controller, use dma 1\n");
+        return;
+    }
+    if (sb_irq_line == 5)
+        printk("sb: irq 5 belongs to the hard disk controller, prefer irq 7\n");
+#endif
+    sb_dma_cache();
+    sb_rate_cache(sb_rate);
+
+    phys = sb_alloc_bounce();
+    if (!phys) {
+        printk("sb: no dma buffer below 1M\n");
+        return;
+    }
+    sb_dma_addr_cache(phys);
+
+#ifdef CONFIG_SB_MAD16
+    if (mad16_opt > 0) {
+        unsigned int port = (mad16_port_opt > 0)?
+            (unsigned int)mad16_port_opt: sb_base;
+        int irq = (mad16_irq_opt >= 0)? mad16_irq_opt: (int)sb_irq_line;
+        int dma = (mad16_dma_opt >= 0)? mad16_dma_opt: (int)sb_dma;
+        int rc = mad16_early_init(port, irq, dma);
+
+        /*
+         * Distinguish the two failures: a card with no jumpers depends on this
+         * step, so "which of the two went wrong" is the whole diagnostic.
+         */
+        if (rc == 0)
+            printk("sb: mad16 at 0x%x irq %d dma %d\n", port, irq, dma);
+        else if (rc == -EINVAL)
+            printk("sb: mad16 cannot route 0x%x irq %d dma %d, "
+                   "allows port 0x220/0x240 irq 5/7 dma 1/3\n", port, irq, dma);
+        else
+            printk("sb: mad16 82c929 not detected\n");
+    }
+#endif
+
+    if (sb_reset() < 0) {
+        printk("sb: no card at 0x%x\n", sb_base);
+        goto out_free;
+    }
+    (void)sb_read_dsp_version();
+    /*
+     * Stop the parallel port sharing our interrupt.  IRQ 7 is LPT1's line as
+     * well as the card's, and the printer port powers up with its interrupt
+     * enabled (control register 0x37A reads 0x3F on this machine).  A floating
+     * or strobed ACK then fires the sound ISR at random points in a transfer,
+     * which is audible as distortion; masking it measurably cleaned up DMA
+     * playback on the PC1640.  0x0C leaves INIT and SELECT_IN in their idle
+     * state with the interrupt bit clear.  ELKS' lp driver is polled and never
+     * requests IRQ 7, so nothing else wants it.
+     */
+    if (sb_irq_line == 7)
+        outb_p(LPT1_CTRL_IDLE, LPT1_CONTROL);
+
+    if (request_irq((int)sb_irq_line, sb_interrupt, INT_GENERIC)) {
+        printk("sb: irq %d busy\n", sb_irq_line);
+        goto out_free;
+    }
+    if (dsp_cmd(DSP_SPEAKER_ON) < 0) {
+        printk("sb: dsp not responding\n");
+        goto out_irq;
+    }
+    sb_mixer_init();
+
+    if (register_chrdev(DSP_MAJOR, "dsp", &sb_dsp_fops)) {
+        printk("sb: unable to register\n");
+        goto out_irq;
+    }
+    sb_present = 1;
+    printk("sb: dsp %d.%02d at 0x%x irq %d dma %d, %u byte buffer\n",
+        sb_dsp_ver_major, sb_dsp_ver_minor, sb_base, sb_irq_line, sb_dma,
+        (unsigned int)SB_BOUNCE);
+    return;
+
+out_irq:
+    free_irq((int)sb_irq_line);
+out_free:
+    seg_put(sb_bounce_seg);
+    sb_bounce_seg = NULL;
+}
+
+#endif /* CONFIG_CHAR_DEV_DSP */

--- a/elks/arch/i86/drivers/char/init.c
+++ b/elks/arch/i86/drivers/char/init.c
@@ -16,6 +16,10 @@ void INITPROC chr_dev_init(void)
     mem_dev_init();
 #endif
 
+#ifdef CONFIG_CHAR_DEV_DSP
+    sb_dsp_init();
+#endif
+
 #ifdef CONFIG_INET
     tcpdev_init();
 #endif

--- a/elks/include/arch/dma.h
+++ b/elks/include/arch/dma.h
@@ -77,6 +77,21 @@
 
 /* DMA controller registers */
 #define DMA1_CMD_REG		0x08	/* command register (w) */
+/*
+ * Command register bit 5 picks the write-strobe timing: 0 is Late Write, 1 is
+ * Extended Write, which asserts the strobe a clock earlier and so holds it for
+ * longer.  It exists for peripherals that cannot meet the short pulse.
+ *
+ * The Amstrad PC1512/1640 need it.  Their 8237 is clocked at 4MHz and takes a
+ * five-clock 1.25us bus cycle on channels 1-3 (PC1640 Technical Reference
+ * 1.5), where a real XT clocks the part near 2.39MHz for a four-clock cycle of
+ * about 1.68us - so the Amstrad completes each transfer roughly 25% faster
+ * than 8-bit cards were designed against, and the ROS firmware additionally
+ * initialises the controller to Late Write (1.5.2), the shorter of the two.
+ * The result is dropped or mistimed bytes: distorted audio on the sound card,
+ * and a hard disk controller that misses its handshake altogether.
+ */
+#define DMA1_CMD_EXTWRITE	0x20	/* extended write for slow peripherals */
 #define DMA1_STAT_REG		0x08	/* status register (r) */
 #define DMA1_REQ_REG            0x09	/* request register (w) */
 #define DMA1_MASK_REG		0x0A	/* single-channel mask (w) */

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -12,8 +12,16 @@
  *  4   Com1    (/dev/ttyS0) CONFIG_CHAR_DEV_RS     Optional
  *  5*  Com3    (/dev/ttyS2) CONFIG_CHAR_DEV_RS     Optional
  *  5*  HW IDE hard drive    CONFIG_BLK_DEV_HD      Non-working directhd.c
+ *  5*  Sound Blaster (/dev/dsp) CONFIG_CHAR_DEV_DSP Optional, avoid if a HD is fitted
  *  6   HW floppy drive      CONFIG_BLK_DEV_FD      Optional
  *  7   Unused (LPT, Com4)
+ *  7*  Sound Blaster (/dev/dsp) CONFIG_CHAR_DEV_DSP Optional, also gets PIC spurious IRQs
+ *
+ * On an XT the hard disk controller owns IRQ 5 and DMA 3, so a sound card has
+ * to be jumpered away from both.  The Amstrad PC1640 technical reference gives
+ * IRQ 5 to the hard disk controller, DMA 2 to the floppy controller, DMA 3 to
+ * the external hard disk controller, and lists DMA 1 as spare for the expansion
+ * bus, which is why the sound driver defaults to DMA 1.
  *  8   Unused (RTC)
  *  9*  3C509/EL3 (/dev/3c0) CONFIG_ETH_EL3         Optional
  * 10*  WD 80x3   (/dev/wd0) CONFIG_ETH_WD          Optional

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -73,6 +73,13 @@ extern void INITPROC pcnet_drv_init(void);
 extern unsigned long INITPROC pci_cfg_read(unsigned int devfn_reg);
 extern void          INITPROC pci_cfg_write(unsigned int devfn_reg, unsigned int val);
 extern void INITPROC lp_init(void);
+#ifdef CONFIG_CHAR_DEV_DSP
+extern void INITPROC sb_dsp_init(void);
+#ifdef CONFIG_SB_MAD16
+extern int  INITPROC mad16_early_init(unsigned int port,int irq,int dma);
+extern void FARPROC mad16_restore_profile(void);
+#endif
+#endif
 extern void INITPROC mem_dev_init(void);
 extern void INITPROC meta_init(void);
 extern void INITPROC pty_init(void);

--- a/elks/include/linuxmt/major.h
+++ b/elks/include/linuxmt/major.h
@@ -24,7 +24,7 @@
  *  4 - /dev/tty[1234]      /dev/df[01]            tty           direct floppy
  *  4 - /dev/ttyp[0123]                            pty slave
  *  4 - /dev/ttyS[0123]                            serial
- *  5 -                     /dev/cf[ab][1-7]                     direct ATA/CF/hd
+ *  5 - /dev/dsp            /dev/cf[ab][1-7]       sound blaster direct ATA/CF/hd
  *  6 - /dev/lp             /dev/rom               printer       rom filesystem
  *  7 -                     /dev/mfm[ab][1-7]                 XT MFM hard disk
  *  8 - /dev/tcpdev                                kernel <-> ktcp
@@ -40,7 +40,7 @@
 #define PTY_MASTER_MAJOR  2
                              /* 3 unused*/
 #define TTY_MAJOR         4
-                             /* 5 unused*/
+#define DSP_MAJOR         5  /* Sound Blaster /dev/dsp, sb_dsp.c */
 #define LP_MAJOR          6
                              /* 7 unused*/
 #define TCPDEV_MAJOR      8

--- a/elks/include/linuxmt/soundcard.h
+++ b/elks/include/linuxmt/soundcard.h
@@ -1,0 +1,98 @@
+/*
+ * OSS /dev/dsp ioctl definitions.
+ *
+ * This is the single definition of the sound ABI.  User programs reach it
+ * through <sys/soundcard.h>, which is a __SYSINC__ shim onto this file, so
+ * there is no second copy to drift out of sync.  Do not create one.
+ *
+ * The /dev/dsp driver plays raw unsigned 8-bit PCM through 8-bit ISA DMA
+ * (8237 channel 1 or 3).  There is no recording path, no mixer, no MIDI and
+ * no sequencer, so the ioctls for those are deliberately absent rather than
+ * present and failing.  Command numbers match upstream OSS, so an ioctl that
+ * is not implemented here returns -EINVAL under its usual number.
+ */
+
+#ifndef __LINUXMT_SOUNDCARD_H
+#define __LINUXMT_SOUNDCARD_H
+
+#include <linuxmt/types.h>
+
+/*
+ * An ELKS ioctl command is a 16-bit int, but the Linux OSS encoding puts its
+ * direction bits and payload size above bit 15, where they cannot survive the
+ * ELKS kernel ABI.  Keep only the low command word: the resulting numbers are
+ * still the ones user programs pass to /dev/dsp.
+ */
+#define OSS__SIOC(x, y) \
+    ((int)((((unsigned int)(x) & 0xffU) << 8) | ((unsigned int)(y) & 0xffU)))
+
+typedef __s32 oss_int32_t;
+
+/*
+ * Implemented commands.  R/W marks the ones that read the caller's value and
+ * write back the value actually accepted, which callers must re-read: SPEED in
+ * particular is quantised by the Sound Blaster time constant.
+ */
+#define SNDCTL_DSP_RESET        OSS__SIOC('P', 0)   /* halt playback         */
+#define SNDCTL_DSP_SYNC         OSS__SIOC('P', 1)   /* drain then halt       */
+#define SNDCTL_DSP_SPEED        OSS__SIOC('P', 2)   /* R/W sample rate in Hz */
+#define SNDCTL_DSP_STEREO       OSS__SIOC('P', 3)   /* R/W 0 = mono          */
+#define SNDCTL_DSP_GETBLKSIZE   OSS__SIOC('P', 4)   /* R   DMA chunk bytes   */
+#define SNDCTL_DSP_SETFMT       OSS__SIOC('P', 5)   /* R/W one AFMT_ value   */
+#define SNDCTL_DSP_CHANNELS     OSS__SIOC('P', 6)   /* R/W channel count     */
+#define SNDCTL_DSP_POST         OSS__SIOC('P', 8)   /* end of a short sound  */
+#define SNDCTL_DSP_GETFMTS      OSS__SIOC('P', 11)  /* R   AFMT_ mask        */
+#define SNDCTL_DSP_GETERROR     OSS__SIOC('P', 25)  /* R   struct audio_errinfo */
+
+/* SNDCTL_DSP_HALT is the modern name for RESET; both are the same command. */
+#define SNDCTL_DSP_HALT         SNDCTL_DSP_RESET
+
+/* Names some OSS programs still use for the commands above. */
+#define SOUND_PCM_RESET         SNDCTL_DSP_RESET
+#define SOUND_PCM_SYNC          SNDCTL_DSP_SYNC
+#define SOUND_PCM_WRITE_RATE    SNDCTL_DSP_SPEED
+#define SOUND_PCM_WRITE_CHANNELS SNDCTL_DSP_CHANNELS
+#define SOUND_PCM_WRITE_BITS    SNDCTL_DSP_SETFMT
+#define SOUND_PCM_SETFMT        SNDCTL_DSP_SETFMT
+#define SOUND_PCM_GETFMTS       SNDCTL_DSP_GETFMTS
+#define SOUND_PCM_POST          SNDCTL_DSP_POST
+
+/*
+ * Sample formats.  The full set is listed because programs test for their
+ * format by name and expect the symbol to exist; only AFMT_U8 is supported,
+ * and SNDCTL_DSP_GETFMTS reports exactly that.
+ */
+#define AFMT_QUERY              0x00000000U /* ask, do not set */
+#define AFMT_MU_LAW             0x00000001U
+#define AFMT_A_LAW              0x00000002U
+#define AFMT_IMA_ADPCM          0x00000004U
+#define AFMT_U8                 0x00000008U /* the only supported format */
+#define AFMT_S16_LE             0x00000010U
+#define AFMT_S16_BE             0x00000020U
+#define AFMT_S8                 0x00000040U
+#define AFMT_U16_LE             0x00000080U
+#define AFMT_U16_BE             0x00000100U
+
+/*
+ * Returned by SNDCTL_DSP_GETERROR.  play_underruns counts DMA blocks whose
+ * completion deadline passed, which is the only way a program can tell that
+ * audio broke up rather than played cleanly.  The remaining fields are kept
+ * at their OSS names and reported as zero.
+ */
+struct audio_errinfo {
+    oss_int32_t play_underruns;
+    oss_int32_t rec_overruns;
+    __u32       play_ptradjust;
+    __u32       rec_ptradjust;
+    oss_int32_t play_errorcount;
+    oss_int32_t rec_errorcount;
+    oss_int32_t play_lasterror;
+    oss_int32_t rec_lasterror;
+    oss_int32_t play_errorparm;
+    oss_int32_t rec_errorparm;
+    oss_int32_t filler[16];
+};
+
+typedef struct audio_errinfo audio_errinfo;
+
+#endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -47,11 +47,23 @@ struct netif_parms netif_parms[MAX_ETHS] = {
     { LANCE_IRQ, LANCE_PORT, 0, LANCE_FLAGS },
 };
 int dma_extwrite_opt;           /* /bootopts dmaxw=1: 8237 Extended Write */
+int lpt_irq_opt = 1;            /* /bootopts lptirq=0: mask LPT1's IRQ 7 */
 int mfmhd_slow_profile;         /* /bootopts mfm= bit 0: slow controller timing */
 int mfmhd_pio;                  /* /bootopts mfm= bit 1: PIO sector transfers */
 int mfmhd_trace;                /* /bootopts mfm= bit 2: driver request tracing */
 int mfm_opts;                   /* CONFIG_BLK_DEV_MFM mfm= options */
 int iga_opts;                   /* CONFIG_CONSOLE_AMSTRAD_IGA iga= options */
+#ifdef CONFIG_CHAR_DEV_DSP
+int sb_port_opt = -1;           /* /bootopts sb=port,irq,dma; 0 disables driver */
+int sb_irq_opt = -1;
+int sb_dma_opt = -1;
+#ifdef CONFIG_SB_MAD16
+int mad16_opt = -1;             /* /bootopts mad16=on|off|port,irq,dma */
+int mad16_port_opt = -1;
+int mad16_irq_opt = -1;
+int mad16_dma_opt = -1;
+#endif
+#endif
 
 /* internal non-driver globals */
 seg_t kernel_cs, kernel_ds;     /* always segment values even in PM */
@@ -228,6 +240,16 @@ static void INITPROC early_kernel_init(void)
     init_command = argv_init[1];    /* default startup task 1 */
     hasopts = parse_options();      /* parse options found in /bootops */
 #endif
+
+    /*
+     * Machine bring-up, not a driver's business: whoever ends up sharing IRQ 7
+     * should not have to discover the printer port sitting on it, and the mask
+     * has to be in place before any driver requests the line.  0x0C leaves INIT
+     * and SELECT_IN in their idle state with the interrupt bit clear.  ELKS' lp
+     * driver is polled and never requests IRQ 7.
+     */
+    if (!lpt_irq_opt)
+        outb_p(0x0C, 0x37A);        /* LPT1 control: interrupt disabled */
 
     /* create near heap at end of kernel bss */
     heap_init();                    /* init near memory allocator */
@@ -501,6 +523,47 @@ static void INITPROC comirq(char *line)
 #endif
 }
 
+#ifdef CONFIG_CHAR_DEV_DSP
+/* sb=port,irq,dma with port in hex or decimal, or sb=off to skip the driver */
+static void INITPROC parse_sb(char *line)
+{
+    char *p;
+
+    if (!strncmp(line, "off", 3) || !strncmp(line, "no", 2)) {
+        sb_port_opt = 0;
+        return;
+    }
+    sb_port_opt = (int)simple_strtol(line, 0);
+    if ((p = strchr(line, ','))) {
+        sb_irq_opt = (int)simple_strtol(p+1, 10);
+        if ((p = strchr(p+1, ',')))
+            sb_dma_opt = (int)simple_strtol(p+1, 10);
+    }
+}
+
+#ifdef CONFIG_SB_MAD16
+/* mad16=on to program the OPTi chip with the sb= route, or mad16=port,irq,dma */
+static void INITPROC parse_mad16(char *line)
+{
+    char *p;
+
+    if (!strncmp(line, "off", 3) || !strncmp(line, "no", 2)) {
+        mad16_opt = 0;
+        return;
+    }
+    mad16_opt = 1;
+    if (!strncmp(line, "on", 2))
+        return;
+    mad16_port_opt = (int)simple_strtol(line, 0);
+    if ((p = strchr(line, ','))) {
+        mad16_irq_opt = (int)simple_strtol(p+1, 10);
+        if ((p = strchr(p+1, ',')))
+            mad16_dma_opt = (int)simple_strtol(p+1, 10);
+    }
+}
+#endif
+#endif
+
 static void INITPROC parse_nic(char *line, struct netif_parms *parms)
 {
     char *p;
@@ -651,6 +714,19 @@ static int INITPROC parse_options(void)
             dma_extwrite_opt = (int)simple_strtol(line+6, 0);
             continue;
         }
+        /*
+         * lptirq=0 stops the parallel port asserting IRQ 7 at all.  The line is
+         * shared with expansion cards that have no other choice of interrupt -
+         * an AD1848 in Windows Sound mode can only be told 7, 9, 10 or 11, and
+         * on an XT class machine with one 8259 only 7 exists - while LPT1 powers
+         * up with its interrupt enabled (0x37A reads 0x3F on the PC1640).  A
+         * floating or strobed ACK then fires the card's handler at random.  Left
+         * on by default; nothing else should disturb a working printer port.
+         */
+        if (!strncmp(line,"lptirq=",7)) {
+            lpt_irq_opt = (int)simple_strtol(line+7, 0);
+            continue;
+        }
         if (!strncmp(line,"ne0=",4)) {
             parse_nic(line+4, &netif_parms[ETH_NE2K]);
             continue;
@@ -705,6 +781,18 @@ static int INITPROC parse_options(void)
             iga_opts = (int)simple_strtol(line+4, 10);
             continue;
         }
+#ifdef CONFIG_CHAR_DEV_DSP
+        if (!strncmp(line,"sb=",3)) {
+            parse_sb(line+3);
+            continue;
+        }
+#ifdef CONFIG_SB_MAD16
+        if (!strncmp(line,"mad16=",6)) {
+            parse_mad16(line+6);
+            continue;
+        }
+#endif
+#endif
         if (!strncmp(line,"heap=",5)) {
 #ifndef CONFIG_286_PMODE
             heapsize = (unsigned int)simple_strtol(line+5, 10);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -46,6 +46,7 @@ struct netif_parms netif_parms[MAX_ETHS] = {
     { ULTRA_IRQ, ULTRA_PORT, ULTRA_RAM, ULTRA_FLAGS },
     { LANCE_IRQ, LANCE_PORT, 0, LANCE_FLAGS },
 };
+int dma_extwrite_opt;           /* /bootopts dmaxw=1: 8237 Extended Write */
 int mfmhd_slow_profile;         /* /bootopts mfm= bit 0: slow controller timing */
 int mfmhd_pio;                  /* /bootopts mfm= bit 1: PIO sector transfers */
 int mfmhd_trace;                /* /bootopts mfm= bit 2: driver request tracing */
@@ -638,6 +639,16 @@ static int INITPROC parse_options(void)
         if (!strncmp(line,"init=",5)) {
             line += 5;
             init_command = argv_init[1] = line;
+            continue;
+        }
+        /*
+         * dmaxw=1 switches the 8237 to Extended Write.  Off by default: only
+         * machines whose DMA timing is tighter than 8-bit cards expect need
+         * it, notably the Amstrad PC1512/1640.  Harmless elsewhere, but there
+         * is no reason to alter a working controller's timing.
+         */
+        if (!strncmp(line,"dmaxw=",6)) {
+            dma_extwrite_opt = (int)simple_strtol(line+6, 0);
             continue;
         }
         if (!strncmp(line,"ne0=",4)) {

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -102,6 +102,8 @@ sys_utils/sercat                :sysutil                            :1440c
 sys_utils/console               :sysutil                :1200k
 #sys_utils/who                  :sysutil                :1200k
 sys_utils/beep                  :sysutil                :1200k
+sys_utils/audioplay             :sysutil                :1200k
+sys_utils/sbmix                 :sysutil                :1200k
 sys_utils/decomp                :sysutil         :360c              :1440k
 sys_utils/sysctl                :sysutil                :1200k
 sys_utils/dmesg                 :sysutil                :1232c      :1440k
@@ -202,6 +204,7 @@ inet/ftp                        :net
 inet/ftpd                       :net
 inet/httpd                      :net
 inet/netcat                     :net
+inet/audiorecv                  :net
 inet/netcat :::nc               :net
 inet/netstat                    :net
 inet/nslookup                   :net

--- a/elkscmd/inet/.gitignore
+++ b/elkscmd/inet/.gitignore
@@ -14,3 +14,4 @@ telnetd
 traceroute
 urlget
 tinyirc/tinyirc
+audiorecv

--- a/elkscmd/inet/Makefile
+++ b/elkscmd/inet/Makefile
@@ -8,7 +8,7 @@ LOCALFLAGS=-I$(ELKSCMD_DIR)
 
 ###############################################################################
 
-PRGS = arp curl ftp ftpd httpd ifconfig netcat netstat nslookup ping tcpdump telnet telnetd traceroute urlget
+PRGS = arp audiorecv curl ftp ftpd httpd ifconfig netcat netstat nslookup ping tcpdump telnet telnetd traceroute urlget
 PRGS += tinyirc/tinyirc
 
 all: $(PRGS)
@@ -33,6 +33,9 @@ httpd: httpd.o $(TINYPRINTF)
 
 netcat: netcat.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-heap=128 -maout-stack=1024 -o $@ $^ $(LDLIBS)
+audiorecv: audiorecv.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -maout-heap=256 -maout-stack=1024 -o $@ $^ $(LDLIBS)
+
 
 netstat: netstat.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)

--- a/elkscmd/inet/audiorecv.c
+++ b/elkscmd/inet/audiorecv.c
@@ -1,0 +1,331 @@
+/*
+ * audiorecv - play raw unsigned 8-bit mono PCM arriving over TCP on /dev/dsp
+ *
+ * usage: audiorecv [-d] [-p port] [-r rate] [-b bytes]
+ *
+ * Listens on a TCP port and writes whatever arrives straight to /dev/dsp.  The
+ * stream carries no header, so the sample rate is a property of this end: -r
+ * must match what the sender was told to produce.  Only raw unsigned 8-bit
+ * mono PCM is understood, because that is all the driver accepts.
+ *
+ *   ELKS:  audiorecv -r 8000
+ *   host:  sox in.wav -t raw -r 8000 -c 1 -b 8 -e unsigned - | nc elks 4950
+ *          ffmpeg -i in.wav -f u8 -ar 8000 -ac 1 - | nc elks 4950
+ *
+ * Without -d one stream is played and the exit status says whether it played
+ * cleanly, so it can be scripted like audioplay.  With -d the process detaches
+ * and serves streams one after another forever, logging to the console.
+ *
+ * /dev/dsp is opened per stream rather than held open, so audioplay can still
+ * use the card while the daemon sits idle.  It is a single-opener device, which
+ * is also why connections are served one at a time in this process instead of
+ * being forked off: a second opener would only get EBUSY.
+ *
+ * Playback is real time.  The link has to sustain `rate' bytes per second and
+ * the slack is one DMA block (4096 bytes, about half a second at 8000 Hz),
+ * because the driver keeps exactly one block in flight.  Ethernet is fine;
+ * SLIP at 19200 baud carries around 1900 bytes per second and cannot feed even
+ * the 4000 Hz minimum, so a serial link needs 40000 baud or better.  TCP flow
+ * control does the throttling, so a slow link breaks the audio up rather than
+ * corrupting it, and the underrun count says so.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/soundcard.h>
+
+#define DEF_PORT        4950
+#define DEFAULT_RATE    8000L
+#define MIN_RATE        4000L       /* driver limits */
+#define MAX_RATE        22050L      /* PIO playback ceiling */
+#define MIN_BUFSIZE     64
+#define MAX_BUFSIZE     4096        /* == the driver's default DMA block */
+
+static unsigned char buf[MAX_BUFSIZE];
+static audio_errinfo einfo;         /* 104 bytes: keep off the small stack */
+
+static void usage(void)
+{
+    fprintf(stderr, "usage: audiorecv [-d] [-p port] [-r rate] [-b bytes]\n");
+    fprintf(stderr, "       -d serves streams forever in the background,"
+        " otherwise one stream is played\n");
+    fprintf(stderr, "       raw unsigned 8-bit mono PCM, %ld-%ld Hz,"
+        " default %ld, port %d\n", MIN_RATE, MAX_RATE, DEFAULT_RATE, DEF_PORT);
+    exit(1);
+}
+
+/*
+ * Fill the buffer unless the sender stops first.  A socket read() is clamped
+ * well below our buffer size, so without this each DMA transfer would be a
+ * fraction of a block and the audio would break up.
+ */
+static int read_full(int fd, unsigned char *p, int len)
+{
+    int got = 0;
+    int n;
+
+    while (got < len) {
+        n = read(fd, p + got, (size_t)(len - got));
+        if (n < 0) {
+            if (errno == EINTR)     /* ktcp returns this on its own */
+                continue;
+            return -1;
+        }
+        if (n == 0)
+            break;
+        got += n;
+    }
+    return got;
+}
+
+static int write_all(int fd, unsigned char *p, int len)
+{
+    int n;
+
+    while (len > 0) {
+        n = write(fd, p, (size_t)len);
+        if (n < 0) {
+            if (errno == EINTR)     /* nothing was accepted, safe to retry */
+                continue;
+            return -1;
+        }
+        if (n == 0)                 /* no progress, do not spin */
+            return -1;
+        p += n;
+        len -= n;
+    }
+    return 0;
+}
+
+/*
+ * Open /dev/dsp and program it for the stream about to arrive.  Returns the
+ * descriptor, or -1 with a message already printed.  bufsizep is lowered if
+ * the driver's DMA block is smaller than the requested write size.
+ */
+static int dsp_open(long rate, int *bufsizep)
+{
+    int dsp;
+    oss_int32_t val;
+
+    dsp = open("/dev/dsp", O_WRONLY);
+    if (dsp < 0) {
+        perror("/dev/dsp");
+        return -1;
+    }
+
+    /* Does this driver offer 8-bit unsigned at all? */
+    val = 0;
+    if (ioctl(dsp, SNDCTL_DSP_GETFMTS, &val) == 0 && !(val & AFMT_U8)) {
+        fprintf(stderr, "audiorecv: no 8-bit unsigned PCM support\n");
+        close(dsp);
+        return -1;
+    }
+
+    /* Format first: it fixes the meaning of the rate and channel count. */
+    val = (oss_int32_t)AFMT_U8;
+    if (ioctl(dsp, SNDCTL_DSP_SETFMT, &val) < 0 || val != (oss_int32_t)AFMT_U8) {
+        perror("SNDCTL_DSP_SETFMT");
+        close(dsp);
+        return -1;
+    }
+
+    /*
+     * SPEED is read-write.  The Sound Blaster time constant quantises the
+     * rate, so the driver reports back what it actually programmed; playing
+     * anyway just shifts the pitch slightly, which beats refusing to play.
+     */
+    val = (oss_int32_t)rate;
+    if (ioctl(dsp, SNDCTL_DSP_SPEED, &val) < 0) {
+        perror("SNDCTL_DSP_SPEED");
+        close(dsp);
+        return -1;
+    }
+    if (val != (oss_int32_t)rate)
+        fprintf(stderr, "audiorecv: %ld Hz requested, %ld Hz selected\n",
+            rate, (long)val);
+
+    val = 1;
+    if (ioctl(dsp, SNDCTL_DSP_CHANNELS, &val) < 0 || val != 1) {
+        perror("SNDCTL_DSP_CHANNELS");
+        close(dsp);
+        return -1;
+    }
+
+    /* Match the driver's block size if it is smaller than our buffer. */
+    val = 0;
+    if (ioctl(dsp, SNDCTL_DSP_GETBLKSIZE, &val) == 0 &&
+        val > 0 && val < (oss_int32_t)*bufsizep)
+        *bufsizep = (int)val;
+
+    return dsp;
+}
+
+/*
+ * Play one connection to completion.  Returns 0 if the stream played cleanly,
+ * 1 if it was cut short or the driver reported underruns.
+ */
+static int play_stream(int conn, long rate, int bufsize)
+{
+    int dsp;
+    int n, err = 0;
+
+    dsp = dsp_open(rate, &bufsize);
+    if (dsp < 0)
+        return 1;
+
+    for (;;) {
+        n = read_full(conn, buf, bufsize);
+        if (n < 0) {
+            perror("audiorecv: read");
+            err = 1;
+            break;
+        }
+        if (n == 0)
+            break;
+        if (write_all(dsp, buf, n) < 0) {
+            perror("/dev/dsp");
+            err = 1;
+            break;
+        }
+    }
+
+    /* Drain before closing or the last partial block is cut off. */
+    if (ioctl(dsp, SNDCTL_DSP_SYNC, (char *)0) < 0)
+        perror("SNDCTL_DSP_SYNC");
+
+    if (ioctl(dsp, SNDCTL_DSP_GETERROR, &einfo) == 0 && einfo.play_underruns) {
+        fprintf(stderr, "audiorecv: %ld underruns\n",
+            (long)einfo.play_underruns);
+        err = 1;
+    }
+
+    close(dsp);
+    return err;
+}
+
+/* Detach from the terminal, keeping messages on the console. */
+static void daemonize(void)
+{
+    int fd;
+    int pid;
+
+    if ((pid = fork()) == -1) {
+        fprintf(stderr, "audiorecv: no more processes\n");
+        exit(1);
+    }
+    if (pid)
+        exit(0);
+    fd = open("/dev/console", O_RDWR);
+    close(STDIN_FILENO);
+    dup2(fd, STDOUT_FILENO);
+    dup2(fd, STDERR_FILENO);
+    if (fd > STDERR_FILENO)
+        close(fd);
+    setsid();                   /* create new process group */
+    signal(SIGINT, SIG_IGN);
+}
+
+int main(int argc, char **argv)
+{
+    long rate = DEFAULT_RATE;
+    long port = DEF_PORT;
+    int bufsize = MAX_BUFSIZE;
+    int dflag = 0;
+    int listen_sock, conn_sock;
+    int c, val, err;
+    struct sockaddr_in localadr;
+
+    while ((c = getopt(argc, argv, "dp:r:b:")) != -1) {
+        switch (c) {
+        case 'd':
+            dflag = 1;
+            break;
+        case 'p':
+            port = atol(optarg);        /* atoi would wrap above 32767 */
+            if (port < 1 || port > 65535) {
+                fprintf(stderr, "audiorecv: port must be 1-65535\n");
+                return 1;
+            }
+            break;
+        case 'r':
+            rate = atol(optarg);
+            if (rate < MIN_RATE || rate > MAX_RATE) {
+                fprintf(stderr, "audiorecv: rate must be %ld-%ld\n",
+                    MIN_RATE, MAX_RATE);
+                return 1;
+            }
+            break;
+        case 'b': {
+            /* parse wide: atoi wraps at 16 bits and can land back in range */
+            long b = atol(optarg);
+            if (b < MIN_BUFSIZE || b > MAX_BUFSIZE) {
+                fprintf(stderr, "audiorecv: buffer must be %d-%d bytes\n",
+                    MIN_BUFSIZE, MAX_BUFSIZE);
+                return 1;
+            }
+            bufsize = (int)b;
+            break;
+        }
+        default:
+            usage();
+        }
+    }
+    if (optind < argc)
+        usage();
+
+    if ((listen_sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        fprintf(stderr, "audiorecv: network is down\n");
+        return 1;
+    }
+
+    /* set local port reuse, allows server to be restarted in less than 10 secs */
+    val = 1;
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(int)) < 0)
+        perror("SO_REUSEADDR");
+
+    /* set small listen buffer to save ktcp memory */
+    val = SO_LISTEN_BUFSIZ;
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_RCVBUF, &val, sizeof(int)) < 0)
+        perror("SO_RCVBUF");
+
+    memset(&localadr, 0, sizeof(localadr));
+    localadr.sin_family = AF_INET;
+    localadr.sin_port = htons((unsigned short)port);
+    localadr.sin_addr.s_addr = INADDR_ANY;
+    if (bind(listen_sock, (struct sockaddr *)&localadr, sizeof(localadr)) < 0) {
+        fprintf(stderr, "audiorecv: bind error (may already be running)\n");
+        return 1;
+    }
+
+    /* one stream plays at a time, so there is nothing to gain from a queue */
+    if (listen(listen_sock, 1) < 0) {
+        perror("audiorecv: listen");
+        return 1;
+    }
+
+    if (dflag)
+        daemonize();
+
+    for (;;) {
+        conn_sock = accept(listen_sock, NULL, NULL);
+        if (conn_sock < 0) {
+            if (errno == ENOTSOCK)      /* ktcp has gone away */
+                return 1;
+            continue;
+        }
+
+        err = play_stream(conn_sock, rate, bufsize);
+        close(conn_sock);
+
+        if (!dflag)                     /* one stream, status says how it went */
+            return err;
+    }
+}

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -43,3 +43,5 @@ custom_poststart_network()
 custom_stop_network()
 {
 }
+# needs /dev/dsp; -r must match the rate the sender produces
+#audiorecv="audiorecv -d -r 8000"

--- a/elkscmd/sys_utils/.gitignore
+++ b/elkscmd/sys_utils/.gitignore
@@ -25,3 +25,5 @@ sysctl
 umount
 test_unreal
 who
+audioplay
+sbmix

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -30,6 +30,8 @@ PRGS = \
 	chmem \
 	test_unreal \
 	beep \
+	audioplay \
+	sbmix \
 	mouse \
 	sercat \
 	console \
@@ -145,3 +147,8 @@ install: $(PRGS)
 
 clean:
 	$(RM) *.o $(PRGS) $(HOSTPRGS)
+audioplay: audioplay.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o audioplay audioplay.o $(TINYPRINTF) $(LDLIBS)
+
+sbmix: sbmix.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o sbmix sbmix.o $(TINYPRINTF) $(LDLIBS)

--- a/elkscmd/sys_utils/audioplay.c
+++ b/elkscmd/sys_utils/audioplay.c
@@ -1,0 +1,206 @@
+/*
+ * audioplay - play raw unsigned 8-bit mono PCM on /dev/dsp
+ *
+ * usage: audioplay [-r rate] [-b bytes] [file]
+ *
+ * Writes are sized to the driver's DMA block (SNDCTL_DSP_GETBLKSIZE, 4096
+ * bytes by default).  The driver keeps one block in flight and write() returns
+ * when the previous block has drained, so writing a whole block at a time lets
+ * the read() for the next one overlap playback of the current one.  Writing
+ * more than a block does not queue more audio, it just blocks for longer, so
+ * MAX_BUFSIZE only needs raising if the driver's block size ever grows.
+ *
+ * Only raw unsigned 8-bit PCM is understood.  Convert on the host first:
+ *   sox in.wav -t raw -r 8000 -c 1 -b 8 -e unsigned out.raw
+ *   ffmpeg -i in.wav -f u8 -ar 8000 -ac 1 out.raw
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/soundcard.h>
+
+#define DEFAULT_RATE    8000L
+#define MIN_RATE        4000L       /* driver limits */
+#define MAX_RATE        22050L      /* PIO playback ceiling */
+#define MIN_BUFSIZE     64
+#define MAX_BUFSIZE     4096        /* == the driver's default DMA block */
+
+static unsigned char buf[MAX_BUFSIZE];
+static audio_errinfo einfo;         /* 104 bytes: keep off the small stack */
+
+static void usage(void)
+{
+    fprintf(stderr, "usage: audioplay [-r rate] [-b bytes] [file]\n");
+    fprintf(stderr, "       raw unsigned 8-bit mono PCM, %ld-%ld Hz,"
+        " default %ld\n", MIN_RATE, MAX_RATE, DEFAULT_RATE);
+    exit(1);
+}
+
+/*
+ * Fill the buffer unless end of file arrives first.  Without this a pipe hands
+ * back one small block per read(), which would turn into a stream of tiny DMA
+ * transfers and break the audio up.
+ */
+static int read_full(int fd, unsigned char *p, int len)
+{
+    int got = 0;
+    int n;
+
+    while (got < len) {
+        n = read(fd, p + got, (size_t)(len - got));
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        if (n == 0)
+            break;
+        got += n;
+    }
+    return got;
+}
+
+static int write_all(int fd, unsigned char *p, int len)
+{
+    int n;
+
+    while (len > 0) {
+        n = write(fd, p, (size_t)len);
+        if (n < 0) {
+            if (errno == EINTR)     /* nothing was accepted, safe to retry */
+                continue;
+            return -1;
+        }
+        if (n == 0)                 /* no progress, do not spin */
+            return -1;
+        p += n;
+        len -= n;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    long rate = DEFAULT_RATE;
+    int bufsize = MAX_BUFSIZE;
+    int in = STDIN_FILENO;
+    int dsp;
+    int c, n, err = 0;
+    oss_int32_t val;
+
+    while ((c = getopt(argc, argv, "r:b:")) != -1) {
+        switch (c) {
+        case 'r':
+            rate = atol(optarg);        /* atoi would wrap above 32767 */
+            if (rate < MIN_RATE || rate > MAX_RATE) {
+                fprintf(stderr, "audioplay: rate must be %ld-%ld\n",
+                    MIN_RATE, MAX_RATE);
+                return 1;
+            }
+            break;
+        case 'b': {
+            /* parse wide: atoi wraps at 16 bits and can land back in range */
+            long b = atol(optarg);
+            if (b < MIN_BUFSIZE || b > MAX_BUFSIZE) {
+                fprintf(stderr, "audioplay: buffer must be %d-%d bytes\n",
+                    MIN_BUFSIZE, MAX_BUFSIZE);
+                return 1;
+            }
+            bufsize = (int)b;
+            break;
+        }
+        default:
+            usage();
+        }
+    }
+
+    if (optind < argc && strcmp(argv[optind], "-")) {
+        in = open(argv[optind], O_RDONLY);
+        if (in < 0) {
+            perror(argv[optind]);
+            return 1;
+        }
+    }
+
+    dsp = open("/dev/dsp", O_WRONLY);
+    if (dsp < 0) {
+        perror("/dev/dsp");
+        return 1;
+    }
+
+    /* Does this driver offer 8-bit unsigned at all? */
+    val = 0;
+    if (ioctl(dsp, SNDCTL_DSP_GETFMTS, &val) == 0 && !(val & AFMT_U8)) {
+        fprintf(stderr, "audioplay: no 8-bit unsigned PCM support\n");
+        return 1;
+    }
+
+    /* Format first: it fixes the meaning of the rate and channel count. */
+    val = (oss_int32_t)AFMT_U8;
+    if (ioctl(dsp, SNDCTL_DSP_SETFMT, &val) < 0 || val != (oss_int32_t)AFMT_U8) {
+        perror("SNDCTL_DSP_SETFMT");
+        return 1;
+    }
+
+    /*
+     * SPEED is read-write.  The Sound Blaster time constant quantises the
+     * rate, so the driver reports back what it actually programmed; playing
+     * anyway just shifts the pitch slightly, which beats refusing to play.
+     */
+    val = (oss_int32_t)rate;
+    if (ioctl(dsp, SNDCTL_DSP_SPEED, &val) < 0) {
+        perror("SNDCTL_DSP_SPEED");
+        return 1;
+    }
+    if (val != (oss_int32_t)rate)
+        fprintf(stderr, "audioplay: %ld Hz requested, %ld Hz selected\n",
+            rate, (long)val);
+
+    val = 1;
+    if (ioctl(dsp, SNDCTL_DSP_CHANNELS, &val) < 0 || val != 1) {
+        perror("SNDCTL_DSP_CHANNELS");
+        return 1;
+    }
+
+    /* Match the driver's block size if it is smaller than our buffer. */
+    val = 0;
+    if (ioctl(dsp, SNDCTL_DSP_GETBLKSIZE, &val) == 0 &&
+        val > 0 && val < (oss_int32_t)bufsize)
+        bufsize = (int)val;
+
+    for (;;) {
+        n = read_full(in, buf, bufsize);
+        if (n < 0) {
+            perror("read");
+            err = 1;
+            break;
+        }
+        if (n == 0)
+            break;
+        if (write_all(dsp, buf, n) < 0) {
+            perror("/dev/dsp");
+            err = 1;
+            break;
+        }
+    }
+
+    /* Drain before closing or the last partial block is cut off. */
+    if (ioctl(dsp, SNDCTL_DSP_SYNC, (char *)0) < 0)
+        perror("SNDCTL_DSP_SYNC");
+
+    if (ioctl(dsp, SNDCTL_DSP_GETERROR, &einfo) == 0 && einfo.play_underruns) {
+        fprintf(stderr, "audioplay: %ld underruns\n",
+            (long)einfo.play_underruns);
+        err = 1;
+    }
+
+    close(dsp);
+    if (in != STDIN_FILENO)
+        close(in);
+    return err;
+}

--- a/elkscmd/sys_utils/sbmix.c
+++ b/elkscmd/sys_utils/sbmix.c
@@ -1,0 +1,366 @@
+/*
+ * sbmix - read and set Sound Blaster mixer levels
+ *
+ * usage: sbmix [-p port] [-m level] [-v level] [-r reg] [-s reg=val]
+ *
+ * The /dev/dsp driver has no mixer ioctl: it sets master and voice to full
+ * scale once at init and treats level as purely a property of the samples.
+ * That is the right default for a card whose output is wired to headphones,
+ * but on a board with its own amplifier every gain stage at maximum clips.
+ * This reads the mixer back so the actual levels can be seen, and sets them so
+ * a sane value can be found by ear before baking it into the driver.
+ *
+ * Port I/O from user space works because ELKS runs the 8086 in real mode with
+ * no I/O privilege level, the same way beep(1) drives the PIT.  Reading the
+ * mixer is harmless while the driver is idle; do not run it during playback.
+ *
+ * The level registers are two 4-bit fields on both the SB Pro and the SB16,
+ * bits 7-4 for left and 3-0 for right, so one decoding covers both.  Linux's
+ * sbpro_mix table is the reference: MIX_ENT(SOUND_MIXER_VOLUME, 0x22, 7, 4,
+ * 0x22, 3, 4) is a bit offset of 7 and a width of 4.  The microphone level is
+ * the exception at 3 bits, MIX_ENT(SOUND_MIXER_MIC, 0x0a, 2, 3, ...).
+ *
+ * A Sound Blaster 1.x or 2.0 (DSP 1.xx/2.xx) has no mixer at all.
+ *
+ * Register 0x0E is not a level: bit 1 selects stereo and bit 5 switches the
+ * output filter off, and 0 in both is mono with the filter engaged.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "arch/io.h"
+
+#define DEF_PORT        0x220
+
+#define SB_RESET        0x06
+#define SB_READ_DATA    0x0A
+#define SB_WRITE_DATA   0x0C
+#define SB_READ_STATUS  0x0E
+#define SB_MIXER_ADDR   0x04
+#define SB_MIXER_DATA   0x05
+
+#define DSP_GET_VERSION 0xE1
+#define DSP_READY       0xAA
+
+#define MIX_RESET       0x00
+#define MIX_VOICE       0x04
+#define MIX_MIC         0x0A
+#define MIX_FILTER      0x0E
+#define MIX_MASTER      0x22
+#define MIX_FM          0x26
+#define MIX_CD          0x28
+#define MIX_LINE        0x2E
+
+static unsigned int base = DEF_PORT;
+static int ver_major, ver_minor;
+
+/* Spin rather than sleep: these waits are microseconds on real hardware. */
+static int dsp_write(unsigned char v)
+{
+    int i;
+
+    for (i = 0; i < 30000; i++) {
+        if ((inb(base + SB_WRITE_DATA) & 0x80) == 0) {
+            outb(v, base + SB_WRITE_DATA);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int dsp_read(unsigned char *v)
+{
+    int i;
+
+    for (i = 0; i < 30000; i++) {
+        if ((inb(base + SB_READ_STATUS) & 0x80) != 0) {
+            *v = inb(base + SB_READ_DATA);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int dsp_reset(void)
+{
+    int i;
+    unsigned char v;
+
+    outb(1, base + SB_RESET);
+    for (i = 0; i < 1000; i++)
+        (void)inb(base + SB_READ_STATUS);
+    outb(0, base + SB_RESET);
+    for (i = 0; i < 30000; i++) {
+        if ((inb(base + SB_READ_STATUS) & 0x80) != 0) {
+            v = inb(base + SB_READ_DATA);
+            if (v == DSP_READY)
+                return 0;
+        }
+    }
+    return -1;
+}
+
+/*
+ * The index and data ports need a delay between them.  The OPTi 82C929
+ * reference driver waits a millisecond either side of the data access
+ * (Knipperts, UNITS/SBPRO.PAS); without it the write is lost and reads return
+ * junk, which is what made this card look like it was ORing 0x11 into every
+ * register.
+ */
+#define MIXER_DELAY 1200
+
+static void mix_delay(void)
+{
+    int i;
+
+    for (i = 0; i < MIXER_DELAY; i++)
+        inb(0x61);
+}
+
+static unsigned char mix_read(unsigned char reg)
+{
+    unsigned char v;
+
+    outb(reg, base + SB_MIXER_ADDR);
+    mix_delay();
+    v = inb(base + SB_MIXER_DATA);
+    mix_delay();
+    return v;
+}
+
+static void mix_write(unsigned char reg, unsigned char val)
+{
+    outb(reg, base + SB_MIXER_ADDR);
+    mix_delay();
+    outb(val, base + SB_MIXER_DATA);
+    mix_delay();
+}
+
+/* Percentage of full scale, decoded for whichever layout this card uses.
+ * A DSP 3.xx card packs two 3-bit fields at bits 7-5 and 3-1 - bits 4 and 0
+ * do not exist in its register file and read back as 1 - so decoding it as
+ * 4-bit reported 0xFF as "15/15" when the level is physically 7/7. */
+static void show(const char *name, unsigned char reg)
+{
+    unsigned char v = mix_read(reg);
+    int l, r, steps;
+
+    if (ver_major == 3) {
+        l = (v >> 5) & 0x07;
+        r = (v >> 1) & 0x07;
+        steps = 7;
+    } else {
+        l = (v >> 4) & 0x0F;
+        r = v & 0x0F;
+        steps = 15;
+    }
+    printf("  %-8s reg 0x%02x = 0x%02x   left %2d/%d (%3d%%)  right %2d/%d (%3d%%)\n",
+        name, reg, v, l, steps, l * 100 / steps, r, steps, r * 100 / steps);
+}
+
+/* Build a register value from a 0-100 percentage in the card's own layout. */
+static unsigned char level_to_reg(int pct)
+{
+    int n;
+
+    /* clamp before the multiply: pct >= 2182 overflows 16-bit int in pct*15 */
+    if (pct < 0)
+        pct = 0;
+    if (pct > 100)
+        pct = 100;
+    if (ver_major == 3) {               /* 3-bit fields at 7-5 and 3-1 */
+        n = (pct * 7 + 50) / 100;
+        return (unsigned char)((n << 5) | (n << 1));
+    }
+    n = (pct * 15 + 50) / 100;          /* same scaling as Linux change_bits */
+    return (unsigned char)((n << 4) | n);
+}
+
+/*
+ * Mute every input that is not the PCM path.  A playback-only driver has no use
+ * for the FM synthesiser, CD, line or microphone inputs, and whatever the card
+ * powers up with is mixed into the same output as the PCM.  On a board whose FM
+ * section is never initialised that is added noise for nothing.
+ */
+static void mute_inputs(void)
+{
+    mix_write(MIX_FM, 0x00);
+    mix_write(MIX_CD, 0x00);
+    mix_write(MIX_LINE, 0x00);
+    mix_write(MIX_MIC, 0x00);
+}
+
+/*
+ * AD1848 codec behind the OPTi's Sound Blaster personality.  Only reachable
+ * when MC5 SPACCESS is set.  The access idiom is the vendor driver's
+ * (Knipperts, AD1848.PAS ReadCODECReg): preserve the upper nibble of the index
+ * register - it holds INIT, MCE and TRD - and read the data port three times,
+ * which that driver marks "Errata for AD1848".
+ */
+#define WSS_BASE        0x530
+#define CODEC_BASE      (WSS_BASE + 4)      /* index, data, status, PIO */
+
+static const char *codec_rate(unsigned char v)
+{
+    static const char *xtal1[8] = { "8000", "16000", "27428", "32000",
+                                    "n/a", "n/a", "48000", "9600" };
+    static const char *xtal2[8] = { "5512", "11025", "18900", "22050",
+                                    "37800", "44100", "33075", "6620" };
+    unsigned char cfs = (unsigned char)((v >> 1) & 0x07);
+
+    return (v & 0x01)? xtal2[cfs] : xtal1[cfs];
+}
+
+static int codec_ready(void)
+{
+    int i;
+
+    for (i = 0; i < 30000; i++)
+        if (inb(CODEC_BASE) != 0x80)        /* 0x80 = still initialising */
+            return 0;
+    return -1;
+}
+
+static unsigned char codec_read(unsigned char reg)
+{
+    unsigned char old, v;
+
+    old = inb(CODEC_BASE);
+    outb((unsigned char)((old & 0xF0) | (reg & 0x0F)), CODEC_BASE);
+    mix_delay();
+    v = inb(CODEC_BASE + 1);
+    v = inb(CODEC_BASE + 1);
+    v = inb(CODEC_BASE + 1);            /* errata: read three times */
+    outb(old, CODEC_BASE);
+    mix_delay();
+    return v;
+}
+
+static void codec_dump(void)
+{
+    unsigned char i8, i9, i6, i7, st;
+
+    if (codec_ready() < 0) {
+        printf("codec: not answering at 0x%x", CODEC_BASE);
+        printf(" (MC5 SPACCESS clear, or not a MAD16)\n");
+        return;
+    }
+    i8 = codec_read(8);
+    i9 = codec_read(9);
+    i6 = codec_read(6);
+    i7 = codec_read(7);
+    st = inb(CODEC_BASE + 2);
+
+    printf("codec at 0x%x (index reg = 0x%02x)\n", CODEC_BASE, inb(CODEC_BASE));
+    printf("  I8  format 0x%02x  %s, %s, %s Hz\n", i8,
+        (i8 & 0x10)? "STEREO" : "mono",
+        (i8 & 0x20)? ((i8 & 0x40)? "8-bit A-law" : "8-bit u-law")
+                   : ((i8 & 0x40)? "16-bit signed" : "8-bit unsigned"),
+        codec_rate(i8));
+    printf("  I9  iface  0x%02x  playback %s, %s, %s\n", i9,
+        (i9 & 0x01)? "ENABLED" : "off",
+        (i9 & 0x40)? "PIO" : "DMA",
+        (i9 & 0x04)? "single-DMA" : "dual-DMA");
+    printf("  I6  left DAC  0x%02x  %s, -%d.5 dB\n", i6,
+        (i6 & 0x80)? "MUTED" : "on", (i6 & 0x3F) * 3 / 2);
+    printf("  I7  right DAC 0x%02x  %s, -%d.5 dB\n", i7,
+        (i7 & 0x80)? "MUTED" : "on", (i7 & 0x3F) * 3 / 2);
+    printf("  status 0x%02x\n", st);
+}
+
+static void usage(void)
+{
+    fprintf(stderr, "usage: sbmix [-p port] [-m pct] [-v pct] [-r reg]"
+        " [-s reg=val] [-z]\n");
+    fprintf(stderr, "       -m master level 0-100, -v voice (PCM) level 0-100\n");
+    fprintf(stderr, "       -r dump one register, -s write one raw register\n");
+    fprintf(stderr, "       -z mute the fm, cd, line and mic inputs\n");
+    fprintf(stderr, "       -k dump the AD1848 codec behind the SB personality\n");
+    fprintf(stderr, "       note: every run resets the DSP, which on some cards\n");
+    fprintf(stderr, "       restores mixer defaults - so pass all changes at once\n");
+    exit(1);
+}
+
+int main(int argc, char **argv)
+{
+    int c;
+    long master = -1, voice = -1, one = -1;
+    unsigned char v;
+    char *set = NULL;
+    int zap = 0, kdump = 0;
+
+    while ((c = getopt(argc, argv, "p:m:v:r:s:zk")) != -1) {
+        switch (c) {
+        case 'p': base = (unsigned int)strtol(optarg, (char **)0, 0); break;
+        case 'm': master = atol(optarg); break;
+        case 'v': voice = atol(optarg); break;
+        case 'r': one = strtol(optarg, (char **)0, 0); break;
+        case 's': set = optarg; break;
+        case 'z': zap = 1; break;
+        case 'k': kdump = 1; break;
+        default: usage();
+        }
+    }
+    if (optind < argc)
+        usage();
+
+    if (dsp_reset() < 0) {
+        fprintf(stderr, "sbmix: no card at 0x%x\n", base);
+        return 1;
+    }
+    if (dsp_write(DSP_GET_VERSION) == 0) {
+        unsigned char hi, lo;
+        if (dsp_read(&hi) == 0 && dsp_read(&lo) == 0) {
+            ver_major = hi;
+            ver_minor = lo;
+        }
+    }
+    printf("sb: dsp %d.%02d at 0x%x", ver_major, ver_minor, base);
+    if (ver_major == 0 || ver_major >= 3)
+        printf(", %s mixer, %s levels\n",
+            (ver_major >= 4)? "SB16" : "SB Pro",
+            (ver_major == 3)? "3-bit" : "4-bit");
+    else {
+        printf(", no mixer on this card\n");
+        /* a requested change was refused, and a script should see that */
+        return (set || zap || master >= 0 || voice >= 0)? 1 : 0;
+    }
+
+    if (set) {
+        char *eq = strchr(set, '=');
+        if (!eq)
+            usage();
+        *eq = '\0';
+        mix_write((unsigned char)strtol(set, (char **)0, 0),
+                  (unsigned char)strtol(eq + 1, (char **)0, 0));
+    }
+    if (zap)
+        mute_inputs();
+    if (master >= 0)
+        mix_write(MIX_MASTER, level_to_reg((int)master));
+    if (voice >= 0)
+        mix_write(MIX_VOICE, level_to_reg((int)voice));
+
+    if (one >= 0) {
+        printf("  reg 0x%02x = 0x%02x\n", (unsigned)one,
+            mix_read((unsigned char)one));
+        return 0;
+    }
+
+    if (kdump)
+        codec_dump();
+
+    show("master", MIX_MASTER);
+    show("voice", MIX_VOICE);
+    show("fm", MIX_FM);
+    show("cd", MIX_CD);
+    show("line", MIX_LINE);
+    printf("  %-8s reg 0x%02x = 0x%02x\n", "mic", MIX_MIC, mix_read(MIX_MIC));
+    v = mix_read(MIX_FILTER);
+    printf("  %-8s reg 0x%02x = 0x%02x   %s, output filter %s\n", "outmode",
+        MIX_FILTER, v, (v & 0x02)? "STEREO" : "mono",
+        (v & 0x20)? "off" : "on");
+    return 0;
+}

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -164,6 +164,13 @@ endif
 	$(MKDEV) /dev/psaux c 4 32
 
 ##############################################################################
+# Sound Blaster DSP
+
+ifdef CONFIG_CHAR_DEV_DSP
+	$(MKDEV) /dev/dsp	c 5 0 1 1 0666
+endif
+
+##############################################################################
 # Parallel devices, as detected by the ROM BIOS.
 
 	$(MKDEV) /dev/lp	c 6 0

--- a/libc/include/sys/soundcard.h
+++ b/libc/include/sys/soundcard.h
@@ -1,0 +1,7 @@
+#ifndef _SYS_SOUNDCARD_H
+#define _SYS_SOUNDCARD_H
+
+#include <features.h>
+#include __SYSINC__(soundcard.h)
+
+#endif

--- a/qemu.sh
+++ b/qemu.sh
@@ -103,7 +103,8 @@ hostfwd=tcp::8047-:49827,\
 hostfwd=tcp::8048-:49828,\
 hostfwd=tcp::8049-:49829,\
 hostfwd=tcp::49152-:49152,\
-hostfwd=tcp::49153-:49153"
+hostfwd=tcp::49153-:49153,\
+hostfwd=tcp::4950-:4950"
 
 # new style
 #NET="-net nic,model=ne2k_isa -net user,$FWD"


### PR DESCRIPTION
A playback-only OSS-style sound system for 8-bit ISA machines, tested functional on a real Amstrad PC1640 DD.

**Depends on #2785** and is branched on top of it: `dsp-sb.c` shares the 8237 Extended Write support (`dmaxw=1`) added there. Merging #2785 first reduces this PR to the single sound commit.

## Kernel

**`dsp-sb.c`** — Sound Blaster driver for `/dev/dsp` (major 5). Mono unsigned 8-bit PCM, 4000–20000 Hz, via the classic DSP `0x14` single-block command and 8-bit DMA on channel 1 or 3. Double-buffered low-memory bounce buffer: the next block is copied while the current one plays. OSS ioctls: `SETFMT`, `SPEED`, `CHANNELS`, `GETBLKSIZE`, `SYNC`, `GETERROR` (underrun counts). Where the card has a mixer (DSP 3.x) it is programmed in the open path — a DSP reset restores the card's own mixer defaults, so open is the one place levels stick.

**`dsp-mad16.c`** — optional OPTi 82C929 (MAD16) early init, `CONFIG_SB_MAD16`. Cards built on the 82C929 power up unrouted: the DSP answers at 0x220, so open/ioctl all succeed, but no IRQ or DMA reaches the bus until the MC registers are programmed through the password gate. Without this, the first real DMA block times out with one underrun — a confusing failure this init removes.

**/bootopts**: `sb=port,irq,dma` (`sb=off` to disable), `mad16=on` / `mad16=port,irq,dma`, and `lptirq=0` to mask the printer port's interrupt at boot. IRQ 7 is shared between LPT1 and 8-bit sound cards, LPT1 powers up with its interrupt enabled, and a floating ACK fires the sound ISR mid-transfer, which is audible as distortion; the ELKS `lp` driver polls and never claims IRQ 7, so nothing is lost.

**Config**: menuconfig entries for the driver, port, IRQ, DMA channel, buffer size and MAD16 init, each with `Configure.help` text including the XT-specific conflict guidance (an XT hard disk controller owns IRQ 5 and DMA 3, so IRQ 7 + DMA 1 is the jumpering to aim for). `/dev/dsp` is created by `Make.devices` when configured, and `ports.h` documents the IRQ usage.

## Userland

- **`audioplay`** — play raw PCM from a file or stdin; re-reads the rate after `SPEED` so quantised rates are visible.
- **`sbmix`** — mixer levels from the command line.
- **`audiorecv`** — TCP daemon that streams network PCM straight into `/dev/dsp` (ELKS sockets have no UDP), so a host can pipe `sox`/`ffmpeg` output at the machine: `sox in.wav -t raw -r 8000 -c 1 -b 8 -e unsigned - | nc elks 4950`. Ships as a commented `net.cfg` example, with a `qemu.sh` port forward for emulator testing.
- **`Documentation/text/dsp-sb.txt`** — format contract, host-side pipelines, bandwidth notes.

## Testing

Running on real hardware: an Amstrad PC1640 DD with an OPTi 82C929A card brought up by the MAD16 path, playing clean 8-bit PCM over DMA channel 1 / IRQ 7 with `dmaxw=1` and `lptirq=0` — both locally with `audioplay` and streamed continuously from a modern host through `audiorecv` at 11025 Hz. Also exercised extensively against 86Box (Sound Blaster Pro v2). Kernel and all three userland programs build clean against this branch.