### PR TITLE
[net] ktcp rework: memory, throughput, UDP sockets

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -106,6 +106,12 @@ setsockopt	+80	5	= CONFIG_SOCKET
 getsocknam	+81	4	= CONFIG_SOCKET
 fmemalloc	+82	2	*
 fmemfree	+83	1	*
+# datagram send/recv. POSIX takes 6 args; ELKS syscalls take at most 5
+# (bx,cx,dx,di,si - libc/system/syscall0.inc), so addrlen is dropped and
+# fixed at sizeof(struct sockaddr_in). libc restores the POSIX shape,
+# exactly as getsocknam does for getsockname/getpeername.
+_sendto	+84	5	= CONFIG_SOCKET
+_recvfrom	+85	5	= CONFIG_SOCKET
 #
 # Name			No	Args	Flag&comment
 #

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -75,6 +75,13 @@
 #define ESERVERERR      129     /* Server error */
 #define ERESTARTSYS     512     /* Restart system call*/
 
+/* datagram sockets need these; moved out of the UNUSED block below when
+ * sendto/recvfrom were added. Remember etc/perror needs matching strings. */
+#define EDESTADDRREQ    89      /* Destination address required */
+#define EMSGSIZE        90      /* Message too long */
+#define EPROTOTYPE      91      /* Protocol wrong type for socket */
+#define EOPNOTSUPP      95      /* Operation not supported on transport endpoint */
+
 #if UNUSED
 /* when any of these added in, add string to etc/perror as well */
 #define EWOULDBLOCK     41      /* Operation would block */
@@ -124,13 +131,9 @@
 #define ESTRPIPE        86      /* Streams pipe error */
 #define EUSERS          87      /* Too many users */
 
-#define EDESTADDRREQ    89      /* Destination address required */
-#define EMSGSIZE        90      /* Message too long */
-#define EPROTOTYPE      91      /* Protocol wrong type for socket */
 #define ENOPROTOOPT     92      /* Protocol not available */
 #define EPROTONOSUPPORT 93      /* Protocol not supported */
 #define ESOCKTNOSUPPORT 94      /* Socket type not supported */
