### PR TITLE
Add tinyprintf linker flag to new network utilities to reduce code size

### DIFF
--- a/elkscmd/inet/Makefile
+++ b/elkscmd/inet/Makefile
@@ -40,16 +40,16 @@ netstat: netstat.o $(TINYPRINTF)
 nslookup: nslookup.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-ping: ping.o
+ping: ping.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-ifconfig: ifconfig.o
+ifconfig: ifconfig.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-tcpdump: tcpdump.o
+tcpdump: tcpdump.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-traceroute: traceroute.o
+traceroute: traceroute.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 telnet: telnet.o $(TINYPRINTF)
@@ -58,7 +58,7 @@ telnet: telnet.o $(TINYPRINTF)
 telnetd: telnetd.o telopt.o
 	$(LD) $(LDFLAGS) -maout-heap=256 -maout-stack=1024 -o $@ $^ $(LDLIBS)
 
-curl: curl.o
+curl: curl.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-stack=2048 -maout-heap=2048 -o $@ $^ $(LDLIBS)
 
 urlget: urlget.o $(TINYPRINTF)

--- a/elkscmd/inet/Makefile
+++ b/elkscmd/inet/Makefile
@@ -22,10 +22,10 @@ install: $(PRGS)
 arp: arp.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-ftp: ftp.o
+ftp: ftp.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-stack=6144 -maout-heap=4096 -o $@ $^ $(LDLIBS)
 
-ftpd: ftpd.o
+ftpd: ftpd.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-stack=4096 -maout-heap=4096 -o $@ $^ $(LDLIBS)
 
 httpd: httpd.o $(TINYPRINTF)
@@ -37,7 +37,7 @@ netcat: netcat.o $(TINYPRINTF)
 netstat: netstat.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-nslookup: nslookup.o
+nslookup: nslookup.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 ping: ping.o $(TINYPRINTF)
@@ -64,7 +64,7 @@ curl: curl.o $(TINYPRINTF)
 urlget: urlget.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-tinyirc/tinyirc: tinyirc/tinyirc.o
+tinyirc/tinyirc: tinyirc/tinyirc.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-heap=8192 -o $@ $^ $(LDLIBS)
 
 clean:

--- a/elkscmd/inet/ftp.c
+++ b/elkscmd/inet/ftp.c
@@ -1137,7 +1137,9 @@ int do_login(char *user, char *passwd, char *buffer, int len, char *ip,
 		return -1;
 	}
 	if (*passwd == '\0') {
-		lip = getpass("Password:");
+		printf("Password: ");
+		fflush(stdout);
+		lip = getpass("");
 		printf("\n");
 		if (strlen(lip) < 2) lip = passwd; /* use passwd from command line if present */
 	} else lip = passwd;

--- a/qemu.sh
+++ b/qemu.sh
@@ -12,11 +12,11 @@
 # Select disk image to use
 # MINIX or FAT .config build
 #IMAGE="-fda image/fd2880.img"
-#IMAGE="-fda image/fd1440.img"
+IMAGE="-fda image/fd1440.img"
 #IMAGE="-fda image/fd1200.img"
 #IMAGE="-fda image/fd720.img"
 #IMAGE="-fda image/fd360.img"
-IMAGE="-hda image/hd.img"
+#IMAGE="-hda image/hd.img"
 #IMAGE="-boot order=a -fda image/fd1440.img -drive file=image/hd32-minix.img,format=raw,if=ide"
 
 # FAT package manager build

--- a/qemu.sh
+++ b/qemu.sh
@@ -12,11 +12,11 @@
 # Select disk image to use
 # MINIX or FAT .config build
 #IMAGE="-fda image/fd2880.img"
-IMAGE="-fda image/fd1440.img"
+#IMAGE="-fda image/fd1440.img"
 #IMAGE="-fda image/fd1200.img"
 #IMAGE="-fda image/fd720.img"
 #IMAGE="-fda image/fd360.img"
