### PR TITLE
[net] Change meaning of SO_RCVBUF to set connect/accept buffer size

### DIFF
--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -5,7 +5,7 @@
 #include <linuxmt/socket.h>
 
 /* Number of protocols */
-#define NPROTO 3
+#define NPROTO 2
 
 #define SOCK_INODE(S)	((S)->inode)
 
@@ -27,14 +27,14 @@ struct socket {
     struct inode *inode;
     struct file *file;
 
-#if defined(CONFIG_UNIX)
+#ifdef CONFIG_UNIX
     struct socket *conn;
     struct socket *iconn;
     struct socket *next;
     void *data;
 #endif
 
-#if defined(CONFIG_INET)
+#ifdef CONFIG_INET
     sem_t sem;			/* one operation at a time per socket */
     int avail_data;		/* data available for reading from ktcp */
     int retval;			/* event return value from ktcp */
@@ -72,6 +72,7 @@ struct proto_ops {
 #define SF_RST_ON_CLOSE	(1 << 4) /* inet */
 #define SF_REUSE_ADDR	(1 << 5) /* inet */
 #define SF_CONNECT	(1 << 6) /* inet */
+#define SF_NOBUF        (1 << 7) /* inet */
 
 struct net_proto {
     const char *name;		/* Protocol name */

--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -3,43 +3,39 @@
 
 #include <linuxmt/types.h>
 
-#define MAX_SOCK_ADDR 110  /* Sufficient size for AF_UNIX */
-
 struct sockaddr {
     unsigned short sa_family;
-    char sa_data [MAX_SOCK_ADDR];
+    char sa_data[20];       /* sufficient size for AF_UNIX sockaddr_un in un.h */
 };
 
-/* for setsockopt(2) */
-#define SOL_SOCKET	1
+/* setsockopt parameters */
+#define SOL_SOCKET      1
 
 /* careful: option names are close to internal SF_ options in net.h*/
-#define SO_REUSEADDR	2
-#define SO_RCVBUF	8		/* set TCP CB receive buffer size*/
-#define SO_LINGER	13		/* only implemented for l_linger = 0*/
+#define SO_REUSEADDR    2
+#define SO_RCVBUF       8               /* set TCP CB receive buffer size*/
+#define SO_LINGER       13              /* only implemented for l_linger = 0*/
 
 /* non-standard options */
-#define SO_LISTEN_BUFSIZ	128	/* suggested buffer size for listen to save mem*/
+#define SO_NOBUFFER     14              /* don't allocate rcv buffer (e.g. for listen) */
 
 struct linger {
         int             l_onoff;        /* Linger active                */
         int             l_linger;       /* How long to linger for       */
 };
 
-#define AF_INET	0
-#define AF_UNIX	1
+#define AF_INET 0
+#define AF_UNIX 1
 
-#define PF_INET	AF_INET
-#define PF_UNIX	AF_UNIX
+#define PF_INET AF_INET
+#define PF_UNIX AF_UNIX
 
 #define AF_LOCAL AF_UNIX
 #define PF_LOCAL PF_UNIX
 
-#define SOCK_STREAM     1	/* stream (connection) socket   */
-#define SOCK_DGRAM      2	/* datagram (conn.less) socket  */
-#define SOCK_RAW        3	/* raw socket                   */
-#define SOCK_RDM        4	/* reliably-delivered message   */
-#define SOCK_SEQPACKET  5	/* sequential packet socket     */
+#define SOCK_STREAM     1       /* stream (connection) socket   */
+#define SOCK_DGRAM      2       /* datagram (conn.less) socket  */
+#define SOCK_RAW        3       /* raw socket                   */
 
 #ifdef __KERNEL__
 struct proto_ops;

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -8,8 +8,6 @@
 #include <linuxmt/in.h>
 #include <linuxmt/net.h>
 
-#define TCP_DEVICE_NAME	"tcpdev"
-
 /* should be equal to PTYOUTQ_SIZE and telnetd buffer size*/
 #define	TDB_WRITE_MAX		512	/* max data in tdb_write packet to ktcp*/
 
@@ -30,7 +28,7 @@
 struct tdb_release {
     unsigned char cmd;
     struct socket *sock;
-    int reset;
+    int reset;                      /* SO_LINGER -> SF_RST_ON_CLOSE */
 };
 
 struct tdb_accept {
@@ -49,7 +47,8 @@ struct tdb_listen {
 struct tdb_bind {
     unsigned char cmd;
     struct socket *sock;
-    int reuse_addr;
+    int reuse_addr;                 /* SO_REUSEADDR -> SF_REUSE_ADDR */
+    int no_buffer;                  /* SO_NOBUFFER -> SF_NOBUF */
     int rcv_bufsiz;
     struct sockaddr_in addr;
 };

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -161,6 +161,7 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
     cmd->cmd = TDC_BIND;
     cmd->sock = sock;
     cmd->reuse_addr = sock->flags & SF_REUSE_ADDR;
+    cmd->no_buffer = sock->flags & SF_NOBUF;
     cmd->rcv_bufsiz = sock->rcv_bufsiz;
     memcpy_fromfs(&cmd->addr, addr, sockaddr_len);
 

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -47,9 +47,6 @@ static struct proto_ops *find_protocol_family(int family)
 
 static int check_addr_to_kernel(void *uaddr, size_t ulen)
 {
-    if (ulen > MAX_SOCK_ADDR)
-	return -EINVAL;
-
     if (ulen == 0)
 	return 0;
 
@@ -575,6 +572,11 @@ int sys_setsockopt(int fd, int level, int option_name, void *option_value,
 	    return 0;
 	}
 	flags = SF_REUSE_ADDR;
+	break;
+
+    case SO_NOBUFFER:
+	setoption = 1;
+	flags = SF_NOBUF;
 	break;
 
     default:

--- a/elkscmd/audio/audiorcv.c
+++ b/elkscmd/audio/audiorcv.c
@@ -308,9 +308,8 @@ int main(int argc, char **argv)
         perror("SO_REUSEADDR");
 
     /* set small listen buffer to save ktcp memory */
-    val = SO_LISTEN_BUFSIZ;
-    if (setsockopt(listen_sock, SOL_SOCKET, SO_RCVBUF, &val, sizeof(int)) < 0)
-        perror("SO_RCVBUF");
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_NOBUFFER, NULL, 0) < 0)
+        perror("SO_NOBUFFER");
 
     memset(&localadr, 0, sizeof(localadr));
     localadr.sin_family = AF_INET;

--- a/elkscmd/inet/ftp.c
+++ b/elkscmd/inet/ftp.c
@@ -820,9 +820,8 @@ int do_active(int cmdfd) {
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
 		perror("SO_REUSEADDR");
 
-	i = SO_LISTEN_BUFSIZ;
-	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &i, sizeof(i)) < 0) 
-		perror("SO_RCVBUF");
+	if (setsockopt(fd, SOL_SOCKET, SO_NOBUFFER, NULL, 0) < 0)
+		perror("SO_NOBUFFER");
 
 	bzero(&myaddr, sizeof(myaddr));
 	myaddr.sin_family = AF_INET;

--- a/elkscmd/inet/ftpd.c
+++ b/elkscmd/inet/ftpd.c
@@ -494,12 +494,16 @@ int do_pasv(int *datafd, int epsv) {
 		perror("PASV socket");
 		return -1;
 	}
-
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i)) < 0)
 		perror("PASV SO_REUSEADDR");