-#define EOPNOTSUPP      95      /* Operation not supported on transport endpoint */
 #define EPFNOSUPPORT    96      /* Protocol family not supported */
 #define EAFNOSUPPORT    97      /* Address family not supported by protocol */
 

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -74,6 +74,7 @@ struct proto_ops {
 #define SF_RST_ON_CLOSE	(1 << 4) /* inet */
 #define SF_REUSE_ADDR	(1 << 5) /* inet */
 #define SF_CONNECT	(1 << 6) /* inet */
+#define SF_DGRAM	(1 << 7) /* inet: SOCK_DGRAM socket (bit 7 was free) */
 
 struct net_proto {
     const char *name;		/* Protocol name */

--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -19,12 +19,35 @@ struct sockaddr {
 #define SO_LINGER	13		/* only implemented for l_linger = 0*/
 
 /* non-standard options */
-#define SO_LISTEN_BUFSIZ	128	/* suggested buffer size for listen to save mem*/
+/*
+ * SO_RCVBUF on a socket that goes on to listen() sets the receive ring of the
+ * connections it ACCEPTS, not of the listening socket (which never receives
+ * anything). Pick by what the protocol actually carries: an over-large ring
+ * costs connection count, an under-large one costs throughput, and ktcp
+ * advertises an MSS no larger than the ring so a small choice stays correct.
+ */
+#define SO_LISTEN_BUFSIZ	128	/* deprecated, was "small ring for the listener
+					 * itself"; too small to accept data into */
+#define SO_ACCEPT_BUFSIZ_TINY	512	/* small fixed packets: telnetd, elkscraft */
+#define SO_ACCEPT_BUFSIZ_SMALL	1024	/* request/response: httpd, ftpd control */
+#define SO_ACCEPT_BUFSIZ_BULK	4096	/* streaming: ftpd data, audiorecv, vidrecv */
 
 struct linger {
         int             l_onoff;        /* Linger active                */
         int             l_linger;       /* How long to linger for       */
 };
+
+/*
+ * Flags for sendto/recvfrom. Only the two that can be honoured are accepted;
+ * the rest return -EOPNOTSUPP rather than being silently ignored, so a caller
+ * can tell "not supported" from "bad argument".
+ */
+#define MSG_OOB		0x01	/* not supported */
+#define MSG_PEEK	0x02	/* not supported */
+#define MSG_DONTROUTE	0x04	/* not supported */
+#define MSG_TRUNC	0x20	/* recv: report the real datagram length */
+#define MSG_DONTWAIT	0x40	/* supported */
+#define MSG_SUPPORTED	(MSG_TRUNC|MSG_DONTWAIT)
 
 #define AF_INET	0
 #define AF_UNIX	1

--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -19,13 +19,8 @@ struct sockaddr {
 #define SO_LINGER	13		/* only implemented for l_linger = 0*/
 
 /* non-standard options */
-/*
- * SO_RCVBUF on a socket that goes on to listen() sets the receive ring of the
- * connections it ACCEPTS, not of the listening socket (which never receives
- * anything). Pick by what the protocol actually carries: an over-large ring
- * costs connection count, an under-large one costs throughput, and ktcp
- * advertises an MSS no larger than the ring so a small choice stays correct.
- */
+/* SO_RCVBUF on a socket that then listens sets the ring of the connections
+ * it accepts, the listener never receives anything itself */
 #define SO_LISTEN_BUFSIZ	128	/* deprecated, was "small ring for the listener
 					 * itself"; too small to accept data into */
 #define SO_ACCEPT_BUFSIZ_TINY	512	/* small fixed packets: telnetd, elkscraft */
@@ -37,11 +32,8 @@ struct linger {
         int             l_linger;       /* How long to linger for       */
 };
 
-/*
- * Flags for sendto/recvfrom. Only the two that can be honoured are accepted;
- * the rest return -EOPNOTSUPP rather than being silently ignored, so a caller
- * can tell "not supported" from "bad argument".
- */
+/* only the two we can honour are accepted, the rest are -EOPNOTSUPP rather
+ * than silently ignored */
 #define MSG_OOB		0x01	/* not supported */
 #define MSG_PEEK	0x02	/* not supported */
 #define MSG_DONTROUTE	0x04	/* not supported */

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -15,12 +15,8 @@
 
 #define TCPDEV_INBUFFERSIZE	1500	/* max data writable to tcpdev from ktcp*/
 
-/*
- * Largest kernel->ktcp message. Both tdb_write and tdb_sendto embed
- * data[TDB_WRITE_MAX]; tdb_sendto is the larger because it also carries a
- * destination address, so it sets the size. Note TDB_WRITE_MAX must not be
- * added on top - doing so oversized tdout_buf by exactly one payload.
- */
+/* largest kernel->ktcp message. tdb_sendto is the bigger of the two as it
+ * also carries an address. do not add TDB_WRITE_MAX on top, it is embedded */
 #define TCPDEV_OUTBUFFERSIZE	(sizeof(struct tdb_sendto) > sizeof(struct tdb_write)? \
 				 sizeof(struct tdb_sendto): sizeof(struct tdb_write))
 
@@ -62,10 +58,7 @@ struct tdb_listen {
 struct tdb_bind {
     unsigned char cmd;
     unsigned char proto;	/* 0 = SOCK_STREAM, 1 = SOCK_DGRAM. Uses the pad
-				 * byte that already sat here for alignment, so
-				 * the struct does not grow. Needed only at bind:
-				 * it is the one point where ktcp must choose
-				 * which table the socket comes from. */
+				 * byte that was already here for alignment */
     struct socket *sock;
     int reuse_addr;
     int rcv_bufsiz;
@@ -75,11 +68,7 @@ struct tdb_bind {
 #define TDB_PROTO_STREAM	0
 #define TDB_PROTO_DGRAM		1
 
-/*
- * Datagram send. A datagram is atomic, so unlike TDC_WRITE there is no
- * chunking loop - the payload is bounded by TDB_WRITE_MAX and anything larger
- * is refused with -EMSGSIZE rather than truncated.
- */
+/* datagram send. atomic, so no chunking loop, oversize is -EMSGSIZE */
 struct tdb_sendto {
     unsigned char cmd;
     unsigned char msgflags;	/* MSG_* (was padding) */
@@ -155,17 +144,10 @@ struct tdb_bind_ret {
     __u16 addr_port;
 };
 
-/*
- * Datagram delivery. The first four members are deliberately laid out
- * identically to struct tdb_return_data (type@0, ret_value@2, sock@4, size@6)
- * so inet_process_tcpdev() can keep dereferencing ->sock and switching on
- * ->type without knowing which reply it has.
- *
- * avail_next carries the size of the NEXT queued datagram in this same reply.
- * ktcp must not follow up with an unsolicited TDT_AVAIL_DATA here: down() on
- * the shared buffer is an uninterruptible sleep_on, so a second write from
- * ktcp would stall the whole stack until an application process drained it.
- */
+/* first four members match struct tdb_return_data so inet_process_tcpdev
+ * can switch on ->type without knowing which reply it has. avail_next is the
+ * size of the next queued datagram, ktcp must not send a separate
+ * TDT_AVAIL_DATA or it stalls the stack on the shared buffer */
 struct tdb_recvfrom_ret {
     char type;			/*  0 */
     char trunc;			/*  1  datagram was longer than the buffer */

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -14,9 +14,20 @@
 #define	TDB_WRITE_MAX		512	/* max data in tdb_write packet to ktcp*/
 
 #define TCPDEV_INBUFFERSIZE	1500	/* max data writable to tcpdev from ktcp*/
-#define TCPDEV_OUTBUFFERSIZE	(TDB_WRITE_MAX + sizeof(struct tdb_write))
 
-#define TCPDEV_MAXREAD TCPDEV_INBUFFERSIZE - sizeof(struct tdb_return_data)
+/*
+ * Largest kernel->ktcp message. Both tdb_write and tdb_sendto embed
+ * data[TDB_WRITE_MAX]; tdb_sendto is the larger because it also carries a
+ * destination address, so it sets the size. Note TDB_WRITE_MAX must not be
+ * added on top - doing so oversized tdout_buf by exactly one payload.
+ */
+#define TCPDEV_OUTBUFFERSIZE	(sizeof(struct tdb_sendto) > sizeof(struct tdb_write)? \
+				 sizeof(struct tdb_sendto): sizeof(struct tdb_write))
+
+/* max datagram deliverable up to the kernel in one TDT_RECVFROM */
+#define TCPDEV_MAXDGRAM		(TCPDEV_INBUFFERSIZE - sizeof(struct tdb_recvfrom_ret))
+
+#define TCPDEV_MAXREAD		(TCPDEV_INBUFFERSIZE - sizeof(struct tdb_return_data))
 
 /* outgoing ops */
 #define TDC_BIND	1
@@ -24,6 +35,8 @@
 #define TDC_CONNECT	3
 #define TDC_LISTEN	4
 #define TDC_RELEASE	5
+#define TDC_SENDTO	6	/* datagram out, carries the destination */
+#define TDC_RECVFROM	7	/* datagram in, reply carries the source */
 #define TDC_READ	8
 #define TDC_WRITE	9
 
@@ -48,10 +61,42 @@ struct tdb_listen {
 
 struct tdb_bind {
     unsigned char cmd;
+    unsigned char proto;	/* 0 = SOCK_STREAM, 1 = SOCK_DGRAM. Uses the pad
+				 * byte that already sat here for alignment, so
+				 * the struct does not grow. Needed only at bind:
+				 * it is the one point where ktcp must choose
+				 * which table the socket comes from. */
     struct socket *sock;
     int reuse_addr;
     int rcv_bufsiz;
     struct sockaddr_in addr;
+};
+
+#define TDB_PROTO_STREAM	0
+#define TDB_PROTO_DGRAM		1
+
+/*
+ * Datagram send. A datagram is atomic, so unlike TDC_WRITE there is no
+ * chunking loop - the payload is bounded by TDB_WRITE_MAX and anything larger
+ * is refused with -EMSGSIZE rather than truncated.
+ */
+struct tdb_sendto {
+    unsigned char cmd;
+    unsigned char msgflags;	/* MSG_* (was padding) */
+    struct socket *sock;
+    __u32 daddr;		/* destination, network byte order */
+    __u16 dport;		/* destination port, network byte order */
+    int size;
+    int nonblock;
+    unsigned char data[TDB_WRITE_MAX];
+};
+
+struct tdb_recvfrom {
+    unsigned char cmd;
+    unsigned char msgflags;
+    struct socket *sock;
+    int size;			/* user buffer size */
+    int nonblock;
 };
 
 struct tdb_connect {
@@ -82,6 +127,7 @@ struct tdb_write {
 #define TDT_ACCEPT	4
 #define TDT_BIND	5
 #define TDT_CONNECT	6
+#define TDT_RECVFROM	7	/* datagram up, with its source address */
 
 struct tdb_return_data {
     char type;
@@ -109,7 +155,34 @@ struct tdb_bind_ret {
     __u16 addr_port;
 };
 
+/*
+ * Datagram delivery. The first four members are deliberately laid out
+ * identically to struct tdb_return_data (type@0, ret_value@2, sock@4, size@6)
+ * so inet_process_tcpdev() can keep dereferencing ->sock and switching on
+ * ->type without knowing which reply it has.
+ *
+ * avail_next carries the size of the NEXT queued datagram in this same reply.
+ * ktcp must not follow up with an unsolicited TDT_AVAIL_DATA here: down() on
+ * the shared buffer is an uninterruptible sleep_on, so a second write from
+ * ktcp would stall the whole stack until an application process drained it.
+ */
+struct tdb_recvfrom_ret {
+    char type;			/*  0 */
+    char trunc;			/*  1  datagram was longer than the buffer */
+    int ret_value;		/*  2  bytes copied, or -errno */
+    struct socket *sock;	/*  4 */
+    int size;			/*  6  bytes of data[] following */
+    __u32 saddr;		/*  8  source, network byte order */
+    __u16 sport;		/* 12  source port, network byte order */
+    __u16 avail_next;		/* 14  size of next queued datagram, 0 if none */
+    unsigned char data[];	/* 16 */
+};
+
+#ifdef __KERNEL__
+/* kernel-internal; ktcp includes this header too and must not see these */
+#include <linuxmt/init.h>
 extern void tcpdev_clear_data_avail(void);
-extern int inet_process_tcpdev(char *buf, int len);
+extern int FARPROC inet_process_tcpdev(char *buf, int len);
+#endif
 
 #endif

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -135,11 +135,7 @@ static int inet_release(struct socket *sock, struct socket *peer)
     return (ret >= 0 ? 0 : ret);
 }
 
-/*
- * Core of bind, taking the address already in kernel space. Split out so the
- * datagram path can bind an ephemeral port itself (inet_autobind) without
- * having to fake a user-space pointer.
- */
+/* bind with the address already in kernel space, for inet_autobind */
 static int FARPROC inet_bind_kernel(register struct socket *sock, struct sockaddr_in *addr)
 {
     register struct tdb_bind *cmd;
@@ -201,16 +197,8 @@ static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
     if (get_user(&(((struct sockaddr_in *)uservaddr)->sin_family)) != AF_INET)
         return -EINVAL;
 
-    /*
-     * connect() on a datagram socket is purely local: it records the peer so
-     * send()/write() need no address and so ktcp will filter arriving
-     * datagrams to that source. No packets, no handshake, and re-connecting
-     * to a different peer is allowed.
-     *
-     * Note ELKS cannot implement the BSD "connect to AF_UNSPEC to dissolve
-     * the association" idiom, because AF_INET is 0 - there is no distinct
-     * AF_UNSPEC to test for.
-     */
+    /* just records the peer, no packets. cannot dissolve the association
+     * the bsd way as AF_INET is 0, there is no AF_UNSPEC to test for */
     if (sock->flags & SF_DGRAM) {
         struct sockaddr_in kaddr;
         int ret;
@@ -332,17 +320,8 @@ static int inet_read(struct socket *sock, char *ubuf, int size, int nonblock)
         if (sock->flags & SF_CLOSING)
             return 0;
 
-        /*
-         * O_NONBLOCK was accepted and then ignored here: the flag was only
-         * forwarded to ktcp further down, which is reached after data has
-         * already arrived. So a nonblocking read on a quiet connected socket
-         * slept anyway, and a single silent peer - a port scanner, a paused
-         * client - parked the whole process. A server polling its clients
-         * could therefore never come back to run its own timeouts, never reap
-         * dead connections, and every connection it held on to kept its
-         * control block alive in ktcp until the heap ran out and every TCP
-         * service on the machine died with it.
-         */
+        /* O_NONBLOCK was ignored here, so a nonblocking read on a quiet
+         * socket slept anyway and one silent peer parked the process */
         if (nonblock)
             return -EAGAIN;
 
@@ -441,13 +420,8 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
         if (ret < 0) {
             if (ret == -ERESTARTSYS) {
-                /*
-                 * ktcp is flow-controlling us (retransmit memory or the
-                 * congestion window). Same bug as the read path: O_NONBLOCK
-                 * was ignored, so a nonblocking write on a congested socket
-                 * span here at 10Hz forever instead of failing. Report the
-                 * bytes already accepted, or EAGAIN if none.
-                 */
+                /* ktcp is flow controlling us. same O_NONBLOCK bug as the
+                 * read path, it span here at 10Hz instead of failing */
                 if (nonblock)
                     return (count < size)? size - count: -EAGAIN;
 
@@ -473,12 +447,8 @@ static int inet_select(register struct socket *sock, int sel_type)
     debug_net("INET(%P) select sock %04x wait %04x type %d avail %u\n",
          sock, sock->wait, sel_type, sock->avail_data);
 
-    /*
-     * Datagram sockets are handled first and never consult sock->state. The
-     * TCP rule below ("readable unless SS_CONNECTED") would make an
-     * unconnected datagram socket permanently readable, and unconnected is
-     * the normal case here.
-     */
+    /* datagrams first, the tcp rule below would call an unconnected
+     * socket permanently readable */
     if (sock->flags & SF_DGRAM) {
         if (sel_type == SEL_IN) {
             if (sock->avail_data)       /* a datagram is queued in ktcp */
@@ -503,12 +473,8 @@ static int inet_select(register struct socket *sock, int sel_type)
     return 0;
 }
 
-/*
- * Give an unbound datagram socket an ephemeral port before any data moves.
- * Doing it here rather than in ktcp means ktcp always holds a udp_sock for a
- * handle before it sees traffic for it, and getsockname() works on a socket
- * that only ever called sendto().
- */
+/* ephemeral port before any data moves, so ktcp always has a udp_sock for
+ * the handle before traffic arrives */
 static int FARPROC inet_autobind(struct socket *sock)
 {
     struct sockaddr_in addr;
@@ -521,10 +487,7 @@ static int FARPROC inet_autobind(struct socket *sock)
     return inet_bind_kernel(sock, &addr);
 }
 
-/*
- * Record the peer with ktcp so arriving datagrams can be filtered to it. No
- * packet goes on the wire; ktcp answers immediately from its UDP table.
- */
+/* record the peer with ktcp, nothing goes on the wire */
 static int FARPROC inet_dgram_connect(struct socket *sock, struct sockaddr_in *addr)
 {
     register struct tdb_connect *cmd;
@@ -611,10 +574,7 @@ static int FARPROC inet_dgram_recv(register struct socket *sock, char *ubuf, int
         size = TCPDEV_MAXDGRAM;
 
     for (;;) {
-        /*
-         * No SF_CLOSING/EOF test here: a datagram socket has no end of
-         * stream. Non-blocking returns without troubling ktcp at all.
-         */
+        /* no EOF test, a datagram socket has no end of stream */
         while (sock->avail_data == 0) {
             if (nonblock || (flags & MSG_DONTWAIT))
                 return -EAGAIN;
@@ -645,8 +605,7 @@ static int FARPROC inet_dgram_recv(register struct socket *sock, char *ubuf, int
                 from.sin_port = r->sport;
                 memcpy_tofs(uaddr, &from, sizeof(from));
             }
-            /* ktcp tells us what is still queued, so a second recv can go
-             * straight out without waiting to be told again */
+            /* ktcp tells us what is still queued */
             down(&sock->sem);
             sock->avail_data = r->avail_next;
             up(&sock->sem);
@@ -654,11 +613,8 @@ static int FARPROC inet_dgram_recv(register struct socket *sock, char *ubuf, int
         tcpdev_clear_data_avail();
         up(&rwlock);
 
-        /*
-         * avail_data can be stale: two processes sharing the fd after fork()
-         * can both see it set and race for one datagram. ktcp is the
-         * authority, so the loser simply goes back to sleep.
-         */
+        /* avail_data can be stale after fork, ktcp is the authority so the
+         * loser goes back to sleep */
         if (ret == -EAGAIN && !nonblock && !(flags & MSG_DONTWAIT)) {
             down(&sock->sem);
             sock->avail_data = 0;

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -14,6 +14,7 @@
 #include <linuxmt/config.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/socket.h>
+#include <linuxmt/string.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/stat.h>
@@ -23,6 +24,7 @@
 #include <linuxmt/in.h>
 #include <linuxmt/tcpdev.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/init.h>
 #include <arch/irq.h>
 
 #include "af_inet.h"
@@ -37,7 +39,16 @@ extern char *get_tdout_buf(void);
 
 static sem_t rwlock;    /* global inet_read/write semaphore*/
 
-int inet_process_tcpdev(register char *buf, int len)
+/* datagram helpers, defined below */
+static int FARPROC inet_bind_kernel(struct socket *sock, struct sockaddr_in *addr);
+static int FARPROC inet_autobind(struct socket *sock);
+static int FARPROC inet_dgram_connect(struct socket *sock, struct sockaddr_in *addr);
+static int FARPROC inet_dgram_send(struct socket *sock, char *ubuf, int size,
+                           int nonblock, unsigned int flags, struct sockaddr *uaddr);
+static int FARPROC inet_dgram_recv(struct socket *sock, char *ubuf, int size,
+                           int nonblock, unsigned int flags, struct sockaddr *uaddr);
+
+int FARPROC inet_process_tcpdev(register char *buf, int len)
 {
     register struct socket *sock;
 
@@ -80,6 +91,7 @@ int inet_process_tcpdev(register char *buf, int len)
     case TDT_RETURN:
     case TDT_ACCEPT:
     case TDT_BIND:
+    case TDT_RECVFROM:
         debug_net("INET(%P) retval %d bufin %d\n",
             ((struct tdb_return_data *)buf)->ret_value, bufin_sem);
         /* tcpdev_clear_data_avail() called by woken process */
@@ -123,26 +135,24 @@ static int inet_release(struct socket *sock, struct socket *peer)
     return (ret >= 0 ? 0 : ret);
 }
 
-static int inet_bind(register struct socket *sock, struct sockaddr *addr,
-                     size_t sockaddr_len)
+/*
+ * Core of bind, taking the address already in kernel space. Split out so the
+ * datagram path can bind an ephemeral port itself (inet_autobind) without
+ * having to fake a user-space pointer.
+ */
+static int FARPROC inet_bind_kernel(register struct socket *sock, struct sockaddr_in *addr)
 {
     register struct tdb_bind *cmd;
     int ret;
 
-    debug_net("INET(%P) bind sock %x\n", sock);
-
-    if (!sockaddr_len || sockaddr_len > sizeof(struct sockaddr_in))
-        return -EINVAL;
-
-    /* TODO : Check if the user has permision to bind the port */
-
     down(&rwlock);
     cmd = (struct tdb_bind *)get_tdout_buf();
     cmd->cmd = TDC_BIND;
+    cmd->proto = (sock->flags & SF_DGRAM)? TDB_PROTO_DGRAM: TDB_PROTO_STREAM;
     cmd->sock = sock;
     cmd->reuse_addr = sock->flags & SF_REUSE_ADDR;
     cmd->rcv_bufsiz = sock->rcv_bufsiz;
-    memcpy_fromfs(&cmd->addr, addr, sockaddr_len);
+    memcpy(&cmd->addr, addr, sizeof(struct sockaddr_in));
 
     tcpdev_inetwrite(cmd, sizeof(struct tdb_bind));
 
@@ -160,6 +170,24 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
     return (ret >= 0 ? 0 : ret);
 }
 
+static int inet_bind(register struct socket *sock, struct sockaddr *addr,
+                     size_t sockaddr_len)
+{
+    struct sockaddr_in kaddr;
+
+    debug_net("INET(%P) bind sock %x\n", sock);
+
+    if (!sockaddr_len || sockaddr_len > sizeof(struct sockaddr_in))
+        return -EINVAL;
+
+    /* TODO : Check if the user has permision to bind the port */
+
+    memset(&kaddr, 0, sizeof(kaddr));
+    memcpy_fromfs(&kaddr, addr, sockaddr_len);
+
+    return inet_bind_kernel(sock, &kaddr);
+}
+
 static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
                         size_t sockaddr_len, int flags)
 {
@@ -172,6 +200,29 @@ static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
 
     if (get_user(&(((struct sockaddr_in *)uservaddr)->sin_family)) != AF_INET)
         return -EINVAL;
+
+    /*
+     * connect() on a datagram socket is purely local: it records the peer so
+     * send()/write() need no address and so ktcp will filter arriving
+     * datagrams to that source. No packets, no handshake, and re-connecting
+     * to a different peer is allowed.
+     *
+     * Note ELKS cannot implement the BSD "connect to AF_UNSPEC to dissolve
+     * the association" idiom, because AF_INET is 0 - there is no distinct
+     * AF_UNSPEC to test for.
+     */
+    if (sock->flags & SF_DGRAM) {
+        struct sockaddr_in kaddr;
+        int ret;
+
+        memcpy_fromfs(&kaddr, uservaddr, sizeof(struct sockaddr_in));
+        if ((ret = inet_autobind(sock)) < 0)
+            return ret;
+        sock->remaddr = kaddr.sin_addr.s_addr;
+        sock->remport = kaddr.sin_port;
+        sock->state = SS_CONNECTED;
+        return inet_dgram_connect(sock, &kaddr);
+    }
 
     if (sock->state == SS_CONNECTING)
         return -EINPROGRESS;
@@ -269,6 +320,9 @@ static int inet_read(struct socket *sock, char *ubuf, int size, int nonblock)
     debug_net("INET(%P) read sock %x size %d nonblock %d bufin %d\n",
            sock, size, nonblock, bufin_sem);
 
+    if (sock->flags & SF_DGRAM)         /* read() == recvfrom(NULL) */
+        return inet_dgram_recv(sock, ubuf, size, nonblock, 0, NULL);
+
     if (size > TCPDEV_MAXREAD)
         size = TCPDEV_MAXREAD;
 
@@ -277,6 +331,20 @@ static int inet_read(struct socket *sock, char *ubuf, int size, int nonblock)
         /* return EOF on socket remote closed*/
         if (sock->flags & SF_CLOSING)
             return 0;
+
+        /*
+         * O_NONBLOCK was accepted and then ignored here: the flag was only
+         * forwarded to ktcp further down, which is reached after data has
+         * already arrived. So a nonblocking read on a quiet connected socket
+         * slept anyway, and a single silent peer - a port scanner, a paused
+         * client - parked the whole process. A server polling its clients
+         * could therefore never come back to run its own timeouts, never reap
+         * dead connections, and every connection it held on to kept its
+         * control block alive in ktcp until the heap ran out and every TCP
+         * service on the machine died with it.
+         */
+        if (nonblock)
+            return -EAGAIN;
 
         debug_net("INET(%P) read waiting on sock->avail_data sock %x buf_in %d\n",
             sock, bufin_sem);
@@ -334,6 +402,9 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
     if (size <= 0)
         return 0;
 
+    if (sock->flags & SF_DGRAM)         /* write() == sendto(NULL), needs connect() */
+        return inet_dgram_send(sock, ubuf, size, nonblock, 0, NULL);
+
     if (sock->state == SS_DISCONNECTING)
         return -EPIPE;
 
@@ -370,6 +441,16 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
         if (ret < 0) {
             if (ret == -ERESTARTSYS) {
+                /*
+                 * ktcp is flow-controlling us (retransmit memory or the
+                 * congestion window). Same bug as the read path: O_NONBLOCK
+                 * was ignored, so a nonblocking write on a congested socket
+                 * span here at 10Hz forever instead of failing. Report the
+                 * bytes already accepted, or EAGAIN if none.
+                 */
+                if (nonblock)
+                    return (count < size)? size - count: -EAGAIN;
+
                 /* delay process 100ms*/
                 current->state = TASK_INTERRUPTIBLE;
                 current->timeout = jiffies() + (HZ / 10); /* 1/10 sec = 100ms*/
@@ -392,6 +473,24 @@ static int inet_select(register struct socket *sock, int sel_type)
     debug_net("INET(%P) select sock %04x wait %04x type %d avail %u\n",
          sock, sock->wait, sel_type, sock->avail_data);
 
+    /*
+     * Datagram sockets are handled first and never consult sock->state. The
+     * TCP rule below ("readable unless SS_CONNECTED") would make an
+     * unconnected datagram socket permanently readable, and unconnected is
+     * the normal case here.
+     */
+    if (sock->flags & SF_DGRAM) {
+        if (sel_type == SEL_IN) {
+            if (sock->avail_data)       /* a datagram is queued in ktcp */
+                return 1;
+            select_wait(sock->wait);
+            return 0;
+        }
+        if (sel_type == SEL_OUT)
+            return 1;                   /* TDC_SENDTO never queues in ktcp */
+        return 0;                       /* no OOB for UDP */
+    }
+
     if (sel_type == SEL_IN) {
         if (sock->avail_data || sock->state != SS_CONNECTED)
             return 1;
@@ -404,20 +503,190 @@ static int inet_select(register struct socket *sock, int sel_type)
     return 0;
 }
 
-static int inet_send(struct socket *sock, void *buff, int len, int nonblock,
-                     unsigned int flags)
+/*
+ * Give an unbound datagram socket an ephemeral port before any data moves.
+ * Doing it here rather than in ktcp means ktcp always holds a udp_sock for a
+ * handle before it sees traffic for it, and getsockname() works on a socket
+ * that only ever called sendto().
+ */
+static int FARPROC inet_autobind(struct socket *sock)
 {
-    if (flags != 0)
-        return -EINVAL;
+    struct sockaddr_in addr;
+
+    if (sock->localport)
+        return 0;
+    addr.sin_family = AF_INET;
+    addr.sin_port = 0;                  /* 0 = pick one */
+    addr.sin_addr.s_addr = INADDR_ANY;
+    return inet_bind_kernel(sock, &addr);
+}
+
+/*
+ * Record the peer with ktcp so arriving datagrams can be filtered to it. No
+ * packet goes on the wire; ktcp answers immediately from its UDP table.
+ */
+static int FARPROC inet_dgram_connect(struct socket *sock, struct sockaddr_in *addr)
+{
+    register struct tdb_connect *cmd;
+    int ret;
+
+    down(&rwlock);
+    cmd = (struct tdb_connect *)get_tdout_buf();
+    cmd->cmd = TDC_CONNECT;
+    cmd->sock = sock;
+    memcpy(&cmd->addr, addr, sizeof(struct sockaddr_in));
+    tcpdev_inetwrite(cmd, sizeof(struct tdb_connect));
+
+    while (bufin_sem == 0)
+        interruptible_sleep_on(sock->wait);
+    ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
+    tcpdev_clear_data_avail();
+    up(&rwlock);
+    return (ret >= 0)? 0: ret;
+}
+
+static int FARPROC inet_dgram_send(register struct socket *sock, char *ubuf, int size,
+                           int nonblock, unsigned int flags, struct sockaddr *uaddr)
+{
+    register struct tdb_sendto *cmd;
+    struct sockaddr_in dest;
+    int ret;
+
+    if (flags & ~MSG_SUPPORTED)
+        return -EOPNOTSUPP;
+    if (size > TDB_WRITE_MAX)           /* no IP fragmentation exists in ktcp */
+        return -EMSGSIZE;
+
+    if (uaddr) {
+        memcpy_fromfs(&dest, uaddr, sizeof(struct sockaddr_in));
+        if (dest.sin_family != AF_INET)
+            return -EINVAL;
+    } else {
+        if (sock->state != SS_CONNECTED)
+            return -EDESTADDRREQ;       /* write() on an unconnected datagram */
+        dest.sin_addr.s_addr = sock->remaddr;
+        dest.sin_port = sock->remport;
+    }
+
+    if ((ret = inet_autobind(sock)) < 0)
+        return ret;
+
+    down(&rwlock);
+    cmd = (struct tdb_sendto *)get_tdout_buf();
+    cmd->cmd = TDC_SENDTO;
+    cmd->msgflags = (unsigned char)flags;
+    cmd->sock = sock;
+    cmd->daddr = dest.sin_addr.s_addr;
+    cmd->dport = dest.sin_port;
+    cmd->size = size;
+    cmd->nonblock = nonblock;
+    if (size)
+        memcpy_fromfs(cmd->data, ubuf, (size_t)size);
+
+    /* send only the header plus the payload, not the whole struct */
+    tcpdev_inetwrite(cmd, (unsigned)((char *)cmd->data - (char *)cmd) + size);
+
+    while (bufin_sem == 0)
+        interruptible_sleep_on(sock->wait);
+
+    ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
+    tcpdev_clear_data_avail();
+    up(&rwlock);
+    return ret;
+}
+
+static int FARPROC inet_dgram_recv(register struct socket *sock, char *ubuf, int size,
+                           int nonblock, unsigned int flags, struct sockaddr *uaddr)
+{
+    register struct tdb_recvfrom *cmd;
+    struct tdb_recvfrom_ret *r;
+    struct sockaddr_in from;
+    int ret;
+
+    if (flags & ~MSG_SUPPORTED)
+        return -EOPNOTSUPP;
+    if ((ret = inet_autobind(sock)) < 0)
+        return ret;
+    if (size > (int)TCPDEV_MAXDGRAM)
+        size = TCPDEV_MAXDGRAM;
+
+    for (;;) {
+        /*
+         * No SF_CLOSING/EOF test here: a datagram socket has no end of
+         * stream. Non-blocking returns without troubling ktcp at all.
+         */
+        while (sock->avail_data == 0) {
+            if (nonblock || (flags & MSG_DONTWAIT))
+                return -EAGAIN;
+            interruptible_sleep_on(sock->wait);
+            if (current->signal)
+                return -EINTR;
+        }
+
+        down(&rwlock);
+        cmd = (struct tdb_recvfrom *)get_tdout_buf();
+        cmd->cmd = TDC_RECVFROM;
+        cmd->msgflags = (unsigned char)flags;
+        cmd->sock = sock;
+        cmd->size = size;
+        cmd->nonblock = nonblock;
+        tcpdev_inetwrite(cmd, sizeof(struct tdb_recvfrom));
+
+        while (bufin_sem == 0)
+            interruptible_sleep_on(sock->wait);
+
+        r = (struct tdb_recvfrom_ret *)tdin_buf;
+        ret = r->ret_value;
+        if (ret > 0) {
+            memcpy_tofs(ubuf, r->data, (size_t)r->size);
+            if (uaddr) {
+                from.sin_family = AF_INET;
+                from.sin_addr.s_addr = r->saddr;
+                from.sin_port = r->sport;
+                memcpy_tofs(uaddr, &from, sizeof(from));
+            }
+            /* ktcp tells us what is still queued, so a second recv can go
+             * straight out without waiting to be told again */
+            down(&sock->sem);
+            sock->avail_data = r->avail_next;
+            up(&sock->sem);
+        }
+        tcpdev_clear_data_avail();
+        up(&rwlock);
+
+        /*
+         * avail_data can be stale: two processes sharing the fd after fork()
+         * can both see it set and race for one datagram. ktcp is the
+         * authority, so the loser simply goes back to sleep.
+         */
+        if (ret == -EAGAIN && !nonblock && !(flags & MSG_DONTWAIT)) {
+            down(&sock->sem);
+            sock->avail_data = 0;
+            up(&sock->sem);
+            continue;
+        }
+        return ret;
+    }
+}
+
+static int inet_send(struct socket *sock, void *buff, int len, int nonblock,
+                     unsigned int flags, struct sockaddr *uaddr)
+{
+    if (sock->flags & SF_DGRAM)
+        return inet_dgram_send(sock, buff, len, nonblock, flags, uaddr);
+    if (flags != 0 || uaddr)
+        return -EOPNOTSUPP;
 
     return inet_write(sock, buff, len, nonblock);
 }
 
 static int inet_recv(struct socket *sock, void *buff, int len, int nonblock,
-                     unsigned int flags)
+                     unsigned int flags, struct sockaddr *uaddr)
 {
-    if (flags != 0)
-        return -EINVAL;
+    if (sock->flags & SF_DGRAM)
+        return inet_dgram_recv(sock, buff, len, nonblock, flags, uaddr);
+    if (flags != 0 || uaddr)
+        return -EOPNOTSUPP;
 
     return inet_read(sock, buff, len, nonblock);
 }

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -17,6 +17,7 @@
 
 #include <linuxmt/errno.h>
 #include <linuxmt/socket.h>
+#include <linuxmt/in.h>
 #include <linuxmt/net.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/mm.h>
@@ -24,6 +25,7 @@
 #include <linuxmt/fcntl.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/init.h>
 
 #include <arch/segment.h>
 #include <arch/irq.h>
@@ -379,6 +381,9 @@ int sys_listen(int fd, int backlog)
     if (!(sock = sockfd_lookup(fd, NULL)))
 	return -ENOTSOCK;
 
+    if (sock->flags & SF_DGRAM)		/* connectionless: nothing to listen for */
+	return -EOPNOTSUPP;
+
     if (sock->state != SS_UNCONNECTED)
 	return -EINVAL;
 
@@ -401,6 +406,9 @@ int sys_accept(int fd, struct sockaddr *upeer_sockaddr, int *upeer_addrlen)
 
     if (!(sock = sockfd_lookup(fd, &file)))
 	return -ENOTSOCK;
+
+    if (sock->flags & SF_DGRAM)
+	return -EOPNOTSUPP;
 
     if (sock->state != SS_UNCONNECTED)
 	return -EINVAL;
@@ -516,13 +524,20 @@ int sys_socket(int family, int type, int protocol)
     if (ops == NULL)
 	return -EINVAL;
 
-    if (type != SOCK_STREAM)
+    if (type != SOCK_STREAM && type != SOCK_DGRAM)
 	return -EINVAL;
 
     if (!(sock = sock_alloc()))
 	return -ENOSR;
 
-    //sock->type = type;
+    /*
+     * There is no sock->type field, and adding one would grow every inode.
+     * SF_DGRAM is bit 7 of the existing flags byte, which was free - so the
+     * datagram/stream distinction costs nothing. It must be set before
+     * ->create() so the family can reject what it does not support.
+     */
+    if (type == SOCK_DGRAM)
+	sock->flags |= SF_DGRAM;
     sock->ops = ops;
     if ((fd = sock->ops->create(sock, protocol)) < 0) {
 	sock_release(sock);
@@ -599,6 +614,54 @@ int sys_getsocknam(int fd, struct sockaddr *usockaddr, int *usockaddr_len, int p
 	return -EINVAL;
 
     return sock->ops->getname(sock, usockaddr, usockaddr_len, peer);
+}
+
+/*
+ * sendto/recvfrom, minus the addrlen argument. POSIX passes six; an ELKS
+ * syscall carries at most five (bx,cx,dx,di,si), so the length is dropped and
+ * fixed at sizeof(struct sockaddr_in) - AF_INET is the only family that
+ * implements these. libc puts the POSIX signature back, the same way
+ * getsocknam already backs getsockname/getpeername.
+ *
+ * These reuse the send/recv slots in proto_ops, which were dead code: no
+ * caller existed anywhere in the kernel, because there were no syscalls.
+ */
+/*
+ * sendto and recvfrom differ only in the direction of the two verify_area
+ * checks and which proto_ops slot is used, so they share a body. It lives in
+ * far text because the kernel's near text is essentially full.
+ */
+static int FARPROC sock_sendrecv(int fd, void *buf, size_t len, int flags,
+                                 struct sockaddr *uaddr, int recving)
+{
+    struct socket *sock;
+    struct file *file;
+    int err;
+
+    if (!(sock = sockfd_lookup(fd, &file)))
+	return -ENOTSOCK;
+    if (len && (err = verify_area(recving? VERIFY_WRITE: VERIFY_READ, buf, len)) < 0)
+	return err;
+    if (uaddr) {
+	err = recving
+	    ? verify_area(VERIFY_WRITE, uaddr, sizeof(struct sockaddr_in))
+	    : check_addr_to_kernel(uaddr, sizeof(struct sockaddr_in));
+	if (err < 0)
+	    return err;
+    }
+
+    return (recving? sock->ops->recv: sock->ops->send)
+	   (sock, buf, (int)len, file->f_flags & O_NONBLOCK, flags, uaddr);
+}
+
+int sys__sendto(int fd, void *buf, size_t len, int flags, struct sockaddr *uaddr)
+{
+    return sock_sendrecv(fd, buf, len, flags, uaddr, 0);
+}
+
+int sys__recvfrom(int fd, void *buf, size_t len, int flags, struct sockaddr *uaddr)
+{
+    return sock_sendrecv(fd, buf, len, flags, uaddr, 1);
 }
 
 #endif /* CONFIG_SOCKET */

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -530,12 +530,8 @@ int sys_socket(int family, int type, int protocol)
     if (!(sock = sock_alloc()))
 	return -ENOSR;
 
-    /*
-     * There is no sock->type field, and adding one would grow every inode.
-     * SF_DGRAM is bit 7 of the existing flags byte, which was free - so the
-     * datagram/stream distinction costs nothing. It must be set before
-     * ->create() so the family can reject what it does not support.
-     */
+    /* no sock->type field and adding one grows every inode, so SF_DGRAM is
+     * bit 7 of the existing flags. must be set before ->create() */
     if (type == SOCK_DGRAM)
 	sock->flags |= SF_DGRAM;
     sock->ops = ops;
@@ -616,21 +612,10 @@ int sys_getsocknam(int fd, struct sockaddr *usockaddr, int *usockaddr_len, int p
     return sock->ops->getname(sock, usockaddr, usockaddr_len, peer);
 }
 
-/*
- * sendto/recvfrom, minus the addrlen argument. POSIX passes six; an ELKS
- * syscall carries at most five (bx,cx,dx,di,si), so the length is dropped and
- * fixed at sizeof(struct sockaddr_in) - AF_INET is the only family that
- * implements these. libc puts the POSIX signature back, the same way
- * getsocknam already backs getsockname/getpeername.
- *
- * These reuse the send/recv slots in proto_ops, which were dead code: no
- * caller existed anywhere in the kernel, because there were no syscalls.
- */
-/*
- * sendto and recvfrom differ only in the direction of the two verify_area
- * checks and which proto_ops slot is used, so they share a body. It lives in
- * far text because the kernel's near text is essentially full.
- */
+/* sendto/recvfrom without addrlen. posix passes six args, an elks syscall
+ * carries five, so the length is fixed at sizeof(struct sockaddr_in) and libc
+ * puts the posix signature back. reuses the dead send/recv proto_ops slots */
+/* both directions share a body, far text as near text is full */
 static int FARPROC sock_sendrecv(int fd, void *buf, size_t len, int flags,
                                  struct sockaddr *uaddr, int recving)
 {

--- a/elkscmd/inet/netstat.c
+++ b/elkscmd/inet/netstat.c
@@ -104,6 +104,8 @@ int main(int ac, char **av)
     printf("TCP Bad Checksum %7lu  TCP Retrans Memory%6u\n", ns->tcpbadchksum, retrans_mem);
     printf("IP Packets       %7lu  IP Packets       %7lu\n", ns->iprcvcnt, ns->ipsndcnt);
     printf("IP Bad Checksum  %7lu  IP Bad Headers   %7lu\n", ns->ipbadchksum, ns->ipbadhdr);
+    printf("UDP Packets      %7lu  UDP Packets      %7lu\n", ns->udprcvcnt, ns->udpsndcnt);
+    printf("UDP Dropped      %7lu  UDP No Port      %7lu\n", ns->udpdropcnt, ns->udpnoportcnt);
     printf("ICMP Packets     %7lu  ICMP Packets     %7lu\n", ns->icmprcvcnt, ns->icmpsndcnt);
     printf("SLIP Packets     %7lu  SLIP Packets     %7lu\n", ns->sliprcvcnt, ns->slipsndcnt);
     printf("ETH Packets      %7lu  ETH Packets      %7lu\n", ns->ethrcvcnt, ns->ethsndcnt);

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,9 +14,8 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	# heap=0xffff means "all the segment that is left" (elks/fs/exec.c:302), so
-	# the heap tracks BSS automatically instead of silently eating the margin
-	# when a buffer grows. Every connection control block comes out of it.
+	# heap=0xffff is all the segment that is left, so it tracks bss instead
+	# of eating the margin when a buffer grows
 	$(LD) $(LDFLAGS) -maout-heap=0xffff -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
 
 install: ktcp

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,10 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-heap=33792 -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
+	# heap=0xffff means "all the segment that is left" (elks/fs/exec.c:302), so
+	# the heap tracks BSS automatically instead of silently eating the margin
+	# when a buffer grows. Every connection control block comes out of it.
+	$(LD) $(LDFLAGS) -maout-heap=0xffff -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
 
 install: ktcp
 	$(INSTALL) ktcp $(DESTDIR)/bin

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -5,6 +5,15 @@
 #define CSLIP		0	/* compile in CSLIP support*/
 #define VERBOSE         0       /* =1 compile in more verbose status messages */
 
+/*
+ * UDP checksums. Off: generating and verifying one over every datagram in both
+ * directions is pure added work where there was none, and a zero checksum is
+ * legal for IPv4 UDP (RFC 768). With it off a corrupted datagram reaches the
+ * application instead of being dropped - only the IP header checksum stands
+ * between the wire and the payload. Turn on for a marginal link.
+ */
+#define UDP_CHECKSUM    0
+
 /* turn these on for ELKS debugging*/
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/
 #define DEBUG_STARTDEF	0	/* default startup debug display*/

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -5,13 +5,9 @@
 #define CSLIP		0	/* compile in CSLIP support*/
 #define VERBOSE         0       /* =1 compile in more verbose status messages */
 
-/*
- * UDP checksums. Off: generating and verifying one over every datagram in both
- * directions is pure added work where there was none, and a zero checksum is
- * legal for IPv4 UDP (RFC 768). With it off a corrupted datagram reaches the
- * application instead of being dropped - only the IP header checksum stands
- * between the wire and the payload. Turn on for a marginal link.
- */
+/* udp checksums off. a zero checksum is legal for ipv4 udp and computing one
+ * over every datagram both ways is work we did not have before. with it off
+ * only the ip header checksum protects the payload */
 #define UDP_CHECKSUM    0
 
 /* turn these on for ELKS debugging*/

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -23,6 +23,7 @@
 #include "tcp_cb.h"
 #include "tcpdev.h"
 #include "netconf.h"
+#include "udp.h"
 
 /* Send a raw ICMP echo request with specified TTL.
  * NOTE: ip_sendpacket() prepends its own IP header, so buf contains only
@@ -177,6 +178,25 @@ void icmp_process(struct iphdr_s *iph, unsigned char *packet)
 	dptcp = (struct tcphdr_s *)(dp->iphdr + len);
 	printf("icmp: destination unreachable code %d from %s\n",
 		dp->code, in_ntoa(iph->saddr));
+
+	/*
+	 * The embedded header was cast to a TCP header and looked up in the
+	 * TCP control blocks WITHOUT checking the protocol, so an ICMP error
+	 * about a UDP datagram could tear down an unrelated TCP connection
+	 * whose 3-tuple happened to match. The first 8 bytes of the quoted
+	 * datagram are a full UDP header, so both ports are available here.
+	 */
+	if (dpip->protocol == PROTO_UDP) {
+	    struct udphdr_s *dpudp = (struct udphdr_s *)(dp->iphdr + len);
+
+	    udp_icmp_error(dpip->daddr, ntohs(dpudp->src), ntohs(dpudp->dest),
+		(dp->code == 1)? -EHOSTUNREACH :
+		(dp->code >= 9)? -ECONNREFUSED : -ENETUNREACH);
+	    break;
+	}
+	if (dpip->protocol != PROTO_TCP)
+	    break;
+
 	debug_ip("icmp: src %s:%u ", in_ntoa(dpip->saddr), ntohs(dptcp->sport));
 	debug_ip("dst %s:%u\n", in_ntoa(dpip->daddr), ntohs(dptcp->dport));
 	cbnode = tcpcb_find(dpip->daddr, ntohs(dptcp->sport), ntohs(dptcp->dport));

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -179,13 +179,9 @@ void icmp_process(struct iphdr_s *iph, unsigned char *packet)
 	printf("icmp: destination unreachable code %d from %s\n",
 		dp->code, in_ntoa(iph->saddr));
 
-	/*
-	 * The embedded header was cast to a TCP header and looked up in the
-	 * TCP control blocks WITHOUT checking the protocol, so an ICMP error
-	 * about a UDP datagram could tear down an unrelated TCP connection
-	 * whose 3-tuple happened to match. The first 8 bytes of the quoted
-	 * datagram are a full UDP header, so both ports are available here.
-	 */
+	/* the embedded header was looked up in the tcp control blocks without
+	 * checking the protocol, so an icmp error about a udp datagram could
+	 * tear down an unrelated tcp connection */
 	if (dpip->protocol == PROTO_UDP) {
 	    struct udphdr_s *dpudp = (struct udphdr_s *)(dp->iphdr + len);
 

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -31,12 +31,8 @@
 
 static unsigned char ipbuf[IP_BUFSIZ];
 
-/*
- * These buffer sizes used to be chained off CB_NORMAL_BUFSIZ, so they were
- * right by accident and enormous. Now that each is sized from what it actually
- * holds, enforce the couplings the comments used to describe. ip.c is the one
- * file that sees both tcp.h and deveth.h.
- */
+/* the sizes used to be chained off CB_NORMAL_BUFSIZ so they were right by
+ * accident. this is the one file that sees both tcp.h and deveth.h */
 typedef char __ip_ll_hdrsiz_ok[(IP_LL_HDRSIZ == sizeof(struct ip_ll))? 1: -1];
 typedef char __ip_bufsiz_ok[
     (IP_BUFSIZ >= IP_LL_HDRSIZ + (int)sizeof(iphdr_t) + TCP_BUFSIZ)? 1: -1];
@@ -142,14 +138,9 @@ void ip_recvpacket(unsigned char *packet, int size)
 	return;
     }
 
-    /*
-     * tot_len is taken on trust by everything downstream: icmp_process() uses
-     * it to size the echo reply it builds in ipbuf, and tcp_process() uses it
-     * as the checksum length. It was never checked against the frame actually
-     * received, so a peer claiming tot_len 0xffff walked those buffers off the
-     * end. Believe the wire length, not the header. Frames shorter than 60
-     * bytes are padded by ethernet, so size may legitimately exceed tot_len.
-     */
+    /* tot_len is trusted downstream but was never checked against the frame
+     * we got, so tot_len 0xffff walked off the end. believe the wire length.
+     * short frames are padded so size can exceed tot_len */
     totlen = ntohs(iphdr->tot_len);
     if (totlen > (unsigned int)size || totlen < (unsigned int)len) {
 	debug_ip("IP: bad tot_len %u (frame %d, hdr %d)\n", totlen, size, len);

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -31,6 +31,16 @@
 
 static unsigned char ipbuf[IP_BUFSIZ];
 
+/*
+ * These buffer sizes used to be chained off CB_NORMAL_BUFSIZ, so they were
+ * right by accident and enormous. Now that each is sized from what it actually
+ * holds, enforce the couplings the comments used to describe. ip.c is the one
+ * file that sees both tcp.h and deveth.h.
+ */
+typedef char __ip_ll_hdrsiz_ok[(IP_LL_HDRSIZ == sizeof(struct ip_ll))? 1: -1];
+typedef char __ip_bufsiz_ok[
+    (IP_BUFSIZ >= IP_LL_HDRSIZ + (int)sizeof(iphdr_t) + TCP_BUFSIZ)? 1: -1];
+
 int ip_init(void)
 {
     return 0;
@@ -113,6 +123,7 @@ static void ip_print(struct iphdr_s *head, int size)
 void ip_recvpacket(unsigned char *packet, int size)
 {
     register struct iphdr_s *iphdr = (struct iphdr_s *)packet;
+    unsigned int totlen;
     int len;
     unsigned char *data;
 
@@ -131,10 +142,29 @@ void ip_recvpacket(unsigned char *packet, int size)
 	return;
     }
 
-    if (ip_calc_chksum((char *)iphdr, len)) {
-	printf("IP: BAD CHKSUM (%x) len %d\n", ip_calc_chksum((char *)iphdr, len), len);
-	netstats.ipbadchksum++;
+    /*
+     * tot_len is taken on trust by everything downstream: icmp_process() uses
+     * it to size the echo reply it builds in ipbuf, and tcp_process() uses it
+     * as the checksum length. It was never checked against the frame actually
+     * received, so a peer claiming tot_len 0xffff walked those buffers off the
+     * end. Believe the wire length, not the header. Frames shorter than 60
+     * bytes are padded by ethernet, so size may legitimately exceed tot_len.
+     */
+    totlen = ntohs(iphdr->tot_len);
+    if (totlen > (unsigned int)size || totlen < (unsigned int)len) {
+	debug_ip("IP: bad tot_len %u (frame %d, hdr %d)\n", totlen, size, len);
+	netstats.ipbadhdr++;
 	return;
+    }
+
+    {
+	__u16 sum = ip_calc_chksum((char *)iphdr, len);	/* compute once, not twice */
+
+	if (sum) {
+	    printf("IP: BAD CHKSUM (%x) len %d\n", sum, len);
+	    netstats.ipbadchksum++;
+	    return;
+	}
     }
 
     switch (iphdr->protocol) {
@@ -153,7 +183,7 @@ void ip_recvpacket(unsigned char *packet, int size)
 
     case PROTO_UDP:
 	data = packet + 4 * IP_HLEN(iphdr);
-	udp_process(iphdr, data);
+	udp_process(iphdr, data, (int)(totlen - (unsigned int)len));
 	netstats.udprcvcnt++;
 	break;
     }

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -38,6 +38,7 @@
 /* defaults*/
 #define DEFAULT_GATEWAY		"10.0.2.2"
 #define DEFAULT_NETMASK		"255.255.255.0"
+#define MIN_MTU			68	/* RFC 791 minimum, keeps MSS (MTU-40) positive */
 int linkprotocol = 	LINK_ETHER;
 char ethdev[10] = 	"/dev/ne0";
 char *serdev = 		"/dev/ttyS0";
@@ -60,6 +61,7 @@ static int intfd;	/* interface fd*/
 int tcp_timeruse;		/* retrans timer active, call tcp_retrans */
 int cbs_in_time_wait;		/* time_wait timer active, call tcp_expire_timeouts */
 int cbs_in_user_timeout;	/* fin_wait/closing/last_ack active, call " */
+int cbs_unaccepted;		/* embryonic CBs alive, call tcpcb_expire_timeouts */
 int tcpcb_need_push;		/* push required, tcpcb_push_data/call notify_data_avail */
 int tcp_retrans_memory;		/* total retransmit memory in use*/
 char dhcp_enabled;
@@ -74,7 +76,8 @@ void ktcp_run(void)
 
     while (1) {
 	if (tcp_timeruse > 0 || tcpcb_need_push > 0 || loopagain ||
-	    cbs_in_time_wait > 0 || cbs_in_user_timeout > 0 || dhcp_timer_active) {
+	    cbs_in_time_wait > 0 || cbs_in_user_timeout > 0 ||
+	    cbs_unaccepted > 0 || dhcp_timer_active) {
 
 	    //printf("tcp: timer %d needpush %d timewait %d usertime %d\n", tcp_timeruse,
 		//tcpcb_need_push, cbs_in_time_wait, cbs_in_user_timeout);
@@ -106,9 +109,9 @@ void ktcp_run(void)
 	Now = get_time();
 
 	/* expire timeouts*/
-	if (cbs_in_time_wait > 0 || cbs_in_user_timeout > 0) {
-	    debug_tcp("tcp: time_wait %d user_timeout %d\n",
-		cbs_in_time_wait, cbs_in_user_timeout);
+	if (cbs_in_time_wait > 0 || cbs_in_user_timeout > 0 || cbs_unaccepted > 0) {
+	    debug_tcp("tcp: time_wait %d user_timeout %d unaccepted %d\n",
+		cbs_in_time_wait, cbs_in_user_timeout, cbs_unaccepted);
 	    tcpcb_expire_timeouts();
 	}
 
@@ -199,6 +202,7 @@ int main(int argc,char **argv)
     int ch;
     int bflag = 0;
     int mtu = 0;
+    unsigned int maxmtu;
     char *p;
     char *default_ip, *default_gateway, *default_netmask;
     static char *linknames[3] = { "", "slip", "cslip" };
@@ -255,6 +259,23 @@ int main(int argc,char **argv)
 	    dhcp_enabled = 1;
     }
     MTU = mtu ? mtu : (linkprotocol == LINK_ETHER ? ETH_MTU : SLIP_MTU);
+
+    /*
+     * Clamp -m to what the static packet buffers can actually hold. ipbuf is
+     * IP_BUFSIZ bytes with sizeof(struct ip_ll) reserved at the front for the
+     * link header; slip's receive buffer is sized from SLIP_MTU. Neither was
+     * checked, so an oversized -m (net.cfg exposes it as mtu=) silently
+     * overran them. Clamp rather than exit: a mistyped MTU should not take
+     * the network down at boot.
+     */
+    maxmtu = (linkprotocol == LINK_ETHER)? IP_BUFSIZ - sizeof(struct ip_ll): SLIP_MTU;
+    if (MTU > maxmtu) {
+	printf("ktcp: MTU %u too large, using %u\n", MTU, maxmtu);
+	MTU = maxmtu;
+    } else if (MTU < MIN_MTU) {		/* MSS is MTU-40, keep it positive */
+	printf("ktcp: MTU %u too small, using %u\n", MTU, (unsigned)MIN_MTU);
+	MTU = MIN_MTU;
+    }
 
     /* must exit() in next two stages on error to reset kernel tcpdev_inuse to 0*/
     if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0)

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -260,14 +260,9 @@ int main(int argc,char **argv)
     }
     MTU = mtu ? mtu : (linkprotocol == LINK_ETHER ? ETH_MTU : SLIP_MTU);
 
-    /*
-     * Clamp -m to what the static packet buffers can actually hold. ipbuf is
-     * IP_BUFSIZ bytes with sizeof(struct ip_ll) reserved at the front for the
-     * link header; slip's receive buffer is sized from SLIP_MTU. Neither was
-     * checked, so an oversized -m (net.cfg exposes it as mtu=) silently
-     * overran them. Clamp rather than exit: a mistyped MTU should not take
-     * the network down at boot.
-     */
+    /* clamp -m to what the packet buffers hold. it was never checked, so an
+     * oversized mtu= in net.cfg overran them. clamp not exit, a typo should
+     * not take the network down at boot */
     maxmtu = (linkprotocol == LINK_ETHER)? IP_BUFSIZ - sizeof(struct ip_ll): SLIP_MTU;
     if (MTU > maxmtu) {
 	printf("ktcp: MTU %u too large, using %u\n", MTU, maxmtu);

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -52,6 +52,8 @@ struct packet_stats_s {
 	__u32	udpsndcnt;
 	__u32	udprcvcnt;
 	__u32	udpnoportcnt;
+	__u32	udpdropcnt;	/* queue full, no memory, or bad length */
+	__u32	udpbadchksum;
 };
 
 extern struct packet_stats_s netstats;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -190,17 +190,8 @@ static void tcp_listen(struct iptcp_s *iptcp, struct tcpcb_s *lcb)
     if (h->flags & TF_ACK)
 	debug_tcp("tcp: ACK in listen not implemented\n");
 
-    /*
-     * Clone the listen CB, giving the new connection the receive ring the
-     * listening socket asked for with SO_RCVBUF. This used to be hardcoded to
-     * CB_NORMAL_BUFSIZ, so SO_RCVBUF reached the listener - which never
-     * receives anything - and never reached the connections that do. A server
-     * therefore had no way to trade window size for connection count, which is
-     * exactly the trade a machine with a 48K stack heap needs to make.
-     *
-     * lcb->buf_size is what tcpdev_bind() allocated: the SO_RCVBUF value, or
-     * CB_NORMAL_BUFSIZ if the socket never set one.
-     */
+    /* give the new connection the ring SO_RCVBUF asked for. was hardcoded,
+     * so SO_RCVBUF only reached the listener which never receives anything */
     n = tcpcb_clone(lcb, lcb->buf_size);    /* copy lcb into linked list*/
     if (!n)
 	return;		     /* no memory for new connection*/
@@ -291,13 +282,8 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
 	/* check if buffer space for received packet*/
 	if (datasize > CB_BUF_SPACE(cb)) {
-	    /*
-	     * Was an unconditional printf to /dev/console. One CGA scroll costs
-	     * milliseconds here, and this fires once per dropped packet - so the
-	     * smaller the receive ring, the more time the machine spends
-	     * reporting drops instead of draining them, which causes more drops.
-	     * netstats.tcpdropcnt still counts every one; netstat reports it.
-	     */
+	    /* was an unconditional printf, one per dropped packet, which made
+	     * the drops worse. netstat still counts them */
 	    debug_tune("tcp: dropping packet, no buffer space: %u > %d\n",
 		datasize, CB_BUF_SPACE(cb));
 	    netstats.tcpdropcnt++;
@@ -517,13 +503,9 @@ void tcp_reject(struct iphdr_s *iph) {
 	debug_tcp("tcp: refusing packet from %s:%u to :%u fl 0x%02x\n",
 	    in_ntoa(iph->saddr), ntohs(tcph->sport), ntohs(tcph->dport), tcph->flags);
 
-	/*
-	 * Dummy up a control block on the STACK and send RST to shut the sender
-	 * down. This used to malloc one from the same heap that connections come
-	 * out of, which meant that once the heap was exhausted ktcp could no
-	 * longer even refuse a connection - exactly when refusing matters most,
-	 * and exactly the condition a port scan creates. 82 bytes of a 3072-byte
-	 * stack, and it saves a malloc/free per rejected packet as well.
+	/* control block on the stack, not the heap. mallocing one meant ktcp
+	 * could not refuse a connection once the heap was gone, which is
+	 * exactly when it needs to.
 	 *
 	 * buf_size stays 0: RST carries no data and needs no window, and
 	 * add_for_retrans() returns early on TF_RST so nothing is queued.

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -189,12 +190,24 @@ static void tcp_listen(struct iptcp_s *iptcp, struct tcpcb_s *lcb)
     if (h->flags & TF_ACK)
 	debug_tcp("tcp: ACK in listen not implemented\n");
 
-    /* duplicate control block but with normal sized input buffer, SO_RCVBUF ignored for now */
-    n = tcpcb_clone(lcb, CB_NORMAL_BUFSIZ);    /* copy lcb into linked list*/
+    /*
+     * Clone the listen CB, giving the new connection the receive ring the
+     * listening socket asked for with SO_RCVBUF. This used to be hardcoded to
+     * CB_NORMAL_BUFSIZ, so SO_RCVBUF reached the listener - which never
+     * receives anything - and never reached the connections that do. A server
+     * therefore had no way to trade window size for connection count, which is
+     * exactly the trade a machine with a 48K stack heap needs to make.
+     *
+     * lcb->buf_size is what tcpdev_bind() allocated: the SO_RCVBUF value, or
+     * CB_NORMAL_BUFSIZ if the socket never set one.
+     */
+    n = tcpcb_clone(lcb, lcb->buf_size);    /* copy lcb into linked list*/
     if (!n)
 	return;		     /* no memory for new connection*/
     cb = &n->tcpcb;
     cb->unaccepted = 1;      		/* indicate new control block is unaccepted*/
+    cbs_unaccepted++;			/* ... and arm the reaper for it */
+    cb->time_wait_exp = Now;		/* stamp for TIMEOUT_UNACCEPTED */
     cb->newsock = lcb->sock;		/* temp hold listen socket in newsock*/
     debug_accept("tcp listen: got SYN, cloning sock[%p]\n", cb->sock);
     /* now both listen CB and unaccepted CB have same sock pointer*/
@@ -278,7 +291,14 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
 	/* check if buffer space for received packet*/
 	if (datasize > CB_BUF_SPACE(cb)) {
-	    printf("tcp: dropping packet, no buffer space: %u > %d\n",
+	    /*
+	     * Was an unconditional printf to /dev/console. One CGA scroll costs
+	     * milliseconds here, and this fires once per dropped packet - so the
+	     * smaller the receive ring, the more time the machine spends
+	     * reporting drops instead of draining them, which causes more drops.
+	     * netstats.tcpdropcnt still counts every one; netstat reports it.
+	     */
+	    debug_tune("tcp: dropping packet, no buffer space: %u > %d\n",
 		datasize, CB_BUF_SPACE(cb));
 	    netstats.tcpdropcnt++;
 	    return;
@@ -488,9 +508,8 @@ static void tcp_last_ack(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 /* Prepare and send RST for non-existing connections
  * (typically lingering connections  after a reboot) */
 void tcp_reject(struct iphdr_s *iph) {
-	struct tcpcb_list_s *cbnode;
 	struct tcphdr_s *tcph;
-	struct tcpcb_s *cb = NULL;
+	struct tcpcb_s cb;
 	__u32 seqno;
 
 	tcph = (struct tcphdr_s *)(((char *)iph) + 4 * IP_HLEN(iph));
@@ -498,26 +517,31 @@ void tcp_reject(struct iphdr_s *iph) {
 	debug_tcp("tcp: refusing packet from %s:%u to :%u fl 0x%02x\n",
 	    in_ntoa(iph->saddr), ntohs(tcph->sport), ntohs(tcph->dport), tcph->flags);
 
-	/* Dummy up a new control block and send RST to shutdown sender */
-	cbnode = tcpcb_new(1);		/* bufsize = 1, dummy */
-	if (cbnode) {
-	    cb = &cbnode->tcpcb;
-	    cb->state = TS_CLOSED;
-	    cb->localaddr = iph->daddr;
-	    cb->localport = ntohs(tcph->dport);
-	    cb->remaddr = iph->saddr;
-	    cb->remport = ntohs(tcph->sport);
-	    if (tcph->flags & TF_ACK) {
-		cb->flags = TF_RST;
-		cb->send_nxt = ntohl(tcph->acknum);
-	    } else
-		cb->flags = TF_RST|TF_ACK;
-	    cb->rcv_nxt = (tcph->flags & TF_SYN)? seqno+1: seqno;
-	    cb->datalen = 0;
-	    tcp_output(cb);		/* send RST*/
-	    tcpcb_remove(cbnode);	/* deallocate*/
-	}
-	return;
+	/*
+	 * Dummy up a control block on the STACK and send RST to shut the sender
+	 * down. This used to malloc one from the same heap that connections come
+	 * out of, which meant that once the heap was exhausted ktcp could no
+	 * longer even refuse a connection - exactly when refusing matters most,
+	 * and exactly the condition a port scan creates. 82 bytes of a 3072-byte
+	 * stack, and it saves a malloc/free per rejected packet as well.
+	 *
+	 * buf_size stays 0: RST carries no data and needs no window, and
+	 * add_for_retrans() returns early on TF_RST so nothing is queued.
+	 */
+	memset(&cb, 0, sizeof(cb));
+	cb.state = TS_CLOSED;
+	cb.localaddr = iph->daddr;
+	cb.localport = ntohs(tcph->dport);
+	cb.remaddr = iph->saddr;
+	cb.remport = ntohs(tcph->sport);
+	if (tcph->flags & TF_ACK) {
+	    cb.flags = TF_RST;
+	    cb.send_nxt = ntohl(tcph->acknum);
+	} else
+	    cb.flags = TF_RST|TF_ACK;
+	cb.rcv_nxt = (tcph->flags & TF_SYN)? seqno+1: seqno;
+	cb.datalen = 0;
+	tcp_output(&cb);		/* send RST*/
 }
 
 /* process an incoming TCP packet*/
@@ -537,10 +561,14 @@ void tcp_process(struct iphdr_s *iph)
     if (cbnode) cb = &cbnode->tcpcb;
     tcp_print(&iptcp, 1, cb);
 
-    if (tcp_chksum(&iptcp) != 0) {
-	printf("tcp: BAD CHECKSUM (0x%x) len %d\n", tcp_chksum(&iptcp), iptcp.tcplen);
-	netstats.tcpbadchksum++;
-	return;
+    {
+	__u16 sum = tcp_chksum(&iptcp);		/* compute once, not twice */
+
+	if (sum != 0) {
+	    printf("tcp: BAD CHECKSUM (0x%x) len %d\n", sum, iptcp.tcplen);
+	    netstats.tcpbadchksum++;
+	    return;
+	}
     }
 
     if (!cbnode) {

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -2,6 +2,7 @@
 #define TCP_H
 
 #include <sys/types.h>
+#include <limits.h>		/* MAX_PACKET_ETH */
 #include "config.h"
 #include "timer.h"
 #include "ip.h"
@@ -9,23 +10,54 @@
 #include <arpa/inet.h>
 
 /*
- * /dev/tcpdev max read/write size
- * must be at least as big as CB_NORMAL_BUFSIZ
- * and at least as big as TCPDEV_INBUFFERSIZE in <linuxmt/tcpdev.h> (currently 1500)
+ * Buffer sizes. These three are independent of each other and none of them is
+ * derived from CB_NORMAL_BUFSIZ - that is the per-connection receive ring and
+ * has nothing to do with how big a packet or a tcpdev message can be. Chaining
+ * them off the ring size (as this header used to) made ipbuf, tcpbuf and
+ * tcpdev's sbuf ~4.4K each, about 9K more BSS than any of them can ever use.
  */
-#define TCPDEV_BUFSIZ	(CB_NORMAL_BUFSIZ + sizeof(struct tdb_return_data))
-
-/* max tcp buffer size (no ip header)*/
-#define TCP_BUFSIZ      (TCPDEV_BUFSIZ + sizeof(tcphdr_t) + TCP_OPT_MSS_LEN)
-
-/* max ip buffer size (with link layer frame)*/
-#define IP_BUFSIZ       (TCP_BUFSIZ + sizeof(iphdr_t) + sizeof(struct ip_ll))
 
 /*
- * control block input buffer size - max window size, doesn't have to be power of two
- * default will be (ETH_MTU - IP_HDRSIZ) * 3 = (1500-40) * 3 = 4380
+ * /dev/tcpdev scratch buffer. Used for messages in both directions, so it has
+ * to hold the larger of:
+ *   kernel -> ktcp:  TCPDEV_OUTBUFFERSIZE  (sizeof(struct tdb_write))
+ *   ktcp -> kernel:  sizeof(struct tdb_return_data) + TCPDEV_MAXREAD, which is
+ *                    exactly TCPDEV_INBUFFERSIZE by construction
+ * The kernel rejects a write longer than TCPDEV_INBUFFERSIZE and silently
+ * truncates a read shorter than the pending message, so this has no slack.
  */
-#define CB_NORMAL_BUFSIZ    4380    /* normal input buffer size*/
+#define TCPDEV_BUFSIZ   (TCPDEV_INBUFFERSIZE > TCPDEV_OUTBUFFERSIZE? \
+                         TCPDEV_INBUFFERSIZE: TCPDEV_OUTBUFFERSIZE)
+
+/*
+ * Wire buffer, including room for the link layer header at the front. Bounded
+ * by the link MTU and never by the receive window: ktcp does no IP reassembly
+ * (see ip.c), so a received IP packet cannot exceed the MTU, and a transmitted
+ * segment cannot exceed the MSS. ktcp clamps -m MTU against this.
+ */
+#define IP_LL_HDRSIZ    14      /* sizeof(struct ip_ll); deveth.h can't be included
+                                 * here, so ip.c asserts these agree */
+#define IP_BUFSIZ       MAX_PACKET_ETH
+
+/* max tcp buffer size (no ip or link layer header)*/
+#define TCP_BUFSIZ      (IP_BUFSIZ - IP_LL_HDRSIZ - sizeof(iphdr_t))
+
+/*
+ * Per-connection receive ring, and therefore the advertised window -
+ * tcp_calc_rcv_window() hands out CB_BUF_SPACE() directly. This is pure heap:
+ * every connection costs sizeof(struct tcpcb_list_s) + this.
+ *
+ * Two MSS rather than the old three. One MSS would mean a single segment in
+ * flight - the window closes on every segment and reopens only once the
+ * application reads, serialising the receive path - while three buys only a
+ * few percent more, because ktcp's per-segment processing rather than the
+ * bandwidth-delay product is the limit on this hardware. Two is the knee.
+ *
+ * Sockets that want something else say so with SO_RCVBUF: bulk receivers
+ * (ftpd data, audiorecv, vidrecv) ask for more, servers holding many mostly
+ * idle clients ask for less.
+ */
+#define CB_NORMAL_BUFSIZ    2920    /* 2 * (ETH_MTU - IP_HDRSIZ) */
 #define USE_SWS             0       /* =1 to use silly window algorithm */
 
 /* max outstanding send window size */
@@ -39,6 +71,12 @@
 /* timeout values - unit is set by 'Now' in ktcp.c, currently 60ms */
 #define TIMEOUT_ENTER_WAIT  (4<<4)  /* TIME_WAIT state (was 30, then 10, now 4 secs) */
 #define TIMEOUT_CLOSE_WAIT  (10<<4) /* CLOSING/LAST_ACK/FIN_WAIT states (10 secs) */
+#define TIMEOUT_UNACCEPTED  (30<<4) /* SYN_RECEIVED / established-but-never-accepted.
+                                     * These had no timeout at all, so a control block
+                                     * the application never accepted lived forever and
+                                     * a port scan leaked them permanently until the
+                                     * heap ran out and every TCP service died with it.
+                                     * Long enough not to punish a slow accept loop. */
                                     /* Initial RTT & RTO values are not important,
                                      * as they get adjusted automatically as soon
                                      * as the connection is up and running. Recommended
@@ -199,6 +237,7 @@ struct	tcp_retrans_list_s {
 extern int tcp_timeruse;        /* retrans timer active, call tcp_retrans */
 extern int cbs_in_time_wait;    /* time_wait timer active, call tcp_expire_timeouts */
 extern int cbs_in_user_timeout; /* fin_wait/closing/last_ack active, call " */
+extern int cbs_unaccepted;      /* embryonic CBs alive, call tcpcb_expire_timeouts */
 extern int tcpcb_need_push;     /* push required,tcpcb_push_data/call notify_data_avail */
 extern int tcp_retrans_memory;  /* total retransmit memory in use */
 

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -10,31 +10,18 @@
 #include <arpa/inet.h>
 
 /*
- * Buffer sizes. These three are independent of each other and none of them is
- * derived from CB_NORMAL_BUFSIZ - that is the per-connection receive ring and
- * has nothing to do with how big a packet or a tcpdev message can be. Chaining
- * them off the ring size (as this header used to) made ipbuf, tcpbuf and
- * tcpdev's sbuf ~4.4K each, about 9K more BSS than any of them can ever use.
+ * buffer sizes. these three are independent, none is derived from
+ * CB_NORMAL_BUFSIZ which is the receive ring. chaining them off the ring
+ * size wasted about 9k of bss.
  */
 
-/*
- * /dev/tcpdev scratch buffer. Used for messages in both directions, so it has
- * to hold the larger of:
- *   kernel -> ktcp:  TCPDEV_OUTBUFFERSIZE  (sizeof(struct tdb_write))
- *   ktcp -> kernel:  sizeof(struct tdb_return_data) + TCPDEV_MAXREAD, which is
- *                    exactly TCPDEV_INBUFFERSIZE by construction
- * The kernel rejects a write longer than TCPDEV_INBUFFERSIZE and silently
- * truncates a read shorter than the pending message, so this has no slack.
- */
+/* tcpdev scratch, used both directions so it holds the larger of the two.
+ * no slack here, the kernel truncates a short read silently */
 #define TCPDEV_BUFSIZ   (TCPDEV_INBUFFERSIZE > TCPDEV_OUTBUFFERSIZE? \
                          TCPDEV_INBUFFERSIZE: TCPDEV_OUTBUFFERSIZE)
 
-/*
- * Wire buffer, including room for the link layer header at the front. Bounded
- * by the link MTU and never by the receive window: ktcp does no IP reassembly
- * (see ip.c), so a received IP packet cannot exceed the MTU, and a transmitted
- * segment cannot exceed the MSS. ktcp clamps -m MTU against this.
- */
+/* wire buffer with room for the link header. bounded by the mtu, not by
+ * the receive window, there is no ip reassembly */
 #define IP_LL_HDRSIZ    14      /* sizeof(struct ip_ll); deveth.h can't be included
                                  * here, so ip.c asserts these agree */
 #define IP_BUFSIZ       MAX_PACKET_ETH
@@ -43,19 +30,10 @@
 #define TCP_BUFSIZ      (IP_BUFSIZ - IP_LL_HDRSIZ - sizeof(iphdr_t))
 
 /*
- * Per-connection receive ring, and therefore the advertised window -
- * tcp_calc_rcv_window() hands out CB_BUF_SPACE() directly. This is pure heap:
- * every connection costs sizeof(struct tcpcb_list_s) + this.
- *
- * Two MSS rather than the old three. One MSS would mean a single segment in
- * flight - the window closes on every segment and reopens only once the
- * application reads, serialising the receive path - while three buys only a
- * few percent more, because ktcp's per-segment processing rather than the
- * bandwidth-delay product is the limit on this hardware. Two is the knee.
- *
- * Sockets that want something else say so with SO_RCVBUF: bulk receivers
- * (ftpd data, audiorecv, vidrecv) ask for more, servers holding many mostly
- * idle clients ask for less.
+ * per connection receive ring, and the advertised window. pure heap, every
+ * connection costs this plus the control block. two mss not three, one would
+ * serialise the receive path and three only buys a few percent. sockets that
+ * want different say so with SO_RCVBUF.
  */
 #define CB_NORMAL_BUFSIZ    2920    /* 2 * (ETH_MTU - IP_HDRSIZ) */
 #define USE_SWS             0       /* =1 to use silly window algorithm */
@@ -71,12 +49,8 @@
 /* timeout values - unit is set by 'Now' in ktcp.c, currently 60ms */
 #define TIMEOUT_ENTER_WAIT  (4<<4)  /* TIME_WAIT state (was 30, then 10, now 4 secs) */
 #define TIMEOUT_CLOSE_WAIT  (10<<4) /* CLOSING/LAST_ACK/FIN_WAIT states (10 secs) */
-#define TIMEOUT_UNACCEPTED  (30<<4) /* SYN_RECEIVED / established-but-never-accepted.
-                                     * These had no timeout at all, so a control block
-                                     * the application never accepted lived forever and
-                                     * a port scan leaked them permanently until the
-                                     * heap ran out and every TCP service died with it.
-                                     * Long enough not to punish a slow accept loop. */
+#define TIMEOUT_UNACCEPTED  (30<<4) /* never accepted. had no timeout at all so
+                                     * a port scan leaked control blocks forever */
                                     /* Initial RTT & RTO values are not important,
                                      * as they get adjusted automatically as soon
                                      * as the connection is up and running. Recommended

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -286,18 +286,9 @@ void tcpcb_expire_timeouts(void)
 		}
 		break;
 	    default:
-		/*
-		 * Embryonic connections - SYN_RECEIVED, or established but
-		 * never accept()ed - had no timeout of any kind, so they lived
-		 * until ktcp restarted. A port scan therefore leaked one
-		 * control block per probe, permanently, and an application
-		 * that stopped calling accept() leaked one per connection.
-		 * Once the heap was gone, every TCP service on the machine
-		 * died with it.
-		 *
-		 * unaccepted is only ever set on a cloned CB (see tcp_listen),
-		 * so LISTEN/CLOSED/SYN_SENT blocks are not touched here.
-		 */
+		/* never accepted connections had no timeout at all, so a port
+		 * scan leaked a control block per probe until the heap went.
+		 * unaccepted is only set on a cloned cb */
 		if (n->tcpcb.unaccepted &&
 		    TIME_GT(Now - TIMEOUT_UNACCEPTED, n->tcpcb.time_wait_exp)) {
 		    debug_tune("tcp: reaping unaccepted cb port %u from %s\n",
@@ -320,17 +311,8 @@ void tcpcb_push_data(void)
 	    notify_data_avail(&n->tcpcb);
 }
 
-/*
- * Ring copies. These were byte-at-a-time loops with a wrap test and a memory
- * increment of buf_used per byte - around 180 clocks per byte on an 8088,
- * against 12.5 for a word-at-a-time block move. They run on every received
- * segment and every application read, which made them the largest single cost
- * in the receive path. Split at the wrap point and let memcpy do the work.
- *
- * Callers guarantee the space: tcp_established() checks CB_BUF_SPACE before
- * writing, netconf_capture_packet() does the same, and tcpdev_read() clamps
- * to bytes_to_push.
- */
+/* were byte at a time loops with a wrap test per byte. split at the wrap
+ * point and let memcpy do it. callers guarantee the space */
 
 /* There must be free space greater-equal than len */
 void tcpcb_buf_write(struct tcpcb_s *cb, unsigned char *data, int len)

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -30,6 +30,7 @@ void tcpcb_init(void)
     tcpcb_need_push = 0;
     cbs_in_time_wait = 0;
     cbs_in_user_timeout = 0;
+    cbs_unaccepted = 0;
 
     tcpcb_num = 0;	/* for netstat*/
 }
@@ -140,6 +141,9 @@ void tcpcb_remove(struct tcpcb_list_s *n)
 	capture_cb = NULL;
     if (&n->tcpcb == pending_icmp_cb)
 	pending_icmp_cb = NULL;
+
+    if (n->tcpcb.unaccepted)	/* still embryonic - release its reaper slot */
+	cbs_unaccepted--;
 
     debug_tcp("tcp: REMOVING control block %x\n", n);
     debug_mem("Free CB\n");
@@ -281,6 +285,27 @@ void tcpcb_expire_timeouts(void)
 		    tcpcb_remove(n);
 		}
 		break;
+	    default:
+		/*
+		 * Embryonic connections - SYN_RECEIVED, or established but
+		 * never accept()ed - had no timeout of any kind, so they lived
+		 * until ktcp restarted. A port scan therefore leaked one
+		 * control block per probe, permanently, and an application
+		 * that stopped calling accept() leaked one per connection.
+		 * Once the heap was gone, every TCP service on the machine
+		 * died with it.
+		 *
+		 * unaccepted is only ever set on a cloned CB (see tcp_listen),
+		 * so LISTEN/CLOSED/SYN_SENT blocks are not touched here.
+		 */
+		if (n->tcpcb.unaccepted &&
+		    TIME_GT(Now - TIMEOUT_UNACCEPTED, n->tcpcb.time_wait_exp)) {
+		    debug_tune("tcp: reaping unaccepted cb port %u from %s\n",
+			n->tcpcb.localport, in_ntoa(n->tcpcb.remaddr));
+		    netstats.tcpdropcnt++;
+		    tcp_reset_connection(&n->tcpcb);	/* RST, then deallocate */
+		}
+		break;
 	}
 	n = next;
     }
@@ -295,32 +320,58 @@ void tcpcb_push_data(void)
 	    notify_data_avail(&n->tcpcb);
 }
 
-/* There must be free space greater-equal than len or will wrap*/
+/*
+ * Ring copies. These were byte-at-a-time loops with a wrap test and a memory
+ * increment of buf_used per byte - around 180 clocks per byte on an 8088,
+ * against 12.5 for a word-at-a-time block move. They run on every received
+ * segment and every application read, which made them the largest single cost
+ * in the receive path. Split at the wrap point and let memcpy do the work.
+ *
+ * Callers guarantee the space: tcp_established() checks CB_BUF_SPACE before
+ * writing, netconf_capture_packet() does the same, and tcpdev_read() clamps
+ * to bytes_to_push.
+ */
+
+/* There must be free space greater-equal than len */
 void tcpcb_buf_write(struct tcpcb_s *cb, unsigned char *data, int len)
 {
-    int tail = cb->buf_tail;
+    unsigned int tail = cb->buf_tail;
+    unsigned int ulen = len;
+    unsigned int n = cb->buf_size - tail;	/* room before the wrap */
 
-    while (--len >= 0) {
-	cb->buf_base[tail++] = *data++;
-	if (tail >= cb->buf_size)
-	    tail = 0;
-	cb->buf_used++;
+    if (ulen < n)
+	n = ulen;
+    memcpy(cb->buf_base + tail, data, n);
+    tail += n;
+    if (tail >= cb->buf_size)
+	tail = 0;
+    if (ulen > n) {				/* wrapped */
+	memcpy(cb->buf_base, data + n, ulen - n);
+	tail = ulen - n;
     }
     cb->buf_tail = tail;
+    cb->buf_used += ulen;
 }
 
 /* same here */
 void tcpcb_buf_read(struct tcpcb_s *cb, unsigned char *data, int len)
 {
-    int head = cb->buf_head;
+    unsigned int head = cb->buf_head;
+    unsigned int ulen = len;
+    unsigned int n = cb->buf_size - head;
 
-    while (--len >= 0) {
-	*data++= cb->buf_base[head++];
-	if (head >= cb->buf_size)
-	    head = 0;
-	cb->buf_used--;
+    if (ulen < n)
+	n = ulen;
+    memcpy(data, cb->buf_base + head, n);
+    head += n;
+    if (head >= cb->buf_size)
+	head = 0;
+    if (ulen > n) {
+	memcpy(data + n, cb->buf_base, ulen - n);
+	head = ulen - n;
     }
     cb->buf_head = head;
+    cb->buf_used -= ulen;
 }
 
 /* congestion avoidance: increment cwnd once per rtt */

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -31,6 +31,11 @@ static struct tcp_retrans_list_s *retrans_last;
 #endif
 static unsigned char tcpbuf[TCP_BUFSIZ];
 
+/* tcp_output() builds header + options + one tcpdev write's worth of data here,
+ * with no runtime bounds check - so the bound has to hold at compile time. */
+typedef char __tcp_bufsiz_ok[
+    (TCP_BUFSIZ >= TDB_WRITE_MAX + (int)sizeof(tcphdr_t) + TCP_OPT_MSS_LEN)? 1: -1];
+
 __u16 tcp_chksum(struct iptcp_s *h)
 {
     __u32 sum = htons(h->tcplen);
@@ -474,10 +479,22 @@ void tcp_output(struct tcpcb_s *cb)
     header_len = sizeof(tcphdr_t);
     if (cb->flags & TF_SYN) {
 	__u8 *options = th->options;
+	unsigned int mss = MTU - 40;
+
+	/*
+	 * Advertise the segment size we can actually accept, not the one the
+	 * link could carry. ktcp has no out-of-order queue and drops any
+	 * segment that will not fit the receive ring (see tcp_established),
+	 * with no fast retransmit to recover it - so promising a peer 1460
+	 * while holding a smaller ring costs a retransmit timeout per segment.
+	 * Only matters once a socket asks for a small SO_RCVBUF.
+	 */
+	if (cb->buf_size && mss > cb->buf_size)
+	    mss = cb->buf_size;
 
 	options[0] = TCP_OPT_MSS;
 	options[1] = TCP_OPT_MSS_LEN;		/* total options length (4)*/
-	*(__u16 *)(options + 2) = htons(MTU - 40);
+	*(__u16 *)(options + 2) = htons(mss);
 	header_len += TCP_OPT_MSS_LEN;
     }
 

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -481,14 +481,9 @@ void tcp_output(struct tcpcb_s *cb)
 	__u8 *options = th->options;
 	unsigned int mss = MTU - 40;
 
-	/*
-	 * Advertise the segment size we can actually accept, not the one the
-	 * link could carry. ktcp has no out-of-order queue and drops any
-	 * segment that will not fit the receive ring (see tcp_established),
-	 * with no fast retransmit to recover it - so promising a peer 1460
-	 * while holding a smaller ring costs a retransmit timeout per segment.
-	 * Only matters once a socket asks for a small SO_RCVBUF.
-	 */
+	/* advertise what we can accept, not what the link carries. there is no
+	 * out of order queue, so promising more than the ring holds costs a
+	 * retransmit timeout per segment */
 	if (cb->buf_size && mss > cb->buf_size)
 	    mss = cb->buf_size;
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -28,9 +28,8 @@
 static __u16	next_port;
 static unsigned char sbuf[TCPDEV_BUFSIZ];
 
-/* sbuf carries traffic both ways: it must hold the largest command the kernel
- * can send us, and the largest reply we can send back. The kernel truncates a
- * short read without erroring, so getting this wrong fails silently. */
+/* sbuf goes both ways so it holds the larger of command and reply. a short
+ * read is truncated without an error, so getting this wrong fails silently */
 typedef char __tcpdev_bufsiz_ok[
     (TCPDEV_BUFSIZ >= (int)TCPDEV_OUTBUFFERSIZE &&
      TCPDEV_BUFSIZ >= (int)sizeof(struct tdb_return_data) + TCPDEV_MAXREAD)? 1: -1];
@@ -266,12 +265,8 @@ static void tcpdev_connect(void)
 
     n = tcpcb_find_by_sock(db->sock);
     if (!n || n->tcpcb.state != TS_CLOSED) {
-	/*
-	 * Same trap as the read path: returning without answering leaves
-	 * inet_connect() spinning on SF_CONNECT forever. It does not hold
-	 * rwlock, so this hangs only the calling process rather than the whole
-	 * machine, but it should still be told.
-	 */
+	/* same trap as the read path, returning without answering leaves
+	 * inet_connect() spinning forever */
 	debug_tcp("tcp: connect on socket with no control block\n");
 	notify_sock(db->sock, TDT_CONNECT, -ECONNREFUSED);
 	return;
@@ -321,20 +316,9 @@ static void tcpdev_read(void)
 
     n = tcpcb_find_by_sock(sock);
     if (!n || n->tcpcb.state == TS_CLOSED) {
-	/*
-	 * The control block is gone - the peer reset, or the socket was
-	 * released while this read was in flight.
-	 *
-	 * This used to print and return WITHOUT answering the socket, which
-	 * wedged the whole machine: inet_read() is asleep in
-	 *     down(&rwlock); ... while (bufin_sem == 0) interruptible_sleep_on();
-	 * so with no reply it sleeps forever holding rwlock - and rwlock is the
-	 * single global lock serialising every inet_read/inet_write on every
-	 * socket. The symptom is that connections still get accepted while
-	 * telnetd, ftpd and everything else fall silent, because the cause is
-	 * below all of them. The write path already answers -EPIPE here; do the
-	 * same rather than leaving a reader stranded.
-	 */
+	/* control block gone. used to return without answering, which left
+	 * inet_read() asleep holding the global rwlock and wedged every socket
+	 * on the machine. the write path already answers -EPIPE here */
 	debug_tune("tcp: read on socket with no control block\n");
 	retval_to_sock(sock, -EPIPE);
 	return;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -23,9 +23,17 @@
 #include "tcpdev.h"
 #include "tcp_cb.h"
 #include "netconf.h"
+#include "udp.h"
 
 static __u16	next_port;
 static unsigned char sbuf[TCPDEV_BUFSIZ];
+
+/* sbuf carries traffic both ways: it must hold the largest command the kernel
+ * can send us, and the largest reply we can send back. The kernel truncates a
+ * short read without erroring, so getting this wrong fails silently. */
+typedef char __tcpdev_bufsiz_ok[
+    (TCPDEV_BUFSIZ >= (int)TCPDEV_OUTBUFFERSIZE &&
+     TCPDEV_BUFSIZ >= (int)sizeof(struct tdb_return_data) + TCPDEV_MAXREAD)? 1: -1];
 
 int tcpdevfd;
 
@@ -73,6 +81,25 @@ static void tcpdev_bind(void)
 
     if (db->addr.sin_family != AF_INET) {
 	retval_to_sock(db->sock,-EINVAL);
+	return;
+    }
+
+    if (db->proto == TDB_PROTO_DGRAM) {
+	struct udp_sock *us;
+	ipaddr_t laddr;
+	struct tdb_bind_ret bret;
+
+	port = ntohs(db->addr.sin_port);
+	laddr = (db->addr.sin_addr.s_addr == htonl(0x7f000001))?
+		 db->addr.sin_addr.s_addr:
+		 (db->addr.sin_addr.s_addr? local_ip: 0);   /* 0 = INADDR_ANY */
+	us = udp_sock_new(db->sock, laddr, &port);
+	bret.type = TDT_BIND;
+	bret.ret_value = us? 0: (port? -EADDRINUSE: -ENOMEM);
+	bret.sock = db->sock;
+	bret.addr_ip = laddr;
+	bret.addr_port = htons(port);
+	write(tcpdevfd, &bret, sizeof(bret));
 	return;
     }
 
@@ -162,6 +189,7 @@ static void tcpdev_accept(void)
     debug_accept("tcpdev accept: ACCEPT (SYN received before accept) sock[%p], using newsock[%p]\n", sock, db->newsock);
 
     cb->unaccepted = 0;
+    cbs_unaccepted--;			/* accepted: no longer subject to reaping */
     cb->sock = db->newsock;
     cb->newsock = 0;			/* clear newsock in accepted CB*/
     n->tcpcb.newsock = 0;		/* clear newsock in listen CB*/
@@ -212,6 +240,7 @@ void tcpdev_notify_accept(struct tcpcb_s *cb)
 						listencb->sock, listencb->newsock);
 
     cb->unaccepted = 0;
+    cbs_unaccepted--;			/* accepted: no longer subject to reaping */
     cb->sock = listencb->newsock;
     listencb->newsock = 0;
 
@@ -224,9 +253,27 @@ static void tcpdev_connect(void)
     struct tcpcb_list_s *n;
     ipaddr_t addr;
 
+    {
+	struct udp_sock *us = udp_sock_find(db->sock);
+
+	if (us) {			/* datagram: record the peer, no packets */
+	    us->remaddr = db->addr.sin_addr.s_addr;
+	    us->remport = ntohs(db->addr.sin_port);
+	    retval_to_sock(db->sock, 0);
+	    return;
+	}
+    }
+
     n = tcpcb_find_by_sock(db->sock);
     if (!n || n->tcpcb.state != TS_CLOSED) {
-	debug_tcp("tcp: panic in connect\n");
+	/*
+	 * Same trap as the read path: returning without answering leaves
+	 * inet_connect() spinning on SF_CONNECT forever. It does not hold
+	 * rwlock, so this hangs only the calling process rather than the whole
+	 * machine, but it should still be told.
+	 */
+	debug_tcp("tcp: connect on socket with no control block\n");
+	notify_sock(db->sock, TDT_CONNECT, -ECONNREFUSED);
 	return;
     }
 
@@ -274,7 +321,22 @@ static void tcpdev_read(void)
 
     n = tcpcb_find_by_sock(sock);
     if (!n || n->tcpcb.state == TS_CLOSED) {
-	printf("ktcp: panic in read\n");
+	/*
+	 * The control block is gone - the peer reset, or the socket was
+	 * released while this read was in flight.
+	 *
+	 * This used to print and return WITHOUT answering the socket, which
+	 * wedged the whole machine: inet_read() is asleep in
+	 *     down(&rwlock); ... while (bufin_sem == 0) interruptible_sleep_on();
+	 * so with no reply it sleeps forever holding rwlock - and rwlock is the
+	 * single global lock serialising every inet_read/inet_write on every
+	 * socket. The symptom is that connections still get accepted while
+	 * telnetd, ftpd and everything else fall silent, because the cause is
+	 * below all of them. The write path already answers -EPIPE here; do the
+	 * same rather than leaving a reader stranded.
+	 */
+	debug_tune("tcp: read on socket with no control block\n");
+	retval_to_sock(sock, -EPIPE);
 	return;
     }
 
@@ -445,6 +507,11 @@ static void tcpdev_release(void)
     struct tcpcb_s *cb;
     void * sock = db->sock;
 
+    if (udp_sock_find(sock)) {		/* datagram socket: just drop it */
+	udp_sock_free(sock);
+	return;
+    }
+
     n = tcpcb_find_by_sock(sock);
     if (n) {
 	cb = &n->tcpcb;
@@ -495,6 +562,55 @@ common_close:
     }
 }
 
+/* datagram out */
+static void tcpdev_sendto(void)
+{
+    struct tdb_sendto *db = (struct tdb_sendto *)sbuf;
+    struct udp_sock *us = udp_sock_find(db->sock);
+    int ret;
+
+    if (!us) {
+	retval_to_sock(db->sock, -EINVAL);
+	return;
+    }
+    ret = udp_sock_sendto(us, db->daddr, ntohs(db->dport), db->data, db->size);
+    retval_to_sock(db->sock, ret);
+}
+
+/* datagram in - the reply carries the source address and what is still queued */
+static void tcpdev_recvfrom(void)
+{
+    struct tdb_recvfrom *db = (struct tdb_recvfrom *)sbuf;
+    struct udp_sock *us = udp_sock_find(db->sock);
+    struct tdb_recvfrom_ret *r;
+    void *sock = db->sock;
+    int size = db->size;
+    ipaddr_t saddr = 0;
+    __u16 sport = 0;
+    int trunc = 0, avail_next = 0, ret;
+
+    if (!us) {
+	retval_to_sock(sock, -EINVAL);
+	return;
+    }
+    if (size > (int)TCPDEV_MAXDGRAM)
+	size = TCPDEV_MAXDGRAM;
+
+    /* sbuf is reused for the reply, so read the request out of it first */
+    r = (struct tdb_recvfrom_ret *)sbuf;
+    ret = udp_sock_recvfrom(us, r->data, size, &saddr, &sport, &trunc, &avail_next);
+
+    r->type = TDT_RECVFROM;
+    r->trunc = (char)trunc;
+    r->ret_value = ret;
+    r->sock = sock;
+    r->size = (ret > 0)? ret: 0;
+    r->saddr = saddr;
+    r->sport = htons(sport);
+    r->avail_next = (__u16)avail_next;
+    write(tcpdevfd, sbuf, sizeof(struct tdb_recvfrom_ret) + r->size);
+}
+
 void tcpdev_process(void)
 {
 	int len = read(tcpdevfd, sbuf, TCPDEV_BUFSIZ);
@@ -523,6 +639,12 @@ void tcpdev_process(void)
 	case TDC_RELEASE:
 	    debug_tcpdev("tcpdev_release\n");
 	    tcpdev_release();
+	    break;
+	case TDC_SENDTO:
+	    tcpdev_sendto();
+	    break;
+	case TDC_RECVFROM:
+	    tcpdev_recvfrom();
 	    break;
 	case TDC_READ:
 	    debug_tcpdev("tcpdev_read\n");

--- a/elkscmd/ktcp/udp.c
+++ b/elkscmd/ktcp/udp.c
@@ -1,53 +1,301 @@
 /*
- * Internal UDP implementation for DHCP. Not accessible through sockets.
+ * UDP for ktcp.
+ *
+ * Originally a four-entry callback table serving DHCP only, demultiplexing on
+ * the destination port alone and never validating a length. It now backs
+ * SOCK_DGRAM sockets: address+port demultiplexing with BSD precedence, a
+ * bounded per-socket receive queue, and ICMP error delivery - while keeping
+ * udp_register()/udp_unregister() so dhcp.c did not have to change.
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <arpa/inet.h>
 #include "config.h"
 #include "ip.h"
 #include "icmp.h"
 #include "udp.h"
+#include <linuxmt/tcpdev.h>
+#include "tcpdev.h"
 #include "netconf.h"
 
 struct udp_sock udp_socks[MAX_UDP_SOCKS];
 
+static __u16 udp_next_port = 1024;
+static int udp_rcvq_memory;             /* bytes queued across all sockets */
+
+static struct udp_sock *udp_alloc(void)
+{
+    struct udp_sock *us;
+
+    for (us = udp_socks; us < &udp_socks[MAX_UDP_SOCKS]; us++) {
+        if (!us->active) {
+            memset(us, 0, sizeof(*us));
+            us->active = 1;
+            return us;
+        }
+    }
+    return NULL;
+}
+
+static struct udp_sock *udp_find_by_port(__u16 port)
+{
+    struct udp_sock *us;
+
+    for (us = udp_socks; us < &udp_socks[MAX_UDP_SOCKS]; us++)
+        if (us->active && us->localport == port)
+            return us;
+    return NULL;
+}
+
+/*
+ * Demultiplex, most specific first: a connected socket (both remote address
+ * and port set) wins outright, otherwise the first wildcard bound to the port
+ * takes it. Standard BSD precedence, in one pass.
+ *
+ * localaddr 0 means INADDR_ANY, which also makes loopback work: ip_route()
+ * loops 127.x internally and the arriving daddr is 127.0.0.1.
+ */
+static struct udp_sock *udp_lookup(ipaddr_t daddr, __u16 dport,
+                                   ipaddr_t saddr, __u16 sport)
+{
+    struct udp_sock *us, *wild = NULL;
+
+    for (us = udp_socks; us < &udp_socks[MAX_UDP_SOCKS]; us++) {
+        if (!us->active || us->localport != dport)
+            continue;
+        if (us->localaddr && us->localaddr != daddr)
+            continue;
+        if (us->remport) {                      /* connected */
+            if (us->remport == sport && us->remaddr == saddr)
+                return us;
+            continue;
+        }
+        if (!wild)
+            wild = us;
+    }
+    return wild;
+}
+
+/* ---- internal (callback) users: DHCP ------------------------------------ */
+
 int udp_register(__u16 local_port, udp_callback_t cb)
 {
-    int i;
+    struct udp_sock *us = udp_alloc();
 
-    for (i = 0; i < MAX_UDP_SOCKS; i++) {
-	if (!udp_socks[i].active) {
-	    udp_socks[i].active = 1;
-	    udp_socks[i].local_port = local_port;
-	    udp_socks[i].remaddr = 0;
-	    udp_socks[i].remport = 0;
-	    udp_socks[i].callback = cb;
-	    return 1;
-	}
-    }
-    return 0;
+    if (!us)
+        return 0;
+    us->localport = local_port;
+    us->callback = cb;
+    return 1;
 }
 
 void udp_unregister(__u16 local_port)
 {
-    int i;
+    struct udp_sock *us = udp_find_by_port(local_port);
 
-    for (i = 0; i < MAX_UDP_SOCKS; i++) {
-	if (udp_socks[i].active && udp_socks[i].local_port == local_port) {
-	    udp_socks[i].active = 0;
-	    return;
-	}
+    if (us && us->callback)
+        us->active = 0;
+}
+
+/* ---- socket-backed users ------------------------------------------------ */
+
+struct udp_sock *udp_sock_find(void *sock)
+{
+    struct udp_sock *us;
+
+    for (us = udp_socks; us < &udp_socks[MAX_UDP_SOCKS]; us++)
+        if (us->active && us->sock == sock)
+            return us;
+    return NULL;
+}
+
+/*
+ * Bind. *port is the requested port in host order, 0 to allocate. The
+ * ephemeral range is kept separate from TCP's, and the upper bound closes the
+ * wrap hole tcpdev_bind() has (a __u16 rolling 65535->0 escapes a "< 1024"
+ * guard on every increment but one).
+ */
+struct udp_sock *udp_sock_new(void *sock, ipaddr_t localaddr, __u16 *port)
+{
+    struct udp_sock *us;
+
+    if (*port) {
+        if (udp_find_by_port(*port))
+            return NULL;                        /* -EADDRINUSE */
+    } else {
+        int tries = 0;
+        do {
+            if (++udp_next_port < 1024 || udp_next_port > 60000)
+                udp_next_port = 1024;
+            /* at most MAX_UDP_SOCKS ports are taken, so one free candidate
+             * must appear within that many consecutive probes. (int is 16-bit
+             * here, so a large bound would never be reached.) */
+            if (++tries > MAX_UDP_SOCKS + 1)
+                return NULL;
+        } while (udp_find_by_port(udp_next_port));
+        *port = udp_next_port;
+    }
+
+    if (!(us = udp_alloc()))
+        return NULL;
+    us->sock = sock;
+    us->localaddr = localaddr;
+    us->localport = *port;
+    return us;
+}
+
+static void udp_flush(struct udp_sock *us)
+{
+    struct udp_dgram *d, *next;
+
+    for (d = us->rcvq; d; d = next) {
+        next = d->next;
+        udp_rcvq_memory -= sizeof(struct udp_dgram) + d->len;
+        free(d);
+    }
+    us->rcvq = NULL;
+    us->rcvcount = 0;
+}
+
+void udp_sock_free(void *sock)
+{
+    struct udp_sock *us = udp_sock_find(sock);
+
+    if (us) {
+        udp_flush(us);
+        us->active = 0;
     }
 }
 
-void udp_send(ipaddr_t dst, __u16 dstport, __u16 srcport,
-	      unsigned char *data, int datalen, ipaddr_t src)
+int udp_sock_avail(struct udp_sock *us)
 {
-    unsigned char buf[sizeof(struct udphdr_s) + 576];
+    if (us->pending_err)
+        return -1;                              /* wakes a blocked reader */
+    return us->rcvq? us->rcvq->len: 0;
+}
+
+int udp_sock_sendto(struct udp_sock *us, ipaddr_t daddr, __u16 dport,
+                    unsigned char *data, int len)
+{
+    /* ktcp does no IP fragmentation, so refuse rather than truncate */
+    if (len + (int)sizeof(struct udphdr_s) > (int)MTU - (int)sizeof(struct iphdr_s))
+        return -EMSGSIZE;
+
+    if (us->pending_err) {                      /* report a queued ICMP error */
+        int err = us->pending_err;
+        us->pending_err = 0;
+        return err;
+    }
+
+    udp_send(daddr, dport, us->localport, data, len,
+             us->localaddr? us->localaddr: local_ip);
+    return len;
+}
+
+int udp_sock_recvfrom(struct udp_sock *us, unsigned char *buf, int maxlen,
+                      ipaddr_t *saddr, __u16 *sport, int *trunc, int *avail_next)
+{
+    struct udp_dgram *d;
+    int n;
+
+    if (us->pending_err) {
+        int err = us->pending_err;
+        us->pending_err = 0;
+        return err;
+    }
+    if (!(d = us->rcvq))
+        return -EAGAIN;
+
+    n = d->len;
+    *trunc = (n > maxlen);
+    if (n > maxlen)
+        n = maxlen;
+    memcpy(buf, d->data, n);
+    *saddr = d->saddr;
+    *sport = d->sport;
+
+    /* a datagram is always consumed whole, never partially */
+    us->rcvq = d->next;
+    us->rcvcount--;
+    udp_rcvq_memory -= sizeof(struct udp_dgram) + d->len;
+    free(d);
+
+    *avail_next = us->rcvq? us->rcvq->len: 0;
+    return n;
+}
+
+static void udp_queue(struct udp_sock *us, ipaddr_t saddr, __u16 sport,
+                      unsigned char *data, int len)
+{
+    struct udp_dgram *d, *tail;
+
+    /*
+     * Tail-drop the newest. Dropping the head instead would let a flood starve
+     * an application that is making forward progress. No ICMP is sent: the
+     * port IS bound, so RFC 1122 does not want a port-unreachable here.
+     */
+    if (us->rcvcount >= UDP_RCVQ_MAX ||
+        udp_rcvq_memory + (int)sizeof(struct udp_dgram) + len > UDP_RCVQ_MAXMEM) {
+        netstats.udpdropcnt++;
+        return;
+    }
+    if (!(d = (struct udp_dgram *)malloc(sizeof(struct udp_dgram) + len))) {
+        netstats.udpdropcnt++;
+        return;
+    }
+    d->next = NULL;
+    d->saddr = saddr;
+    d->sport = sport;
+    d->len = len;
+    memcpy(d->data, data, len);
+
+    if (!us->rcvq)
+        us->rcvq = d;
+    else {
+        for (tail = us->rcvq; tail->next; tail = tail->next)
+            ;
+        tail->next = d;
+    }
+    us->rcvcount++;
+    udp_rcvq_memory += sizeof(struct udp_dgram) + len;
+}
+
+/*
+ * ICMP destination-unreachable for a datagram we sent. Only a connected socket
+ * can be blamed - for an unconnected one the error cannot be attributed to any
+ * particular peer, which is what BSD does too.
+ */
+void udp_icmp_error(ipaddr_t laddr, __u16 lport, __u16 rport, int err)
+{
+    struct udp_sock *us;
+
+    for (us = udp_socks; us < &udp_socks[MAX_UDP_SOCKS]; us++) {
+        if (us->active && us->sock && us->localport == lport &&
+            us->remport == rport && us->remaddr == laddr) {
+            us->pending_err = (__s8)err;
+            notify_sock(us->sock, TDT_AVAIL_DATA, -1);  /* break a blocked read */
+            return;
+        }
+    }
+}
+
+/* ---- wire ---------------------------------------------------------------- */
+
+void udp_send(ipaddr_t dst, __u16 dstport, __u16 srcport,
+              unsigned char *data, int datalen, ipaddr_t src)
+{
+    static unsigned char buf[sizeof(struct udphdr_s) + UDP_MAXPAYLOAD];
     struct udphdr_s *udp = (struct udphdr_s *)buf;
     struct addr_pair apair;
-    int total = sizeof(struct udphdr_s) + datalen;
+    int total;
+
+    if (datalen < 0 || datalen > UDP_MAXPAYLOAD) {  /* was unchecked */
+        netstats.udpdropcnt++;
+        return;
+    }
+    total = sizeof(struct udphdr_s) + datalen;
 
     udp->src = htons(srcport);
     udp->dest = htons(dstport);
@@ -56,6 +304,13 @@ void udp_send(ipaddr_t dst, __u16 dstport, __u16 srcport,
 
     memcpy(buf + sizeof(struct udphdr_s), data, datalen);
 
+#if UDP_CHECKSUM
+    {
+        __u16 sum = ip_chksum_pseudo(buf, src, dst, total, PROTO_UDP);
+        udp->check = sum? sum: 0xFFFF;  /* RFC 768: 0 means "none" on the wire */
+    }
+#endif
+
     apair.daddr = dst;
     apair.saddr = src;
     apair.protocol = PROTO_UDP;
@@ -63,23 +318,54 @@ void udp_send(ipaddr_t dst, __u16 dstport, __u16 srcport,
     netstats.udpsndcnt++;
 }
 
-void udp_process(struct iphdr_s *iph, unsigned char *packet)
+void udp_process(struct iphdr_s *iph, unsigned char *packet, int iplen)
 {
     struct udphdr_s *udp = (struct udphdr_s *)packet;
-    int udplen = ntohs(udp->len);
-    __u16 dest = ntohs(udp->dest);
-    __u16 src = ntohs(udp->src);
-    unsigned char *data = packet + sizeof(struct udphdr_s);
-    int datalen = udplen - sizeof(struct udphdr_s);
-    int i;
+    struct udp_sock *us;
+    unsigned int udplen;
+    __u16 dest, src;
+    unsigned char *data;
+    int datalen;
 
-    for (i = 0; i < MAX_UDP_SOCKS; i++) {
-	if (udp_socks[i].active && udp_socks[i].local_port == dest) {
-	    udp_socks[i].callback(iph, src, data, datalen);
-	    netstats.udprcvcnt++;
-	    return;
-	}
+    /*
+     * Validate the UDP length against the IP payload we actually received.
+     * This was never checked: a peer claiming a short or oversized length
+     * produced a negative datalen that flowed straight into memcpy.
+     */
+    udplen = ntohs(udp->len);
+    if (udplen < sizeof(struct udphdr_s) || udplen > (unsigned int)iplen) {
+        netstats.ipbadhdr++;
+        return;
     }
-    netstats.udpnoportcnt++;
-    icmp_send_port_unreachable(iph);
+
+#if UDP_CHECKSUM
+    /* check == 0 means the sender generated none; that is legal, accept it */
+    if (udp->check &&
+        ip_chksum_pseudo(packet, iph->saddr, iph->daddr, udplen, PROTO_UDP)) {
+        netstats.udpbadchksum++;
+        return;                         /* silent drop, RFC 1122 - no ICMP */
+    }
+#endif
+
+    dest = ntohs(udp->dest);
+    src = ntohs(udp->src);
+    data = packet + sizeof(struct udphdr_s);
+    datalen = udplen - sizeof(struct udphdr_s);
+
+    us = udp_lookup(iph->daddr, dest, iph->saddr, src);
+    if (!us) {
+        netstats.udpnoportcnt++;
+        icmp_send_port_unreachable(iph);
+        return;
+    }
+    netstats.udprcvcnt++;
+
+    if (us->callback) {                 /* internal user, e.g. DHCP */
+        us->callback(iph, src, data, datalen);
+        return;
+    }
+
+    udp_queue(us, iph->saddr, src, data, datalen);
+    if (us->sock)
+        notify_sock(us->sock, TDT_AVAIL_DATA, udp_sock_avail(us));
 }

--- a/elkscmd/ktcp/udp.c
+++ b/elkscmd/ktcp/udp.c
@@ -1,11 +1,7 @@
 /*
- * UDP for ktcp.
- *
- * Originally a four-entry callback table serving DHCP only, demultiplexing on
- * the destination port alone and never validating a length. It now backs
- * SOCK_DGRAM sockets: address+port demultiplexing with BSD precedence, a
- * bounded per-socket receive queue, and ICMP error delivery - while keeping
- * udp_register()/udp_unregister() so dhcp.c did not have to change.
+ * UDP for ktcp. was a four entry callback table for dhcp only, now backs
+ * SOCK_DGRAM as well. udp_register/udp_unregister kept so dhcp.c is
+ * unchanged.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,14 +45,8 @@ static struct udp_sock *udp_find_by_port(__u16 port)
     return NULL;
 }
 
-/*
- * Demultiplex, most specific first: a connected socket (both remote address
- * and port set) wins outright, otherwise the first wildcard bound to the port
- * takes it. Standard BSD precedence, in one pass.
- *
- * localaddr 0 means INADDR_ANY, which also makes loopback work: ip_route()
- * loops 127.x internally and the arriving daddr is 127.0.0.1.
- */
+/* most specific first, connected socket wins, else the first wildcard on
+ * the port. localaddr 0 is INADDR_ANY */
 static struct udp_sock *udp_lookup(ipaddr_t daddr, __u16 dport,
                                    ipaddr_t saddr, __u16 sport)
 {
@@ -111,12 +101,8 @@ struct udp_sock *udp_sock_find(void *sock)
     return NULL;
 }
 
-/*
- * Bind. *port is the requested port in host order, 0 to allocate. The
- * ephemeral range is kept separate from TCP's, and the upper bound closes the
- * wrap hole tcpdev_bind() has (a __u16 rolling 65535->0 escapes a "< 1024"
- * guard on every increment but one).
- */
+/* *port is host order, 0 to allocate. own ephemeral range, and the upper
+ * bound closes the wrap hole tcpdev_bind() has */
 struct udp_sock *udp_sock_new(void *sock, ipaddr_t localaddr, __u16 *port)
 {
     struct udp_sock *us;
@@ -129,9 +115,7 @@ struct udp_sock *udp_sock_new(void *sock, ipaddr_t localaddr, __u16 *port)
         do {
             if (++udp_next_port < 1024 || udp_next_port > 60000)
                 udp_next_port = 1024;
-            /* at most MAX_UDP_SOCKS ports are taken, so one free candidate
-             * must appear within that many consecutive probes. (int is 16-bit
-             * here, so a large bound would never be reached.) */
+            /* at most MAX_UDP_SOCKS are taken so one must be free */
             if (++tries > MAX_UDP_SOCKS + 1)
                 return NULL;
         } while (udp_find_by_port(udp_next_port));
@@ -231,11 +215,8 @@ static void udp_queue(struct udp_sock *us, ipaddr_t saddr, __u16 sport,
 {
     struct udp_dgram *d, *tail;
 
-    /*
-     * Tail-drop the newest. Dropping the head instead would let a flood starve
-     * an application that is making forward progress. No ICMP is sent: the
-     * port IS bound, so RFC 1122 does not want a port-unreachable here.
-     */
+    /* tail drop, dropping the head would let a flood starve an app that is
+     * getting on with it. no icmp, the port is bound */
     if (us->rcvcount >= UDP_RCVQ_MAX ||
         udp_rcvq_memory + (int)sizeof(struct udp_dgram) + len > UDP_RCVQ_MAXMEM) {
         netstats.udpdropcnt++;
@@ -262,11 +243,7 @@ static void udp_queue(struct udp_sock *us, ipaddr_t saddr, __u16 sport,
     udp_rcvq_memory += sizeof(struct udp_dgram) + len;
 }
 
-/*
- * ICMP destination-unreachable for a datagram we sent. Only a connected socket
- * can be blamed - for an unconnected one the error cannot be attributed to any
- * particular peer, which is what BSD does too.
- */
+/* only a connected socket can be blamed, same as bsd */
 void udp_icmp_error(ipaddr_t laddr, __u16 lport, __u16 rport, int err)
 {
     struct udp_sock *us;
@@ -327,11 +304,8 @@ void udp_process(struct iphdr_s *iph, unsigned char *packet, int iplen)
     unsigned char *data;
     int datalen;
 
-    /*
-     * Validate the UDP length against the IP payload we actually received.
-     * This was never checked: a peer claiming a short or oversized length
-     * produced a negative datalen that flowed straight into memcpy.
-     */
+    /* never checked before, a bad length gave a negative datalen straight
+     * into memcpy */
     udplen = ntohs(udp->len);
     if (udplen < sizeof(struct udphdr_s) || udplen > (unsigned int)iplen) {
         netstats.ipbadhdr++;

--- a/elkscmd/ktcp/udp.h
+++ b/elkscmd/ktcp/udp.h
@@ -1,12 +1,8 @@
 #ifndef UDP_H
 #define UDP_H
 
-/*
- * UDP for ktcp. This was a four-entry callback table that existed only so DHCP
- * could work, with its own header saying "Not accessible through sockets". It
- * is now a real demultiplexer backing SOCK_DGRAM, while keeping the callback
- * form so dhcp.c is unchanged.
- */
+/* was a four entry callback table for dhcp only, now a real demultiplexer
+ * backing SOCK_DGRAM. callback form kept so dhcp.c is unchanged */
 
 #define PROTO_UDP       0x11
 
@@ -16,24 +12,10 @@
 
 #define MAX_UDP_SOCKS   8       /* internal (DHCP) + socket-backed, machine wide */
 
-/*
- * Receive queue limits. Datagrams are lost rather than retransmitted, so a
- * deep queue only converts loss into latency - which is the wrong trade for
- * the media receivers this exists for. Four covers a duplicate or late reply
- * plus one scheduling hiccup.
- *
- * The byte cap is the load-bearing one: per-socket counts alone would allow
- * 8 x 4 x 1482 = 47424 bytes, more than ktcp's entire heap.
- *
- * It must be sized in FULL-SIZE datagrams, not in bytes that merely look
- * generous. At 2048 a single 1027-byte datagram plus its 10-byte queue header
- * fitted but a second did not, so any sender emitting two back to back - which
- * is exactly what a video stream with separate audio and picture datagrams
- * does - lost one of every pair before the application ever looked. 6144 holds
- * four 1482-byte datagrams and their headers. That is worst case, reached only
- * while an application is actually behind; against a 49152-byte heap it costs
- * less than three TCP control blocks, and nothing at all when the queue drains.
- */
+/* receive queue limits. a deep queue only turns loss into latency so keep it
+ * shallow. the byte cap is the real limit and must hold four full size
+ * datagrams, at 2048 a sender emitting two back to back lost one of each
+ * pair */
 #define UDP_RCVQ_MAX    4       /* datagrams queued per socket */
 #define UDP_RCVQ_MAXMEM 6144    /* bytes queued across all UDP sockets */
 

--- a/elkscmd/ktcp/udp.h
+++ b/elkscmd/ktcp/udp.h
@@ -1,8 +1,41 @@
 #ifndef UDP_H
 #define UDP_H
 
+/*
+ * UDP for ktcp. This was a four-entry callback table that existed only so DHCP
+ * could work, with its own header saying "Not accessible through sockets". It
+ * is now a real demultiplexer backing SOCK_DGRAM, while keeping the callback
+ * form so dhcp.c is unchanged.
+ */
+
 #define PROTO_UDP       0x11
-#define MAX_UDP_SOCKS   4
+
+/* largest datagram payload ktcp will build: DHCP needs 576, the socket path is
+ * bounded by TDB_WRITE_MAX (512), so 576 covers both */
+#define UDP_MAXPAYLOAD  576
+
+#define MAX_UDP_SOCKS   8       /* internal (DHCP) + socket-backed, machine wide */
+
+/*
+ * Receive queue limits. Datagrams are lost rather than retransmitted, so a
+ * deep queue only converts loss into latency - which is the wrong trade for
+ * the media receivers this exists for. Four covers a duplicate or late reply
+ * plus one scheduling hiccup.
+ *
+ * The byte cap is the load-bearing one: per-socket counts alone would allow
+ * 8 x 4 x 1482 = 47424 bytes, more than ktcp's entire heap.
+ *
+ * It must be sized in FULL-SIZE datagrams, not in bytes that merely look
+ * generous. At 2048 a single 1027-byte datagram plus its 10-byte queue header
+ * fitted but a second did not, so any sender emitting two back to back - which
+ * is exactly what a video stream with separate audio and picture datagrams
+ * does - lost one of every pair before the application ever looked. 6144 holds
+ * four 1482-byte datagrams and their headers. That is worst case, reached only
+ * while an application is actually behind; against a 49152-byte heap it costs
+ * less than three TCP control blocks, and nothing at all when the queue drains.
+ */
+#define UDP_RCVQ_MAX    4       /* datagrams queued per socket */
+#define UDP_RCVQ_MAXMEM 6144    /* bytes queued across all UDP sockets */
 
 struct udphdr_s {
     __u16   src;
@@ -14,21 +47,47 @@ struct udphdr_s {
 typedef void (*udp_callback_t)(struct iphdr_s *iph, __u16 src_port,
                                unsigned char *data, int datalen);
 
+/* one queued datagram; header is 10 bytes, payload follows */
+struct udp_dgram {
+    struct udp_dgram *next;
+    ipaddr_t          saddr;    /* network byte order */
+    __u16             sport;    /* host byte order */
+    __u16             len;
+    unsigned char     data[];
+};
+
 struct udp_sock {
-    int active;
-    __u16 local_port;
-    ipaddr_t remaddr;           /* 0 if not connected */
-    __u16 remport;              /* 0 if not connected */
-    udp_callback_t callback;
+    void             *sock;     /* kernel socket handle; NULL for internal users */
+    udp_callback_t    callback; /* non-NULL for internal users (DHCP) */
+    ipaddr_t          localaddr;/* network order; 0 = INADDR_ANY */
+    ipaddr_t          remaddr;  /* network order; 0 = unconnected */
+    struct udp_dgram *rcvq;     /* FIFO, oldest first */
+    __u16             localport;/* host order */
+    __u16             remport;  /* host order; 0 = unconnected */
+    __u8              active;
+    __s8              pending_err; /* negative errno from ICMP, else 0 */
+    __u8              rcvcount;
 };
 
 extern struct udp_sock udp_socks[MAX_UDP_SOCKS];
 
-void udp_process(struct iphdr_s *iph, unsigned char *packet);
+void udp_process(struct iphdr_s *iph, unsigned char *packet, int iplen);
 void udp_send(ipaddr_t dst, __u16 dstport, __u16 srcport,
               unsigned char *data, int datalen, ipaddr_t src);
 
-int udp_register(__u16 local_port, udp_callback_t cb);
+/* internal (callback) users - DHCP */
+int  udp_register(__u16 local_port, udp_callback_t cb);
 void udp_unregister(__u16 local_port);
+
+/* socket-backed users, driven from tcpdev.c */
+struct udp_sock *udp_sock_new(void *sock, ipaddr_t localaddr, __u16 *port);
+struct udp_sock *udp_sock_find(void *sock);
+void udp_sock_free(void *sock);
+int  udp_sock_sendto(struct udp_sock *us, ipaddr_t daddr, __u16 dport,
+                     unsigned char *data, int len);
+int  udp_sock_recvfrom(struct udp_sock *us, unsigned char *buf, int maxlen,
+                       ipaddr_t *saddr, __u16 *sport, int *trunc, int *avail_next);
+int  udp_sock_avail(struct udp_sock *us);
+void udp_icmp_error(ipaddr_t laddr, __u16 lport, __u16 rport, int err);
 
 #endif

--- a/libc/include/sys/socket.h
+++ b/libc/include/sys/socket.h
@@ -20,4 +20,13 @@ int getsockname (int sock, struct sockaddr * restrict address,
 int getpeername (int sock, struct sockaddr * restrict address,
 	socklen_t * restrict address_len);
 
+/* datagram sockets. The kernel entries take five arguments (ELKS syscalls
+ * carry no more); these restore the POSIX six-argument shape. */
+int sendto (int sock, const void *buf, size_t len, int flags,
+	const struct sockaddr *address, socklen_t address_len);
+int recvfrom (int sock, void *buf, size_t len, int flags,
+	struct sockaddr * restrict address, socklen_t * restrict address_len);
+int send (int sock, const void *buf, size_t len, int flags);
+int recv (int sock, void *buf, size_t len, int flags);
+
 #endif

--- a/libc/net/Makefile
+++ b/libc/net/Makefile
@@ -5,7 +5,7 @@ LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
-OBJS = in_aton.o in_ntoa.o in_gethostbyname.o getsocknam.o in_connect.o in_resolv.o
+OBJS = in_aton.o in_ntoa.o in_gethostbyname.o getsocknam.o in_connect.o in_resolv.o sendto.o recvfrom.o
 
 all: $(LIB)
 

--- a/libc/net/recvfrom.c
+++ b/libc/net/recvfrom.c
@@ -1,0 +1,29 @@
+/*
+ * recvfrom/recv over the 5-argument _recvfrom syscall. See sendto.c for why
+ * addrlen is not passed to the kernel.
+ */
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+
+int _recvfrom(int, void *, size_t, int, struct sockaddr *);
+
+int recvfrom(int fd, void *buf, size_t len, int flags,
+	struct sockaddr *address, socklen_t *address_len)
+{
+	int ret;
+
+	if (address && (!address_len || *address_len < sizeof(struct sockaddr_in))) {
+		errno = EINVAL;
+		return -1;
+	}
+	ret = _recvfrom(fd, buf, len, flags, address);
+	if (ret >= 0 && address && address_len)
+		*address_len = sizeof(struct sockaddr_in);
+	return ret;
+}
+
+int recv(int fd, void *buf, size_t len, int flags)
+{
+	return _recvfrom(fd, buf, len, flags, (struct sockaddr *)0);
+}

--- a/libc/net/sendto.c
+++ b/libc/net/sendto.c
@@ -1,0 +1,29 @@
+/*
+ * sendto/send over the 5-argument _sendto syscall.
+ *
+ * An ELKS syscall carries at most five arguments (bx,cx,dx,di,si), and POSIX
+ * sendto takes six. The kernel entry therefore drops addrlen and assumes
+ * sizeof(struct sockaddr_in) - AF_INET is the only family implementing it.
+ * This restores the POSIX shape, exactly as getsocknam.c does for
+ * getsockname/getpeername.
+ */
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+
+int _sendto(int, const void *, size_t, int, const struct sockaddr *);
+
+int sendto(int fd, const void *buf, size_t len, int flags,
+	const struct sockaddr *address, socklen_t address_len)
+{
+	if (address && address_len < sizeof(struct sockaddr_in)) {
+		errno = EINVAL;
+		return -1;
+	}
+	return _sendto(fd, buf, len, flags, address);
+}
+
+int send(int fd, const void *buf, size_t len, int flags)
+{
+	return _sendto(fd, buf, len, flags, (struct sockaddr *)0);
+}

--- a/libc/net/sendto.c
+++ b/libc/net/sendto.c
@@ -1,12 +1,6 @@
-/*
- * sendto/send over the 5-argument _sendto syscall.
- *
- * An ELKS syscall carries at most five arguments (bx,cx,dx,di,si), and POSIX
- * sendto takes six. The kernel entry therefore drops addrlen and assumes
- * sizeof(struct sockaddr_in) - AF_INET is the only family implementing it.
- * This restores the POSIX shape, exactly as getsocknam.c does for
- * getsockname/getpeername.
- */
+/* an elks syscall carries five args and posix sendto takes six, so the
+ * kernel drops addrlen and assumes sizeof(struct sockaddr_in). this puts the
+ * posix shape back, same as getsocknam.c does */
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <errno.h>


### PR DESCRIPTION
Rework of ktcp and the kernel socket shim. I've spent the last 20 hours or so, on and off, in ktcp.

## Why

Four things bound the stack, in the order they bite:

1. **~7 connections machine-wide.** `tcpcb_new()` allocated 86 + 4380 bytes per connection out of a 33792 byte heap, shared by telnetd, ftpd, httpd and everything else.
2. **~13 KB of ktcp's 16.8 KB BSS was unusable.** `ipbuf`, `tcpbuf` and tcpdev's `sbuf` were all sized off `CB_NORMAL_BUFSIZ` — the per-connection *ring* size — rather than off the MTU. There's no IP reassembly and the MTU is capped at 1500, so most of that was dead weight sitting where heap should be.
3. **A deadlock that wedged the whole machine.** `tcpdev_read()` on a socket whose control block had gone printed a message and returned without replying. The caller stayed asleep holding the global `rwlock` in `af_inet.c`, so every socket on the machine stopped. This is what had been hanging my box: all services would accept connections and then transfer nothing. It reproduces reliably by killing a server while a client is attached.
4. **UDP was unreachable from userspace.** `udp.c` existed but said "not accessible through sockets"; `sys_socket()` rejected `SOCK_DGRAM`, and there were no `sendto`/`recvfrom` syscalls.

## What changed

**Buffer sizing.** `TCPDEV_BUFSIZ`, `IP_BUFSIZ` and `CB_NORMAL_BUFSIZ` are now three independent definitions sized from what each actually holds, instead of all deriving from the receive window. The wire buffers come from `MAX_PACKET_ETH`; the ring stays a per-connection tuning dial. That frees enough heap to raise the connection ceiling from about 7 to 14 measured, and to 16 with a smaller `SO_RCVBUF`, at which point the fd limit binds rather than memory.

**`SO_RCVBUF` is honoured on accepted sockets.** `tcp_listen()` used to hardcode the ring size, so a bulk receiver and an idle game client cost the same. `SO_ACCEPT_BUFSIZ_TINY/SMALL/BULK` are suggested values; the semantics are that `SO_RCVBUF` on a socket that goes on to `listen()` sets the ring of the connections it *accepts*, since the listening socket never receives anything itself.

**Ring copies use `memcpy`.** Both were byte-at-a-time loops with a wrap test per byte; they're now at most two `memcpy` calls split at the wrap point. These run on every received segment and every application read.

**The deadlock fix.** A read on a socket with no control block now answers with `-EPIPE` instead of returning silently. Connect on a refused socket likewise notifies rather than leaving the caller asleep.

**Embryonic connection reaping.** Unaccepted control blocks are now timed out, so an unattended port can't exhaust the heap.

**UDP sockets.** `sendto`/`recvfrom` syscalls, `TDC_SENDTO`/`TDC_RECVFROM` tcpdev opcodes carrying the peer address, and `udp.c` promoted from a DHCP callback table to a real demultiplexer with BSS most-specific-wins matching, per-socket receive queues, length validation and ICMP error delivery. DHCP still registers the same way and is unaffected.

The syscalls take five arguments, not six — ELKS syscalls carry no more than five — so `addrlen` is dropped at the kernel boundary and fixed at `sizeof(struct sockaddr_in)`. libc restores the POSIX six-argument shape. There's precedent for this in `getsocknam`.

## Measured on the hardware

Real Amstrad PC1640, 8086:

| | |
|---|---|
| TCP | **20463 B/s** |
| UDP | lossless to **16000 B/s**, saturating around 20500 B/s |
| Concurrent connections | **7 → 14** (16 with a smaller `SO_RCVBUF`, then fd-limited) |

Same figures on QEMU and on 86Box configured as a PC1640, using the same instrument.

**UDP works, but TCP currently outperforms it.** I haven't chased why yet. I suspect the per-datagram path through tcpdev has more fixed cost than the TCP path amortises over a segment, but that's a guess and I'd rather say so than dress it up.

The clearest practical result: with the old stack, audio receive topped out at **8000 Hz**. With this one I can max the driver out at **20000 Hz** 8-bit PCM and send it continuously with zero issues.

Also, my game server daemon used to hang the box after a while. Since the `-EPIPE` fix I haven't reproduced it.

## Notes

`netstat` gains UDP packet and drop counters.

I've deliberately kept this to the stack itself and the changes needed to build it. The applications that would benefit from the new `SO_ACCEPT_BUFSIZ_*` values aren't touched here.

There's also a `libc/asm/memcpy-s.S` change I've left out of this PR — it copies words instead of bytes, which is about 26% cheaper on an 8088 and speeds the ring copies above. It's a global libc change rather than networking, so it seemed better as its own PR.
