### PR TITLE
[kernel] Use himem.sys method to enable A20 for greater 8042 compatibility

### DIFF
--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -68,10 +68,14 @@ unsigned int INITPROC setup_arch(void)
 
     arch_cpu = SETUP_CPU_TYPE;
 #ifdef SYS_CAPS
-    sys_caps = SYS_CAPS;    /* custom system capabilities */
+    sys_caps = SYS_CAPS;                /* custom system capabilities */
 #else
     if (arch_cpu >= CPU_80286)          /* 80286+ IBM PC/AT capabilities or Unknown CPU */
         sys_caps = CAP_ALL;
+#ifdef CONFIG_ARCH_IBMPC
+    else if (peekb(0x96, BIOSSEG) & 0x10)
+        sys_caps |= CAP_KBD_LEDS;       /* 101/102 enhanced keyboard installed */
+#endif
     debug("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
 #endif
 

--- a/elks/arch/i86/lib/a20-ibm.inc
+++ b/elks/arch/i86/lib/a20-ibm.inc
@@ -13,8 +13,8 @@
 #   USE_A20ASM		- use Chris Giese A20.ASM method (send D0, read, OR 2, D1, write)
 #   USE_HIMEM_AT	- use himem.sys PC AT method (send D1,DF,FF)
 #define USE_BIOS
-#define USE_A20ASM
-//#define USE_HIMEM_AT
+//#define USE_A20ASM
+#define USE_HIMEM_AT
 
 # Attempt to enable A20 address gate, return 0 on fail
 enable_a20_gate:


### PR DESCRIPTION
After research and discussion in #2790, this changes the A20 enable mechanism to use the method employed by DOS himem.sys, which should allow for more compatibility with the various implementations of the 8042 keyboard controller.

As also discussed in #2790, the BIOS Data Area location 40:96 bit 4 is checked to see whether an 101/102 enhanced keyboard is installed, and enables CAP_KBD_LEDS so that the LEDS are processed during keypresses.

@EC1842, can you please test this to verify it works on your hardware?