-	i = SO_LISTEN_BUFSIZ;
-	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &i, sizeof(i)) < 0)
-                perror("PASV SO_RCVBUF");
+	if (setsockopt(fd, SOL_SOCKET, SO_NOBUFFER, NULL, 0) < 0)
+		perror("PASV SO_NOBUFFER");
+#if 1
+    /* test using 2/3 of normal 4390 byte buffer (=MTU-40 = 1460*2) */
+    int size = 2920;
+	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) < 0)
+		perror("SO_RCVBUF");
+#endif
 
 	pasv.sin_family = AF_INET;
 	pasv.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -700,9 +704,8 @@ int main(int argc, char **argv) {
 		perror("SO_REUSEADDR");
 
 	/* set small listen buffer to save ktcp memory */
-	ret = SO_LISTEN_BUFSIZ;
-	if (setsockopt(listenfd, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
-		perror("SO_RCVBUF");
+	if (setsockopt(listenfd, SOL_SOCKET, SO_NOBUFFER, NULL, 0) < 0)
+		perror("SO_NOBUFFER");
 
 	servaddr.sin_family      = AF_INET;
 	servaddr.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/elkscmd/inet/httpd.c
+++ b/elkscmd/inet/httpd.c
@@ -160,9 +160,8 @@ int main(int argc, char **argv)
         errmsg("http: SO_REUSEADDR");
 
     /* set small listen buffer to save ktcp memory */
-    ret = SO_LISTEN_BUFSIZ;
-    if (setsockopt(listen_sock, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
-        errmsg("httpd: SO_RCVBUF");
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_NOBUFFER, NULL, 0) < 0)
+        errmsg("httpd: SO_NOBUFFER");
 
     localadr.sin_family = AF_INET;
     localadr.sin_port = htons(DEF_PORT);

--- a/elkscmd/inet/telnetd.c
+++ b/elkscmd/inet/telnetd.c
@@ -201,9 +201,8 @@ main(int argc, char **argv)
         perror("SO_REUSEADDR");
 
     /* set small listen buffer to save ktcp memory */
-    ret = SO_LISTEN_BUFSIZ;
-    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
-        perror("SO_RCVBUF");
+    if (setsockopt(sockfd, SOL_SOCKET, SO_NOBUFFER, NULL, 0) < 0)
+        perror("SO_NOBUFFER");
 
     memset(&addr_in, 0, sizeof(addr_in));
     addr_in.sin_family = AF_INET;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -189,8 +189,8 @@ static void tcp_listen(struct iptcp_s *iptcp, struct tcpcb_s *lcb)
     if (h->flags & TF_ACK)
 	debug_tcp("tcp: ACK in listen not implemented\n");
 
-    /* duplicate control block but with normal sized input buffer, SO_RCVBUF ignored for now */
-    n = tcpcb_clone(lcb, CB_NORMAL_BUFSIZ);    /* copy lcb into linked list*/
+    /* duplicate CB  with normal or SO_RCVBUF sized buffer */
+    n = tcpcb_clone(lcb, lcb->acc_size? lcb->acc_size: CB_NORMAL_BUFSIZ);
     if (!n)
 	return;		     /* no memory for new connection*/
     cb = &n->tcpcb;

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -166,6 +166,7 @@ struct tcpcb_s {
 	__u16	buf_tail;
 	__u16	buf_used;		/* # valid bytes in buffer */
 	__u16	buf_size;		/* total buffer size */
+	__u16	acc_size;		/* accept CB buffer size from SO_RCVBUF */
 	__u8	buf_base[];
 };
 

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -474,10 +474,14 @@ void tcp_output(struct tcpcb_s *cb)
     header_len = sizeof(tcphdr_t);
     if (cb->flags & TF_SYN) {
 	__u8 *options = th->options;
+	unsigned int mss = MTU - 40;
 
+	/* advertise segment we can actually accept */
+	if (cb->buf_size && mss > cb->buf_size)
+	    mss = cb->buf_size;
 	options[0] = TCP_OPT_MSS;
 	options[1] = TCP_OPT_MSS_LEN;		/* total options length (4)*/
-	*(__u16 *)(options + 2) = htons(MTU - 40);
+	*(__u16 *)(options + 2) = htons(mss);
 	header_len += TCP_OPT_MSS_LEN;
     }
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -67,7 +67,7 @@ static void tcpdev_bind(void)
 {
     struct tdb_bind *db = (struct tdb_bind *)sbuf; /* read from sbuf*/
     struct tcpcb_list_s *n;
-    int size;
+    int size = 0;
     __u16 port;
     struct tdb_bind_ret bind_ret;
 
@@ -76,8 +76,12 @@ static void tcpdev_bind(void)
 	return;
     }
 
-    /* SO_RCVBUF currently only sets listen or connect buffer size, NOT accept size!*/
-    size = db->rcv_bufsiz? db->rcv_bufsiz: CB_NORMAL_BUFSIZ;
+    /*
+     * Use SO_NOBUFFER on listen sockets to save ktcp heap.
+     * Use SO_RCVBUF set connect or accept CB buffer size.
+     */
+    if (!db->no_buffer)
+	size = db->rcv_bufsiz? db->rcv_bufsiz: CB_NORMAL_BUFSIZ;
     n = tcpcb_new(size);
     if (n == NULL) {
 	retval_to_sock(db->sock,-ENOMEM);
@@ -117,6 +121,7 @@ reject:
     }
 
     n->tcpcb.sock = db->sock;
+    n->tcpcb.acc_size = db->rcv_bufsiz;
     if (db->addr.sin_addr.s_addr == htonl(0x7f000001))
         n->tcpcb.localaddr = db->addr.sin_addr.s_addr;
     else


### PR DESCRIPTION
This enhancement allows tuning ELKS network applications to use less memory than was otherwise possible from ktcp's heap, while still maximizing efficiency. Programs now have total control over their TCP/IP receive buffer sizes during both passive listen, active connect, and accept sockets.

Previously, SO_RCVBUF set the buffer size for connect and listen sockets. Most ELKS network applications used this to set a small receive buffer for `listen` using SO_LISTEN_BUFSIZE, which was 128. The buffer size for new sockets from `accept` always defaulted to CB_NORMAL_BUFSIZ (=4380 = 3*(MTU-40)). 

Now, SO_RCVBUF additionally sets the receive buffer size for accepted sockets, allowing applications to set a smaller (or larger) buffer size for efficiency as well as better use of ktcp's heap.

Adds non-standard `setsockopt` option SO_NOBUFFER which replaces previous SO_RCVBUF to eliminate any listen socket buffer completely.

`ftpd` has been experimentally enhanced to use a 2920 byte buffer (=2*(MTU-40)). Testing with QEMU showed a small decrease in throughput but using 1/3 less heap per connection in ktcp. This may also want to be performed for the other network applications, to enable more connections in ELKS without running out of ktcp heap.

All network applications in elkscmd/inet have been updated. External applications which used SO_LISTEN_BUFSIZ to eliminate a listen socket buffer will have to be recompiled, or their receive buffer size will be set to a very small 128.

Partly based off ideas from code in #2801 which didn't work properly for listen sockets.