-#IMAGE="-hda image/hd.img"
+IMAGE="-hda image/hd.img"
 #IMAGE="-boot order=a -fda image/fd1440.img -drive file=image/hd32-minix.img,format=raw,if=ide"
 
 # FAT package manager build


### PR DESCRIPTION
Add $TINYPRINT linker flag to new network utilities per discussion in #2805

ftp was interesting.  With this change to add the $TINYPRINTF linker flag, initially I was not seeing the password prompt in testing until I logged out of the ftp session.  The ftp.c change in this PR is the AI-deduced "fix".

AI-generated explanation:
```
Why  ftp fix works:
- printf("Password: ") + fflush(stdout) writes the prompt immediately (tiny's fflush flushes bufout), instead of it being stuck in buferr until exit.
- getpass("") still does the termios echo-off + /dev/tty read, just prints nothing.
```

AI generated reasoning as to why the warning in tiny_vfprint is too restrictive:


```
Why is tiny_print comment too restrictive?

The comment at tiny_vfprintf.c:11 says "Don't use with fopen (stdout, stderr only)" — but that's overly conservative, and the ftp fix earlier proved it. Here's why:
The tiny functions are actually FILE-agnostic. Look at what they touch:
- fflush(fp) → just write(fp->fd, fp->bufstart, fp->bufpos - fp->bufstart) (tiny_vfprintf.c:73-75)
- fputc(ch, fp) → only fp->bufpos, fp->bufend, calls fflush (line 83-91)
- vfprintf(op, ...) → only passes op down to fputc
All of these fields (fd, bufpos, bufstart, bufend) are standard libc FILE members that fopen() initializes identically to the static stdout/stderr here. So FILE *fp = fopen("x","w"); fprintf(fp,...) works fine — as demonstrated when getpass()'s fopen("/dev/tty") worked under tiny.
What the warning is really about (the legitimate core): mixing tiny's write path with libc's buffered read path on the same stream. libc stdio does "flush/switch buffer on read↔write mode change" logic; tiny's fflush ignores __MODE_READING/__MODE_WRITING and won't discard libc's read-ahead when you switch from fgetc to fprintf on one FILE. That's a real hazard — but only for mixed read+write streams.
So the accurate restriction is:
Don't mix tiny's output with libc's input buffering on the same stream; write-only fopen'd files are fine.
The stated blanket ban is too strong because it forbids the perfectly safe write-only case (exactly the getpass/ftp scenario). The correct fix for the comment would be to narrow it to "no read/write mode-switching on the same stream" (and note tiny forces line-buffering on every FILE, so bulk-write perf on fopen'd files is worse than full-buffer libc).
```

ftp/ftpd with fix:

<img width="642" height="391" alt="Screenshot 2026-08-09 at 3 03 14 PM" src="https://github.com/user-attachments/assets/8b4d0427-be19-4782-8f38-87efba154600" />


Other tests:

ifconfig, ping, traceroute


<img width="640" height="402" alt="Screenshot 2026-08-09 at 2 29 40 PM" src="https://github.com/user-attachments/assets/bb51dc30-2443-4fb1-8a67-7bd360a83d21" />

nslookup, tcpdump
<img width="660" height="397" alt="Screenshot 2026-08-09 at 2 38 01 PM" src="https://github.com/user-attachments/assets/0885bbf6-852c-4015-8de0-d4396e6b1721" />

curl
<img width="639" height="388" alt="Screenshot 2026-08-09 at 2 41 48 PM" src="https://github.com/user-attachments/assets/35323e9b-2047-4f91-afdd-395656099e63" />

tiny irc 
<img width="638" height="383" alt="Screenshot 2026-08-09 at 2 49 46 PM" src="https://github.com/user-attachments/assets/44aa2727-bba2-4798-b3f9-b109b28b5fc0" />

tiny irc 2

<img width="645" height="393" alt="Screenshot 2026-08-09 at 2 53 09 PM" src="https://github.com/user-attachments/assets/16e0325a-80b5-4aa1-a5f1-b1f4463b16b7" />
