### PR TITLE
[libc] memcpy: copy words, not bytes

### DIFF
--- a/libc/asm/memcpy-s.S
+++ b/libc/asm/memcpy-s.S
@@ -49,7 +49,25 @@ memcpy:
 		     // n = CX already
 #endif
 
+	// Copy words, then the odd trailing byte if there is one.
+	//
+	// REP MOVSB moves one byte per 17 clocks on an 8088; REP MOVSW moves
+	// two per 25, so words are ~26% cheaper and there is no misalignment
+	// penalty on an 8088 (the bus is 8 bits wide either way). On a real
+	// 8086 an aligned word move is cheaper still and a misaligned one
+	// costs the same as two bytes, so this never loses.
+	//
+	// SHR puts the odd-length bit in CF; REP MOVSW leaves flags alone and
+	// ends with CX = 0; RCL then reconstitutes CX = 0 or 1. This is the
+	// same sequence the kernel has used in memcpy_fromfs/memcpy_tofs
+	// (elks/arch/i86/mm/memcpyfs.S) for years. n = 0 falls through both
+	// REPs without copying.
+
 	cld
+	shr	$1,%cx			// copy words
+	rep
+	movsw
+	rcl	$1,%cx			// then possibly final byte
 	rep
 	movsb
 

--- a/libc/asm/memcpy-s.S
+++ b/libc/asm/memcpy-s.S
@@ -49,20 +49,6 @@ memcpy:
 		     // n = CX already
 #endif
 
-	// Copy words, then the odd trailing byte if there is one.
-	//
-	// REP MOVSB moves one byte per 17 clocks on an 8088; REP MOVSW moves
-	// two per 25, so words are ~26% cheaper and there is no misalignment
-	// penalty on an 8088 (the bus is 8 bits wide either way). On a real
-	// 8086 an aligned word move is cheaper still and a misaligned one
-	// costs the same as two bytes, so this never loses.
-	//
-	// SHR puts the odd-length bit in CF; REP MOVSW leaves flags alone and
-	// ends with CX = 0; RCL then reconstitutes CX = 0 or 1. This is the
-	// same sequence the kernel has used in memcpy_fromfs/memcpy_tofs
-	// (elks/arch/i86/mm/memcpyfs.S) for years. n = 0 falls through both
-	// REPs without copying.
-
 	cld
 	shr	$1,%cx			// copy words
 	rep


### PR DESCRIPTION
Split out of #2801  — it's a libc change rather than a networking one, so it belongs on its own.

`memcpy` copied a byte at a time. On an 8088 `REP MOVSB` is 17 clocks per byte and `REP MOVSW` is 25 per two, so words are about **26% cheaper**. There is no misalignment penalty on an 8088 — the bus is 8 bits wide either way — and on a real 8086 an aligned word move is cheaper still while a misaligned one costs the same as two bytes. So this never loses.

`SHR` puts the odd-length bit in CF, `REP MOVSW` leaves flags alone and ends with CX = 0, and `RCL` reconstitutes CX = 0 or 1 for the trailing byte. `n = 0` falls through both REPs without copying. This is the same sequence the kernel has used in `memcpy_fromfs`/`memcpy_tofs` (`elks/arch/i86/mm/memcpyfs.S`) for years.

## Effect

This matters most where the machine moves bytes in bulk. In ktcp that's the control block ring copies, which run on every received segment and every application read.

I've had this in the tree throughout the ktcp work in #2801. With the two together on a real Amstrad PC1640:

- **Sustained 20000 Hz 8-bit PCM playback** over the network, which is the sound driver's ceiling. Before, audio receive topped out at 8000 Hz.
- **My game server daemon no longer wedges the box.** It used to hang after a while, with every service accepting connections and then transferring nothing.

To be precise about which change did what: the wedge itself was a deadlock in ktcp — a read on a socket whose control block had gone never replied, leaving the caller asleep holding the global inet lock — and that's fixed in #2801, not here. What this change contributes is throughput and the CPU headroom that makes the 20000 Hz rate hold rather than break up.

## Testing

Beyond the ktcp work, this has had a lot of incidental exercise on real hardware: multi-megabyte FTP transfers with size verification, and video playback where I compared the machine's framebuffer byte-for-byte against the encoder's model. Both would have caught an off-by-one in the odd-length tail.
