### PR TITLE
MFM driver: park heads on shutdown

### DIFF
--- a/elks/arch/i86/drivers/block/mfmhd.c
+++ b/elks/arch/i86/drivers/block/mfmhd.c
@@ -61,8 +61,7 @@
 #include <arch/segment.h>
 #include <arch/system.h>
 #include <arch/divmod.h>
-
-#include "mfmhd.h"
+#include <arch/mfmhd.h>
 
 #define MAJOR_NR        MFMHD_MAJOR
 #include "blk.h"
@@ -75,7 +74,7 @@
 #define MFM_HD_JUMPER           2
 #define MFM_HD_CONTROL          3
 
-/* Hardware status register bits, mirrored in mfmhd.h for user tools. */
+/* Hardware status register bits, mirrored in arch/mfmhd.h for user tools. */
 #define MFM_STAT_READY          MFMHD_STAT_READY
 #define MFM_STAT_INPUT          MFMHD_STAT_INPUT
 #define MFM_STAT_COMMAND        MFMHD_STAT_COMMAND
@@ -108,6 +107,7 @@
 #define MFM_CMD_TEST_DRIVE_READY        MFMHD_CMD_TEST_DRIVE_READY
 #define MFM_CMD_RECALIBRATE             MFMHD_CMD_RECALIBRATE
 #define MFM_CMD_SENSE                   MFMHD_CMD_READ_STATUS
+#define MFM_CMD_SEEK                    MFMHD_CMD_SEEK
 #define MFM_CMD_READ_SECTORS            MFMHD_CMD_READ_SECTORS
 #define MFM_CMD_WRITE_SECTORS           MFMHD_CMD_WRITE_SECTORS
 #define MFM_CMD_INIT_DRIVE_PARAMETERS   MFMHD_CMD_INIT_DRIVE_PARAMETERS
@@ -1116,6 +1116,7 @@ mfmhd_command_wait_ticks(unsigned char op)
 {
     switch (op) {
     case MFM_CMD_RECALIBRATE:
+    case MFM_CMD_SEEK:              /* a park is a full stroke, 3ms a step */
     case MFM_CMD_READ_SECTORS:
     case MFM_CMD_WRITE_SECTORS:
     case MFM_CMD_INIT_DRIVE_PARAMETERS:
@@ -1703,6 +1704,15 @@ mfmhd_recalibrate_drive(unsigned int port, int drive)
     mfmhd_recalibrate_unit(port, drive, (unsigned int)drive & 1U);
 }
 
+static void
+mfmhd_seek_unit(unsigned int port, int drive, unsigned int unit,
+    unsigned short cylinder)
+{
+    mfmhd_build_command(mfmhd_cmdblk, MFM_CMD_SEEK, (unsigned char)unit,
+        0, cylinder, 0, 0, mfmhd_drive_cmd_control(drive));
+    (void)mfmhd_cmd(port, mfmhd_cmdblk, NULL, 0, NULL, 0);
+}
+
 static int
 mfmhd_reset_controller(unsigned int port)
 {
@@ -2287,6 +2297,42 @@ struct gendisk * INITPROC mfmhd_init(void)
         mfmhd_pio ? "pio" : "dma=3", mfmhd_extwrite ? " xw" : "");
     mfmhd_debug_set(91, -1, MFMHD_PORT, 0);
     return &mfmhd_gendisk;
+}
+
+/*
+ * Park heads before the machine stops.  The last cylinder is the landing
+ * zone on an ST-506 drive, which is where an unpowered head should settle.
+ * This goes out as the controller's own SEEK, so it works with the option
+ * ROM strapped off, which is the case CONFIG_BLK_DEV_MFMHD exists for, and
+ * leaves the driver free of BIOS calls for the protected mode kernel.
+ * Errors are ignored, there being nothing left to retry against.
+ */
+void mfmhd_park_all(void)
+{
+    int drive;
+
+    if (!mfmhd_initialized)
+        return;
+
+    for (drive = 0; drive < MFMHD_DRIVES; drive++) {
+        if (!drive_info[drive].heads || !drive_info[drive].cylinders)
+            continue;
+
+        /*
+         * A FileCard 20 is one drive spread over both controller units,
+         * each with an actuator of its own, so park the pair.
+         */
+        if (drive == 0 && drive_info[drive].source == MFM_GEO_SRC_FILECARD20) {
+            mfmhd_seek_unit(MFMHD_PORT, drive, 0,
+                MFM_FILECARD20_UNIT_CYLINDERS - 1);
+            mfmhd_seek_unit(MFMHD_PORT, drive, 1,
+                MFM_FILECARD20_UNIT_CYLINDERS - 1);
+            continue;
+        }
+
+        mfmhd_seek_unit(MFMHD_PORT, drive, (unsigned int)drive & 1U,
+            drive_info[drive].cylinders - 1);    /* cylinders are zero based */
+    }
 }
 
 static int

--- a/elks/include/arch/mfmhd.h
+++ b/elks/include/arch/mfmhd.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#ifndef _I86_DRIVERS_BLOCK_MFMHD_H
-#define _I86_DRIVERS_BLOCK_MFMHD_H
+#ifndef __ARCH_MFMHD_H
+#define __ARCH_MFMHD_H
 
 /* Current ELKS port: G Keet <gatekeeper@xt-emporium.com>, 2026. */
 
@@ -144,4 +144,8 @@ struct mfmhd_ioc_buffer {
     unsigned char sense[4];
 };
 
-#endif /* _I86_DRIVERS_BLOCK_MFMHD_H */
+#ifdef __KERNEL__
+void mfmhd_park_all(void);      /* seek the heads to the landing zone */
+#endif
+
+#endif /* __ARCH_MFMHD_H */

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -19,6 +19,7 @@
 #include <arch/segment.h>
 #include <arch/system.h>
 #include <arch/io.h>
+#include <arch/mfmhd.h>
 
 /*
  * reboot doesn't sync: do that yourself before calling this.
@@ -30,6 +31,9 @@ int sys_reboot(unsigned int magic, unsigned int magic_too, int flag)
 
 #ifdef CONFIG_BLK_DEV_BHD
     bios_disk_park_all();
+#endif
+#ifdef CONFIG_BLK_DEV_MFMHD
+    mfmhd_park_all();
 #endif
     switch(flag) {
     case RB_REBOOT:


### PR DESCRIPTION
Parks the MFM drives on shutdown, which the driver did not do.

sys_reboot seeks each drive to its last cylinder, the landing zone on an ST-506, so an unpowered head settles off the data area. The call sits next to the existing bios_disk_park_all under its own ifdef.

It goes through the BIOS seek rather than the controller's own SEEK command block. That is smaller, and on any board whose option ROM is enabled it is the same seek the BIOS driver already performs. Worth saying plainly though: it depends on that ROM hooking INT 13h. A card strapped with its ROM off is exactly the case CONFIG_BLK_DEV_MFMHD exists for, and there BD_DX = 0x80 + drive addresses whatever the system BIOS thinks drive 80h is. If you would rather it used MFMHD_CMD_SEEK, which needs no ROM, say so and I will swap it, it is about ten lines more.

Two notes on reusing the BIOS interface from a driver: bdt is bios.c's own static and the BD_ macros name it by identifier, so this declares its own struct biosparms, and zeroes it because a local starts as stack garbage where the static did not.

Tested on an Amstrad PC1640 with a WD1002A-WX1. Rebooted through the new path, the machine came back, the filesystem mounted clean and the disk reads normally. What that does not show is the heads actually moving, which is not observable from software.

Touches mfmhd.c, as does #2791. They edit different parts of the file so they should not conflict, but whichever lands second may want a look.
